### PR TITLE
When cr annotation update,sts annotations will not updated!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### :beetle: Bug Fixes
 
 - Fixed multiple follower logic for redis cluster
+- Fixed CR's annotations updated,sts annotations will not updated
 
 #### :tada: Features
 

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -3,6 +3,7 @@ package k8sutils
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"path"
 	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
@@ -100,6 +101,8 @@ func patchStatefulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 	if !patchResult.IsEmpty() {
 		logger.Info("Changes in statefulset Detected, Updating...", "patch", string(patchResult.Patch))
 		// Field is immutable therefore we MUST keep it as is.
+		di := cmp.Diff(newStateful.Spec.VolumeClaimTemplates, storedStateful.Spec.VolumeClaimTemplates)
+		fmt.Println(di)
 		if !apiequality.Semantic.DeepEqual(newStateful.Spec.VolumeClaimTemplates, storedStateful.Spec.VolumeClaimTemplates) {
 			// resize pvc
 			// 1.Get the data already stored internally
@@ -161,7 +164,7 @@ func patchStatefulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 				}
 			}
 			// set stored.volumeClaimTemplates
-			newStateful.Annotations = storedStateful.Annotations
+			newStateful.Annotations["storageCapacity"] = storedStateful.Annotations["storageCapacity"]
 			newStateful.Spec.VolumeClaimTemplates = storedStateful.Spec.VolumeClaimTemplates
 		}
 

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -162,8 +162,8 @@ func patchStatefulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 					}
 				}
 			}
-			// set stored.volumeClaimTemplates
 			newStateful.Annotations["storageCapacity"] = storedStateful.Annotations["storageCapacity"]
+			// set stored.volumeClaimTemplates
 			newStateful.Spec.VolumeClaimTemplates = storedStateful.Spec.VolumeClaimTemplates
 		}
 

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -3,7 +3,6 @@ package k8sutils
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"path"
 	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
