### PR TITLE
Update zap options to support specifying log level

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - -zap-log-level=info
         image: quay.io/opstree/redis-operator:v0.9.0
         imagePullPolicy: Always
         name: manager

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
resolved #305 
Can check with this command
go run main.go -zap-log-level [level]

[flag] -zap-log-level value: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity

ref) https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
By passing args to the spec part of deployment, the log level can be set.

e.g)
https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/config/manager/manager.yaml
At line 31
```yaml
args:
  - --leader-elect
  - --zap-log-level=debug
```
