### PR TITLE
Fix issue where command output was continuously being appended

### DIFF
--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -16,11 +16,6 @@ import (
 	"strings"
 )
 
-var (
-	execOut bytes.Buffer
-	execErr bytes.Buffer
-)
-
 // RedisDetails will hold the information for Redis Pod
 type RedisDetails struct {
 	PodName   string
@@ -233,6 +228,10 @@ func executeCommand(cr *redisv1beta1.Redis, cmd []string, podName string) {
 	if err != nil {
 		reqLogger.Error(err, "Failed to init executor")
 	}
+	var (
+		execOut bytes.Buffer
+		execErr bytes.Buffer
+	)
 
 	err = exec.Stream(remotecommand.StreamOptions{
 		Stdout: &execOut,


### PR DESCRIPTION
Command output was being continuously appended for each execution, making logging and debugging extremely difficult to understand which portion related to what output.

This now ensures that the variables are clean on each execution.