### PR TITLE
Remove useless ownerReference

### DIFF
--- a/controllers/redis_controller.go
+++ b/controllers/redis_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	redisv1beta1 "redis-operator/api/v1beta1"
 )
@@ -61,9 +60,6 @@ func (r *RedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	if err := controllerutil.SetControllerReference(instance, instance, r.Scheme); err != nil {
-		return ctrl.Result{}, err
-	}
 	err = k8sutils.CreateStandaloneRedis(instance)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	redisv1beta1 "redis-operator/api/v1beta1"
 )
@@ -54,9 +53,6 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	if err := controllerutil.SetControllerReference(instance, instance, r.Scheme); err != nil {
-		return ctrl.Result{}, err
-	}
 	err = k8sutils.CreateRedisLeader(instance)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
Hello,

It does not work to make a ownerReference to himself. I have tested it and it had nothing in the redis and redisCluster resource. More than this, we don't update the redis/redisCluster resource to k8s api so it does nothing.

redis/redisCluster resources should not have an owner, pods should have them.

Or am I missing something ?

Have a good day,