### PR TITLE
fix: lost replications when followerReplicas bigger than leaderReplicas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ testbin/*
 *.swp
 *.swo
 *~
+.vscode
 
 docs/build

--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -158,15 +158,16 @@ func createRedisReplicationCommand(cr *redisv1beta1.RedisCluster, leaderPod Redi
 func ExecuteRedisReplicationCommand(cr *redisv1beta1.RedisCluster) {
 	var podIP string
 	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
-	replicas := cr.Spec.GetReplicaCounts("follower")
+	followerCounts := cr.Spec.GetReplicaCounts("follower")
+	leaderCounts := cr.Spec.GetReplicaCounts("leader")
 	nodes := checkRedisCluster(cr)
-	for podCount := 0; podCount <= int(replicas)-1; podCount++ {
+	for followerIdx := 0; followerIdx <= int(followerCounts)-1; followerIdx++ {
 		followerPod := RedisDetails{
-			PodName:   cr.ObjectMeta.Name + "-follower-" + strconv.Itoa(podCount),
+			PodName:   cr.ObjectMeta.Name + "-follower-" + strconv.Itoa(followerIdx),
 			Namespace: cr.Namespace,
 		}
 		leaderPod := RedisDetails{
-			PodName:   cr.ObjectMeta.Name + "-leader-" + strconv.Itoa(podCount),
+			PodName:   cr.ObjectMeta.Name + "-leader-" + strconv.Itoa(int(followerIdx)%int(leaderCounts)),
 			Namespace: cr.Namespace,
 		}
 		podIP = getRedisServerIP(followerPod)


### PR DESCRIPTION
Fix this:

When we have:
* leader: [xxx-leader-0, xxx-leader-1, xxx-leader-2]
* follower: [xxx-follower-0, xxx-follower-1, xxx-follower-2, xxx-follower-3, xxx-follower-4, xxx-follower-5]

[xxx-follower-3, xxx-follower-4, xxx-follower-5] can not join cluster.