### PR TITLE
make the dockerfile support multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 COPY k8sutils/ k8sutils/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(uname -m) GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Hello, 

Target: make docker file support multi-arch
Chanes: change amd64 to `$(uname -m)`

I tried it on Z, and it works to build the image.

Thanks.