### PR TITLE
Expose redis exporter port as a container port

### DIFF
--- a/k8sutils/services.go
+++ b/k8sutils/services.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	redisPort         = 6379
-	redisExporterPort = 9121
+	redisPort             = 6379
+	redisExporterPort     = 9121
+	redisExporterPortName = "redis-exporter"
 )
 
 var (
@@ -53,7 +54,7 @@ func generateServiceDef(serviceMeta metav1.ObjectMeta, enableMetrics bool, owner
 // enableMetricsPort will enable the metrics for Redis service
 func enableMetricsPort() *corev1.ServicePort {
 	return &corev1.ServicePort{
-		Name:       "redis-exporter",
+		Name:       redisExporterPortName,
 		Port:       redisExporterPort,
 		TargetPort: intstr.FromInt(int(redisExporterPort)),
 		Protocol:   corev1.ProtocolTCP,

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -379,6 +379,13 @@ func enableRedisMonitoring(params containerParameters) corev1.Container {
 			params.TLSConfig,
 		),
 		VolumeMounts: getVolumeMount("", nil, nil, params.AdditionalMountPath, params.TLSConfig), // We need/want the tls-certs but we DON'T need the PVC (if one is available)
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          redisExporterPortName,
+				ContainerPort: redisExporterPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
 	}
 	if params.RedisExporterResources != nil {
 		exporterDefinition.Resources = *params.RedisExporterResources


### PR DESCRIPTION


<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Exposes the `redis-exporter` port as a named port for the container.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #386

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Testing has been performed
- [ ] No functionality is broken
- [ ] Documentation updated
