### PR TITLE
fix: crash if targetContainer does not exist

### DIFF
--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -274,10 +274,12 @@ func executeCommand(cr *redisv1beta1.RedisCluster, cmd []string, podName string)
 	config, err := generateK8sConfig()
 	if err != nil {
 		logger.Error(err, "Could not find pod to execute")
+		return
 	}
 	targetContainer, pod := getContainerID(cr, podName)
 	if targetContainer < 0 {
 		logger.Error(err, "Could not find pod to execute")
+		return
 	}
 
 	req := generateK8sClient().CoreV1().RESTClient().Post().Resource("pods").Name(podName).Namespace(cr.Namespace).SubResource("exec")
@@ -290,6 +292,7 @@ func executeCommand(cr *redisv1beta1.RedisCluster, cmd []string, podName string)
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
 		logger.Error(err, "Failed to init executor")
+		return
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
@@ -299,6 +302,7 @@ func executeCommand(cr *redisv1beta1.RedisCluster, cmd []string, podName string)
 	})
 	if err != nil {
 		logger.Error(err, "Could not execute command", "Command", cmd, "Output", execOut.String(), "Error", execErr.String())
+		return
 	}
 	logger.Info("Successfully executed the command", "Command", cmd, "Output", execOut.String())
 }


### PR DESCRIPTION
This pull request serves as a naive patch to the crashing problem when `targetContainer` does not exist. 

Specifically, the operator crashes when it cannot find the pod to execute command on. When the pod being queried does not exist, `getContainerID` returns '-1'. The operator detects the error, but instead of aborting immediately, it continues to access `pod.Spec.Containers[]` with index `targetContainer`, leading to a crash.

```shell
1.6543661422595975e+09	ERROR	controller_redis	Could not find pod to execute	{"Request.RedisManager.Namespace": "default", "Request.RedisManager.Name": "test-cluster"}
redis-operator/k8sutils.ExecuteRedisClusterCommand
	/workspace/k8sutils/redis.go:71
redis-operator/controllers.(*RedisClusterReconciler).Reconcile
	/workspace/controllers/rediscluster_controller.go:124
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
panic: runtime error: index out of range [-1]

goroutine 312 [running]:

redis-operator/k8sutils.executeCommand(0xc000283200, {0xc00003ce40, 0xc, 0x1726e26}, {0xc000afa630, 0x15})

/workspace/k8sutils/redis.go:285 +0x827

redis-operator/k8sutils.ExecuteRedisClusterCommand(0xc000283200)
```

The detailed information and steps to reproduce the problem has been included in https://github.com/OT-CONTAINER-KIT/redis-operator/issues/291.

This pull request avoids the crash by adding a return inside every block of error handling code, as can be seen from the changes I made. 

#### Additional Comments
This crashing problem is caused by only printing error logs but not dealing with those errors. The functions continue execution even in the presence of errors. For example, in `executeCommand`, even though errors are detected and error logs are printed, the function continues execution and print out the `Successfully executed the command` log.

In the current code base, there are many other places where errors are only detected but bot dealt with. To make the operator more robust, I think we should refactor the error handling code in many functions. As the desired error handling behavior is unknown to me, I cannot make that fix now. Nonetheless, I am more than happy to discuss with you and make the patches for you. 
