### PR TITLE
Add pvc, pv clusterrole for deletion

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,8 @@ rules:
   - pods
   - services
   - configmaps
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs:
   - create
   - delete


### PR DESCRIPTION
Signed-off-by: zmrdltl <meenseek5929@naver.com>
resolved #312 

The go operator logic is implemented, ref : https://github.com/OT-CONTAINER-KIT/redis-operator/pull/204
but since pv and pvc are not added to clusterrole, they are not deleted together when CR is deleted. I solved this.

