### PR TITLE
fix crash with go panic

### DIFF
--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -175,9 +175,13 @@ func (service RedisClusterService) CreateRedisClusterService(cr *redisv1beta1.Re
 	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
 		enableMetrics = true
 	}
+	additionalServiceAnnotations := map[string]string{}
+	if cr.Spec.KubernetesConfig.Service != nil {
+		additionalServiceAnnotations = cr.Spec.KubernetesConfig.Service.ServiceAnnotations
+	}
 	objectMetaInfo := generateObjectMetaInformation(serviceName, cr.Namespace, labels, annotations)
 	headlessObjectMetaInfo := generateObjectMetaInformation(serviceName+"-headless", cr.Namespace, labels, annotations)
-	additionalObjectMetaInfo := generateObjectMetaInformation(serviceName+"-additional", cr.Namespace, labels, generateServiceAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.Service.ServiceAnnotations))
+	additionalObjectMetaInfo := generateObjectMetaInformation(serviceName+"-additional", cr.Namespace, labels, generateServiceAnots(cr.ObjectMeta, additionalServiceAnnotations))
 	err := CreateOrUpdateService(cr.Namespace, headlessObjectMetaInfo, redisClusterAsOwner(cr), false, true, "ClusterIP")
 	if err != nil {
 		logger.Error(err, "Cannot create headless service for Redis", "Setup.Type", service.RedisServiceRole)

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -192,7 +192,11 @@ func (service RedisClusterService) CreateRedisClusterService(cr *redisv1beta1.Re
 		logger.Error(err, "Cannot create service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
 	}
-	err = CreateOrUpdateService(cr.Namespace, additionalObjectMetaInfo, redisClusterAsOwner(cr), false, false, cr.Spec.KubernetesConfig.Service.ServiceType)
+	additionalServiceType := "ClusterIP"
+	if cr.Spec.KubernetesConfig.Service != nil {
+		additionalServiceType = cr.Spec.KubernetesConfig.Service.ServiceType
+	}
+	err = CreateOrUpdateService(cr.Namespace, additionalObjectMetaInfo, redisClusterAsOwner(cr), false, false, additionalServiceType)
 	if err != nil {
 		logger.Error(err, "Cannot create additional service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -16,9 +16,13 @@ func CreateStandaloneService(cr *redisv1beta1.Redis) error {
 	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
 		enableMetrics = true
 	}
+	additionalServiceAnnotations := map[string]string{}
+	if cr.Spec.KubernetesConfig.Service != nil {
+		additionalServiceAnnotations = cr.Spec.KubernetesConfig.Service.ServiceAnnotations
+	}
 	objectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name, cr.Namespace, labels, annotations)
 	headlessObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-headless", cr.Namespace, labels, annotations)
-	additionalObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-additional", cr.Namespace, labels, generateServiceAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.Service.ServiceAnnotations))
+	additionalObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-additional", cr.Namespace, labels, generateServiceAnots(cr.ObjectMeta, additionalServiceAnnotations))
 	err := CreateOrUpdateService(cr.Namespace, headlessObjectMetaInfo, redisAsOwner(cr), false, true, "ClusterIP")
 	if err != nil {
 		logger.Error(err, "Cannot create standalone headless service for Redis")

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -33,7 +33,11 @@ func CreateStandaloneService(cr *redisv1beta1.Redis) error {
 		logger.Error(err, "Cannot create standalone service for Redis")
 		return err
 	}
-	err = CreateOrUpdateService(cr.Namespace, additionalObjectMetaInfo, redisAsOwner(cr), false, false, cr.Spec.KubernetesConfig.Service.ServiceType)
+	additionalServiceType := "ClusterIP"
+	if cr.Spec.KubernetesConfig.Service != nil {
+		additionalServiceType = cr.Spec.KubernetesConfig.Service.ServiceType
+	}
+	err = CreateOrUpdateService(cr.Namespace, additionalObjectMetaInfo, redisAsOwner(cr), false, false, additionalServiceType)
 	if err != nil {
 		logger.Error(err, "Cannot create additional service for Redis")
 		return err


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
`service` and `annotations`  may not be present in all KubernetesConfig. This PR adds a check to only add the annotations
if the service block actually exists in the KubernetesConfig
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #381

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Testing has been performed
- [ ] No functionality is broken
- [ ] Documentation updated
