### PR TITLE
Fix: An Incomplete `redisSecret` crashes the operator

### DIFF
--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -964,6 +964,9 @@ spec:
                         type: string
                       name:
                         type: string
+                    required:
+                      - key
+                      - name
                     type: object
                   resources:
                     description: ResourceRequirements describes the compute resource

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -160,6 +160,9 @@ spec:
                         type: string
                       name:
                         type: string
+                    required:
+                      - key
+                      - name
                     type: object
                   resources:
                     description: ResourceRequirements describes the compute resource


### PR DESCRIPTION
This pull request makes both fields `key` and `name` required by the field `redisSecret` so that an incomplete `redisSecret` in the cr input will be automatically rejected due to failed openApi V3 validation.

Previously, if only `key` or `name` is specified for `redisSecret`, the operator will crash due to a nil-pointer reference. 
https://github.com/OT-CONTAINER-KIT/redis-operator/blob/f1c547e26ece015c0c5cd8a8549ff277e8e7c2ab/k8sutils/statefulset.go#L412-L414

Detailed information and steps to reproduce the problem have been explained here https://github.com/OT-CONTAINER-KIT/redis-operator/issues/286

#### Comments
We understand that a experienced dev-ops engineer should never submit an incomplete `redisSecret` normally. However, humans are error makers and we want to make use of the openApi v3 validation to avoid catastrophic outcomes caused by human mistakes.