### PR TITLE
Fix invalid RBAC kustomization

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- monitor.yaml
 - auth_proxy_client_clusterrole.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml


### PR DESCRIPTION
Looks like there's a copy/paste error from the prometheus kustomization? This one fails to build because `monitor.yaml` doesn't exist.