### PR TITLE
Fixes issue with arm64 support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+FROM golang:1.17 as builder
 ARG BUILDOS
 ARG BUILDPLATFORM
 ARG BUILDARCH
@@ -44,7 +44,7 @@ RUN GO111MODULE=on go build  -ldflags "${LDFLAGS}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot
 LABEL maintainer="The Opstree Opensource <opensource@opstree.com>"
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,6 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-RUN echo "Container image build platform details :: "
-RUN echo "BUILDPLATFORM.....: $BUILDPLATFORM"
-RUN echo "BUILDOS...........: $BUILDOS"
-RUN echo "BUILDARCH.........: $BUILDARCH"
-RUN echo "BUILDVARIANT......: $BUILDVARIANT"
-RUN echo "Container image target platform details :: "
-RUN echo "TARGETPLATFORM....: $TARGETPLATFORM"
-RUN echo "TARGETOS..........: $TARGETOS"
-RUN echo "TARGETARCH........: $TARGETARCH"
-RUN echo "TARGETVARIANT.....: $TARGETVARIANT"
-
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,12 @@ vet:
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+docker-create:
+	docker buildx create --platform "linux/amd64,linux/arm64" --use
+
 # Build the docker image
 docker-build:
-	docker build -t ${IMG} .
+	docker buildx build --platform="linux/arm64,linux/amd64" -t ${IMG} .
 
 # Push the docker image
 docker-push:
@@ -116,4 +119,4 @@ bundle: manifests kustomize
 # Build the bundle image.
 .PHONY: bundle-build
 bundle-build:
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker buildx build --platform="linux/arm64,linux/amd64" -f bundle.Dockerfile -t $(BUNDLE_IMG) .


### PR DESCRIPTION
**Description**

This PR adds support for multi-architecture container images. I am not sure of the CI flow but rather than reusing the existing make targets (e.g. `docker-build`), I could create new make targets for the `docker builds` commands but wanted to get the conversation started before making any assumptions.

Fixes #390 

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Testing has been performed
- [x] No functionality is broken
- [ ] Documentation updated
