### PR TITLE
Added option for namespaced operator

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,14 +65,20 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "6cab913b.redis.opstreelabs.in",
-	})
+	}
+
+	if ns := os.Getenv("NAMESPACE"); ns != "" {
+		options.Namespace = ns
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
This add option to have an operator that do not need cluster-wide rights. If env var `NAMESPACE` is present, operator will watch resources in this namespace and not cluster-wide.

I have tested it and it work.

#187 
