### PR TITLE
Update and fix docs due to recent changes

### DIFF
--- a/docs/src/guide/exposing-redis.md
+++ b/docs/src/guide/exposing-redis.md
@@ -5,7 +5,7 @@ If we can expose the service by doing some configuration inside the helm values 
 
 The service can be exposed with these service types:-
 
-- **NodePort**: Exposes the Service on each Node's IP at a static port (the NodePort). A ClusterIP Service, to which the NodePort Service routes, is automatically created. You'll be able to contact the NodePort Service, from outside the cluster, by requesting <NodeIP>:<NodePort>.
+- **NodePort**: Exposes the Service on each Node's IP at a static port (the NodePort). A ClusterIP Service, to which the NodePort Service routes, is automatically created. You'll be able to contact the NodePort Service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`.
 - **LoadBalancer**: Exposes the Service externally using a cloud provider's load balancer. NodePort and ClusterIP Services, to which the external load balancer routes, are automatically created.
 
 ## Exposing Service

--- a/docs/src/guide/redis-cluster-config.md
+++ b/docs/src/guide/redis-cluster-config.md
@@ -2,7 +2,7 @@
 
 The redis setup cluster mode can be customized using custom configuration. If redis setup is done by **Helm**, in that case `values.yaml` can be updated.
 
-- [Redis cluster values](https://github.com/OT-CONTAINER-KIT/helm-charts/blob/main/charts/redis-cluster/values.yaml) 
+- [Redis cluster values](https://github.com/OT-CONTAINER-KIT/helm-charts/blob/main/charts/redis-cluster/values.yaml)
 
 But if the setup is not done via Helm, in that scenario we may have to customize the CRD parameters.
 
@@ -22,8 +22,6 @@ In this configuration section, we have these configuration parameters:-
 |`redisCluster.image` | quay.io/opstree/redis | Name of the redis image |
 |`redisCluster.tag` | v6.2 | Tag of the redis image |
 |`redisCluster.imagePullPolicy` | IfNotPresent | Image Pull Policy of the redis image |
-|`redisCluster.leader.serviceType` | ClusterIP | Kubernetes service type for Redis Leader |
-|`redisCluster.follower.serviceType` | ClusterIP | Kubernetes service type for Redis Follower |
 |`redisCluster.leader.affinity` | {} | Affinity for node and pods for redis leader statefulset |
 |`redisCluster.follower.affinity` | {} | Affinity for node and pods for redis follower statefulset |
 |`externalService.enabled`| false | If redis service needs to be exposed using LoadBalancer or NodePort |
@@ -63,7 +61,6 @@ These are the CRD Parameters which is currently supported by Redis Exporter for 
 
 ```yaml
   redisLeader:
-    serviceType: ClusterIP
     redisConfig:
       additionalRedisConfig: redis-external-config
     affinity:
@@ -83,7 +80,6 @@ These are the CRD Parameters which is currently supported by Redis Exporter for 
 
 ```yaml
   redisFollower:
-    serviceType: ClusterIP
     redisConfig:
       additionalRedisConfig: redis-external-config
     affinity:
@@ -115,7 +111,6 @@ In the `kubernetesConfig` section, we define configuration related to Kubernetes
     redisSecret:
       name: redis-secret
       key: password
-    serviceType: ClusterIP
     imagePullSecrets:
       - name: regcred
 ```

--- a/docs/src/guide/redis-config.md
+++ b/docs/src/guide/redis-config.md
@@ -2,7 +2,7 @@
 
 The redis setup in standalone mode can be customized using custom configuration. If redis setup is done by **Helm**, in that case `values.yaml` can be updated.
 
-- [Redis standalone values](https://github.com/OT-CONTAINER-KIT/helm-charts/blob/main/charts/redis/values.yaml) 
+- [Redis standalone values](https://github.com/OT-CONTAINER-KIT/helm-charts/blob/main/charts/redis/values.yaml)
 
 But if the setup is not done via Helm, in that scenario we may have to customize the CRD parameters.
 
@@ -11,7 +11,7 @@ In this configuration section, we have these configuration parameters:-
 - [Helm Parameters](redis-config.html#helm-parameters)
 - [CRD Parameters](redis-config.html#crd-parameters)
 
-## Helm Parameters
+# Helm Parameters
 
 |**Name**|**Value**|**Description**|
 |--------|-----------------|-------|
@@ -21,7 +21,6 @@ In this configuration section, we have these configuration parameters:-
 |`redisStandalone.image` | quay.io/opstree/redis | Name of the redis image |
 |`redisStandalone.tag` | v6.2 | Tag of the redis image |
 |`redisStandalone.imagePullPolicy` | IfNotPresent | Image Pull Policy of the redis image |
-|`redisStandalone.serviceType` | ClusterIP | Kubernetes service type for Redis |
 |`redisStandalone.resources` | {} | Request and limits for redis statefulset |
 |`externalService.enabled`| false | If redis service needs to be exposed using LoadBalancer or NodePort |
 |`externalService.annotations`| {} | Kubernetes service related annotations |
@@ -65,7 +64,6 @@ In the `kubernetesConfig` section, we define configuration related to Kubernetes
     redisSecret:
       name: redis-secret
       key: password
-    serviceType: LoadBalancer
     imagePullSecrets:
       - name: regcred
 ```


### PR DESCRIPTION
1. Remove `serviceType` configuration from docs due to [these changes](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/148)
2. Fix anchor and markdown
