### PR TITLE
Removed conflicting redis=monitor label

### DIFF
--- a/k8sutils/services.go
+++ b/k8sutils/services.go
@@ -112,7 +112,6 @@ func CreateMasterService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
 		"app":   cr.ObjectMeta.Name + "-master",
 		"role":  "master",
-		"redis": "monitor",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "master", cr.ObjectMeta.Name+"-master", cr.Spec.Master.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name+"-master", metav1.GetOptions{})
@@ -145,7 +144,6 @@ func CreateSlaveService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
 		"app":   cr.ObjectMeta.Name + "-slave",
 		"role":  "slave",
-		"redis": "monitor",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "slave", cr.ObjectMeta.Name+"-slave", cr.Spec.Slave.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name+"-slave", metav1.GetOptions{})
@@ -162,7 +160,6 @@ func CreateStandaloneService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
 		"app":   cr.ObjectMeta.Name + "-" + "standalone",
 		"role":  "standalone",
-		"redis": "monitor",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "standalone", cr.ObjectMeta.Name, cr.Spec.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name, metav1.GetOptions{})

--- a/k8sutils/services.go
+++ b/k8sutils/services.go
@@ -110,8 +110,8 @@ func CreateMasterHeadlessService(cr *redisv1beta1.Redis) {
 // CreateMasterService creates different services for master
 func CreateMasterService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
-		"app":   cr.ObjectMeta.Name + "-master",
-		"role":  "master",
+		"app":  cr.ObjectMeta.Name + "-master",
+		"role": "master",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "master", cr.ObjectMeta.Name+"-master", cr.Spec.Master.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name+"-master", metav1.GetOptions{})
@@ -142,8 +142,8 @@ func CreateSlaveHeadlessService(cr *redisv1beta1.Redis) {
 // CreateSlaveService creates different services for slave
 func CreateSlaveService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
-		"app":   cr.ObjectMeta.Name + "-slave",
-		"role":  "slave",
+		"app":  cr.ObjectMeta.Name + "-slave",
+		"role": "slave",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "slave", cr.ObjectMeta.Name+"-slave", cr.Spec.Slave.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name+"-slave", metav1.GetOptions{})
@@ -158,8 +158,8 @@ func CreateSlaveService(cr *redisv1beta1.Redis) {
 // CreateStandaloneService creates redis standalone service
 func CreateStandaloneService(cr *redisv1beta1.Redis) {
 	labels := map[string]string{
-		"app":   cr.ObjectMeta.Name + "-" + "standalone",
-		"role":  "standalone",
+		"app":  cr.ObjectMeta.Name + "-" + "standalone",
+		"role": "standalone",
 	}
 	serviceDefinition := GenerateServiceDef(cr, labels, int32(redisPort), "standalone", cr.ObjectMeta.Name, cr.Spec.Service.Type)
 	serviceBody, err := GenerateK8sClient().CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.ObjectMeta.Name, metav1.GetOptions{})


### PR DESCRIPTION
For redis-master and redis-slave services pod selector. See issue #79.