### PR TITLE
fix probe is nil

### DIFF
--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -345,9 +345,14 @@ func getVolumeMount(name string, persistenceEnabled *bool, externalConfig *strin
 
 // getProbeInfo generate probe for Redis StatefulSet
 func getProbeInfo(probe *redisv1beta1.Probe) *corev1.Probe {
-	// when probe is nil, return handler
+	// when probe is nil, return default handler
 	if probe == nil {
 		return &corev1.Probe{
+			InitialDelaySeconds: 1,
+			PeriodSeconds:       10,
+			FailureThreshold:    3,
+			TimeoutSeconds:      1,
+			SuccessThreshold:    1,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -345,6 +345,19 @@ func getVolumeMount(name string, persistenceEnabled *bool, externalConfig *strin
 
 // getProbeInfo generate probe for Redis StatefulSet
 func getProbeInfo(probe *redisv1beta1.Probe) *corev1.Probe {
+	// when probe is nil, return handler
+	if probe == nil {
+		return &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"bash",
+						"/usr/bin/healthcheck.sh",
+					},
+				},
+			},
+		}
+	}
 	return &corev1.Probe{
 		InitialDelaySeconds: probe.InitialDelaySeconds,
 		PeriodSeconds:       probe.PeriodSeconds,


### PR DESCRIPTION
when probe is nil,will panic.
```shell
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ccacb6]

goroutine 516 [running]:
redis-operator/k8sutils.getProbeInfo(0x0)
        /home/jiuker/workspace/go/src/ot/redis-operator/k8sutils/statefulset.go:349 +0x76
redis-operator/k8sutils.generateContainerDef({0xc000895af0, 0xc}, {{0xc000650a20, 0x1c}, {0xc000895b20, 0xc}, 0xc000a894a0, {0xc0000f4a80, 0x22}, {0x0, ...}, ...}, ...)
        /home/jiuker/workspace/go/src/ot/redis-operator/k8sutils/statefulset.go:226 +0xe5
redis-operator/k8sutils.generateStatefulSetsDef({{0xc000895af0, 0xc}, {0x0, 0x0}, {0xc000895b00, 0xd}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...)
        /home/jiuker/workspace/go/src/ot/redis-operator/k8sutils/statefulset.go:134 +0x17e
redis-operator/k8sutils.CreateOrUpdateStateFul({_, _}, {{0xc000895af0, 0xc}, {0x0, 0x0}, {0xc000895b00, 0xd}, {0x0, 0x0}, ...}, ...)
        /home/jiuker/workspace/go/src/ot/redis-operator/k8sutils/statefulset.go:61 +0x1de
redis-operator/k8sutils.CreateStandaloneRedis(0xc00044cfc0)
        /home/jiuker/workspace/go/src/ot/redis-operator/k8sutils/redis-standalone.go:40 +0x3fe
redis-operator/controllers.(*RedisReconciler).Reconcile(0xc0003bf380, {0x2175208, 0xc0004e3f50}, {{{0xc000895b00, 0xd}, {0xc000895af0, 0xc}}})
        /home/jiuker/workspace/go/src/ot/redis-operator/controllers/redis_controller.go:63 +0x4ee
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc00064c0b0, {0x2175208, 0xc0004e3f50}, {{{0xc000895b00, 0xd}, {0xc000895af0, 0xc}}})
        /home/jiuker/workspace/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114 +0x365
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00064c0b0, {0x2175208, 0xc0004e3e90}, {0x1e6e540, 0xc00062a060})
        /home/jiuker/workspace/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311 +0x425
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00064c0b0, {0x2175160, 0xc000c195c0})
        /home/jiuker/workspace/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266 +0x398
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /home/jiuker/workspace/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227 +0xdc
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /home/jiuker/workspace/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:223 +0x4d6

```