### PR TITLE
Fixes case where node ip contains another PodIP

### DIFF
--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -327,7 +327,8 @@ func checkRedisNodePresence(cr *redisv1beta1.RedisCluster, nodeList [][]string, 
 	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
 	logger.Info("Checking if Node is in cluster", "Node", nodeName)
 	for _, node := range nodeList {
-		if strings.Contains(node[1], nodeName) {
+		s := strings.Split(node[1], ":")
+		if s[0] == nodeName {
 			return true
 		}
 	}

--- a/k8sutils/redis_test.go
+++ b/k8sutils/redis_test.go
@@ -1,0 +1,39 @@
+// checkRedisNodePresence
+package k8sutils
+
+import (
+	"encoding/csv"
+	"fmt"
+	redisv1beta1 "redis-operator/api/v1beta1"
+	"strings"
+	"testing"
+)
+
+func TestCheckRedisNodePresence(t *testing.T) {
+	cr := &redisv1beta1.RedisCluster{}
+	output := "205dd1780dda981f9320c9d47d069b3c0ceaa358 172.17.0.24:6379@16379 slave b65312dcf5537b8826c344783f078096fdb7f27c 0 1654197347000 1 connected\nfaa21623054227826e93dd71314cce3706491dac 172.17.0.28:6379@16379 slave d54557b21bc5a5aa947ce58b7dbadc5d39bdd551 0 1654197347000 2 connected\nb65312dcf5537b8826c344783f078096fdb7f27c 172.17.0.25:6379@16379 master - 0 1654197346000 1 connected 0-5460\nd54557b21bc5a5aa947ce58b7dbadc5d39bdd551 172.17.0.29:6379@16379 myself,master - 0 1654197347000 2 connected 5461-10922\nc9fa05269c4e662295bf34eb93f1315f962493ba 172.17.0.3:6379@16379 master - 0 1654197348006 3 connected 10923-16383"
+	csvOutput := csv.NewReader(strings.NewReader(output))
+	csvOutput.Comma = ' '
+	csvOutput.FieldsPerRecord = -1
+	nodes, _ := csvOutput.ReadAll()
+
+	var tests = []struct {
+		nodes [][]string
+		ip    string
+		want  bool
+	}{
+		{nodes, "172.17.0.24", true},
+		{nodes, "172.17.0.111", false},
+		{nodes, "172.17.0.2", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%s,%s", tt.nodes, tt.ip)
+		t.Run(testname, func(t *testing.T) {
+			ans := checkRedisNodePresence(cr, tt.nodes, tt.ip)
+			if ans != tt.want {
+				t.Errorf("got %t, want %t", ans, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes a case where a follower won't get added because the PodIP is
contained within another node ip, for example PodIP 172.17.0.2 and node 172.17.0.24:6379@16379

Signed-off-by: Andrew Thompson <andrew.thompson@crowdstrike.com>