### PR TITLE
Fix: Crash if fields `resources` are not present

### DIFF
--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -224,7 +224,6 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 				containerParams.RedisExporterEnv,
 				containerParams.TLSConfig,
 			),
-			Resources:      *containerParams.Resources,
 			ReadinessProbe: getProbeInfo(),
 			LivenessProbe:  getProbeInfo(),
 			VolumeMounts:   getVolumeMount(name, containerParams.PersistenceEnabled, externalConfig, containerParams.TLSConfig),
@@ -318,7 +317,6 @@ func enableRedisMonitoring(params containerParameters) corev1.Container {
 			params.RedisExporterEnv,
 			params.TLSConfig,
 		),
-		Resources:    *params.RedisExporterResources,
 		VolumeMounts: getVolumeMount("", nil, nil, params.TLSConfig), // We need/want the tls-certs but we DON'T need the PVC (if one is available)
 	}
 	if params.RedisExporterResources != nil {


### PR DESCRIPTION
This pull request removes some obsolete code that leads to nil-pointer reference when the field `kubernetesConfig.resources` and other `resources` fields are unspecified.

The detailed information and steps to reproduce the crash have been explained in https://github.com/OT-CONTAINER-KIT/redis-operator/issues/283.