### PR TITLE
Improve cluster provisioning logic

### DIFF
--- a/k8sutils/client.go
+++ b/k8sutils/client.go
@@ -3,11 +3,27 @@ package k8sutils
 import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // GenerateK8sClient create client for kubernetes
 func GenerateK8sClient() *kubernetes.Clientset {
-	config, _ := rest.InClusterConfig()
-	clientset, _ := kubernetes.NewForConfig(config)
+	config, err := GenerateK8sConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
 	return clientset
+}
+
+func GenerateK8sConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	return kubeConfig.ClientConfig()
 }

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -298,7 +298,7 @@ func CompareAndCreateStateful(cr *redisv1beta1.Redis, clusterInfo StatefulInterf
 
 	if clusterInfo.Existing != nil {
 		if !state {
-			reqLogger.Info("Reconciling redis setup because spec is changed", "Redis.Name", cr.ObjectMeta.Name+"-"+clusterInfo.Type, "Setup.Type", clusterInfo.Type)
+			reqLogger.Info("Reconciling redis setup because spec has changed", "Redis.Name", cr.ObjectMeta.Name+"-"+clusterInfo.Type, "Setup.Type", clusterInfo.Type)
 			_, err := GenerateK8sClient().AppsV1().StatefulSets(cr.Namespace).Update(context.TODO(), clusterInfo.Desired, metav1.UpdateOptions{})
 			if err != nil {
 				reqLogger.Error(err, "Failed in updating statefulset for redis")


### PR DESCRIPTION
Whilst trialing this operator I found the following issues:

- If the cluster failed to be created, the slaves/followers, where subsequently joined to their pair, and unable to join the cluster at a later date due to data.
  Therefore, waiting/ensuring the cluster is created, helps to ensure that everything is in order and the cluster can be formed successfully.

- `STDERR` was missing when a command failed, this is now printed out to help debugging.

- When checking for failed nodes, a string regex search was being used... but what if a node was called similar.. this would end up in a state of constant fail.. Taken from the redis docs [cluster nodes](https://redis.io/commands/cluster-nodes#serialization-format)
> The output of the command is just a space-separated CSV string, where each line represents a node in the cluster.
Therefore this change will use the connection (disconnected) and flag as `fail` to better detect the true state.

- All nodes were being attempted to join the cluster, when only a single instance was required, this now only attempts to join the cluster if it is not known.

This also brings in the standardised client for in/out of cluster in #90