### PR TITLE
Close redis client connections

### DIFF
--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -134,6 +134,7 @@ func checkRedisCluster(cr *redisv1beta1.RedisCluster) [][]string {
 	var client *redis.Client
 	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
 	client = configureRedisClient(cr, cr.ObjectMeta.Name+"-leader-0")
+	defer client.Close()
 	cmd := redis.NewStringCmd("cluster", "nodes")
 	err := client.Process(cmd)
 	if err != nil {
@@ -180,6 +181,7 @@ func executeFailoverCommand(cr *redisv1beta1.RedisCluster, role string) error {
 	for podCount := 0; podCount <= int(replicas)-1; podCount++ {
 		logger.Info("Executing redis failover operations", "Redis Node", podName+strconv.Itoa(podCount))
 		client := configureRedisClient(cr, podName+strconv.Itoa(podCount))
+		defer client.Close()
 		cmd := redis.NewStringCmd("cluster", "reset")
 		err := client.Process(cmd)
 		if err != nil {


### PR DESCRIPTION
I noticed that there is a goroutine leak due to opening redis client connections and never closing or reusing them.  The goroutine count with a single cluster was increasing by about 2 per reconcile.  The following shows the before/after count of redis connection goroutines.

This will ensure the redis client connections get closed which fixes the goroutine leak.

<details><summary>Before</summary><br><pre>
$ while true                                                                                                                                                                                                                                                                                                                                 
do
curl -s http://localhost:8082/debug/pprof/goroutine\?debug\=2 | grep -c -E "go-redis.*NewConnPool"
sleep 60
done
2
2
4
4
6
6
8
8
10
10
12
12
14
14
16
16
18
18
20
20
22
22
24
24
26
26
28
28
30
30
</pre></details>

<details><summary>After</summary><br><pre>
$ while true                                                                                                                                                                                                                                                                                                                                 
do
curl -s http://localhost:8082/debug/pprof/goroutine\?debug\=2 | grep -c -E "go-redis.*NewConnPool"
sleep 60
done
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
2
0
</pre></details>