@@ -100,65 +99,65 @@ func patchStatefulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 	}
 	if !patchResult.IsEmpty() {
 		logger.Info("Changes in statefulset Detected, Updating...", "patch", string(patchResult.Patch))
-		// Field is immutable therefore we MUST keep it as is.
-		di := cmp.Diff(newStateful.Spec.VolumeClaimTemplates, storedStateful.Spec.VolumeClaimTemplates)
-		fmt.Println(di)
-		if !apiequality.Semantic.DeepEqual(newStateful.Spec.VolumeClaimTemplates, storedStateful.Spec.VolumeClaimTemplates) {
-			// resize pvc
-			// 1.Get the data already stored internally
-			// 2.Get the desired data
-			// 3.Start querying the pvc list when you find data inconsistencies
-			// 3.1 Comparison using real pvc capacity and desired data
-			// 3.1.1 Update if you find inconsistencies
-			// 3.2 Writing successful updates to internal
-			// 4. Set to old VolumeClaimTemplates to update.Prevent update error reporting
-			// 5. Set to old annotations to update
-			annotations := storedStateful.Annotations
-			if annotations == nil {
-				annotations = map[string]string{
-					"storageCapacity": "0",
+		if len(newStateful.Spec.VolumeClaimTemplates) >= 1 && len(newStateful.Spec.VolumeClaimTemplates) == len(storedStateful.Spec.VolumeClaimTemplates) {
+			// Field is immutable therefore we MUST keep it as is.
+			if !apiequality.Semantic.DeepEqual(newStateful.Spec.VolumeClaimTemplates[0].Spec, storedStateful.Spec.VolumeClaimTemplates[0].Spec) {
+				// resize pvc
+				// 1.Get the data already stored internally
+				// 2.Get the desired data
+				// 3.Start querying the pvc list when you find data inconsistencies
+				// 3.1 Comparison using real pvc capacity and desired data
+				// 3.1.1 Update if you find inconsistencies
+				// 3.2 Writing successful updates to internal
+				// 4. Set to old VolumeClaimTemplates to update.Prevent update error reporting
+				// 5. Set to old annotations to update
+				annotations := storedStateful.Annotations
+				if annotations == nil {
+					annotations = map[string]string{
+						"storageCapacity": "0",
+					}
 				}
-			}
-			storedCapacity, _ := strconv.ParseInt(annotations["storageCapacity"], 0, 64)
-			if len(newStateful.Spec.VolumeClaimTemplates) != 0 {
-				stateCapacity := newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().Value()
-				if storedCapacity != stateCapacity {
-					listOpt := metav1.ListOptions{
-						LabelSelector: labels.FormatLabels(
-							map[string]string{
-								"app":                         storedStateful.Name,
-								"app.kubernetes.io/component": "redis",
-								"app.kubernetes.io/name":      storedStateful.Name,
-							},
-						),
-					}
-					pvcs, err := generateK8sClient().CoreV1().PersistentVolumeClaims(storedStateful.Namespace).List(context.Background(), listOpt)
-					if err != nil {
-						return err
-					}
-					updateFailed := false
-					realUpdate := false
-					for _, pvc := range pvcs.Items {
-						realCapacity := pvc.Spec.Resources.Requests.Storage().Value()
-						if realCapacity != stateCapacity {
-							realUpdate = true
-							pvc.Spec.Resources.Requests = newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests
-							_, err = generateK8sClient().CoreV1().PersistentVolumeClaims(storedStateful.Namespace).Update(context.Background(), &pvc, metav1.UpdateOptions{})
-							if err != nil {
-								if !updateFailed {
-									updateFailed = true
+				storedCapacity, _ := strconv.ParseInt(annotations["storageCapacity"], 0, 64)
+				if len(newStateful.Spec.VolumeClaimTemplates) != 0 {
+					stateCapacity := newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().Value()
+					if storedCapacity != stateCapacity {
+						listOpt := metav1.ListOptions{
+							LabelSelector: labels.FormatLabels(
+								map[string]string{
+									"app":                         storedStateful.Name,
+									"app.kubernetes.io/component": "redis",
+									"app.kubernetes.io/name":      storedStateful.Name,
+								},
+							),
+						}
+						pvcs, err := generateK8sClient().CoreV1().PersistentVolumeClaims(storedStateful.Namespace).List(context.Background(), listOpt)
+						if err != nil {
+							return err
+						}
+						updateFailed := false
+						realUpdate := false
+						for _, pvc := range pvcs.Items {
+							realCapacity := pvc.Spec.Resources.Requests.Storage().Value()
+							if realCapacity != stateCapacity {
+								realUpdate = true
+								pvc.Spec.Resources.Requests = newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests
+								_, err = generateK8sClient().CoreV1().PersistentVolumeClaims(storedStateful.Namespace).Update(context.Background(), &pvc, metav1.UpdateOptions{})
+								if err != nil {
+									if !updateFailed {
+										updateFailed = true
+									}
+									logger.Error(fmt.Errorf("redis:%s resize pvc failed:%s", storedStateful.Name, err.Error()), "")
 								}
-								logger.Error(fmt.Errorf("redis:%s resize pvc failed:%s", storedStateful.Name, err.Error()), "")
 							}
 						}
-					}
-					if !updateFailed && len(pvcs.Items) != 0 {
-						annotations["storageCapacity"] = fmt.Sprintf("%d", stateCapacity)
-						storedStateful.Annotations = annotations
-						if realUpdate {
-							logger.Info(fmt.Sprintf("redis:%s resize pvc from  %d to %d", storedStateful.Name, storedCapacity, stateCapacity))
-						} else {
-							logger.Info(fmt.Sprintf("redis:%s resize noting,just set annotations", storedStateful.Name))
+						if !updateFailed && len(pvcs.Items) != 0 {
+							annotations["storageCapacity"] = fmt.Sprintf("%d", stateCapacity)
+							storedStateful.Annotations = annotations
+							if realUpdate {
+								logger.Info(fmt.Sprintf("redis:%s resize pvc from  %d to %d", storedStateful.Name, storedCapacity, stateCapacity))
+							} else {
+								logger.Info(fmt.Sprintf("redis:%s resize noting,just set annotations", storedStateful.Name))
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

When Cr annotations updated, the VolumeClaimTemplates's annotations update everyTime
```go
if !apiequality.Semantic.DeepEqual(newStateful.Spec.VolumeClaimTemplates, storedStateful.Spec.VolumeClaimTemplates) {
				// resize pvc
				// 1.Get the data already stored internally
				// 2.Get the desired data
				// 3.Start querying the pvc list when you find data inconsistencies
				// 3.1 Comparison using real pvc capacity and desired data
				// 3.1.1 Update if you find inconsistencies
				// 3.2 Writing successful updates to internal
				// 4. Set to old VolumeClaimTemplates to update.Prevent update error reporting
				// 5. Set to old annotations to update
				annotations := storedStateful.Annotations
				if annotations == nil {
					annotations = map[string]string{
						"storageCapacity": "0",
					}
				}
```
will go in.
and end of the,will be set 
```
			newStateful.Annotations = storedStateful.Annotations
```
so,the newStateful with the newest annotations will be set old annotations again.
In fact,just set ```storageCapacity``` . and compare `VolumeClaimTemplates[0].spec` is ok
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [x] Testing has been performed
- [x] No functionality is broken
- [x] Documentation updated
