### PR TITLE
declare module correctly

### DIFF
--- a/controllers/redis_controller.go
+++ b/controllers/redis_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	"redis-operator/k8sutils"
+	"github.com/OT-CONTAINER-KIT/redis-operator/k8sutils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 // RedisReconciler reconciles a Redis object

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"redis-operator/k8sutils"
+	"github.com/OT-CONTAINER-KIT/redis-operator/k8sutils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 // RedisClusterReconciler reconciles a RedisCluster object

--- a/controllers/redisreplication_controller.go
+++ b/controllers/redisreplication_controller.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"redis-operator/k8sutils"
+	"github.com/OT-CONTAINER-KIT/redis-operator/k8sutils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -13,7 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 // RedisReplicationReconciler reconciles a RedisReplication object

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module redis-operator
+module github.com/OT-CONTAINER-KIT/redis-operator
 
 go 1.17
 

--- a/k8sutils/finalizer.go
+++ b/k8sutils/finalizer.go
@@ -2,8 +2,9 @@ package k8sutils
 
 import (
 	"context"
-	redisv1beta1 "redis-operator/api/v1beta1"
 	"strconv"
+
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/k8sutils/labels.go
+++ b/k8sutils/labels.go
@@ -1,7 +1,7 @@
 package k8sutils
 
 import (
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/k8sutils/poddisruption.go
+++ b/k8sutils/poddisruption.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 // CreateRedisLeaderPodDisruptionBudget check and create a PodDisruptionBudget for Leaders

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -1,7 +1,7 @@
 package k8sutils
 
 import (
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -1,7 +1,7 @@
 package k8sutils
 
 import (
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 // CreateReplicationService method will create replication service for Redis

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -1,7 +1,7 @@
 package k8sutils
 
 import (
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 var (

--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	"github.com/go-logr/logr"
 	"github.com/go-redis/redis"

--- a/k8sutils/redis_test.go
+++ b/k8sutils/redis_test.go
@@ -4,9 +4,10 @@ package k8sutils
 import (
 	"encoding/csv"
 	"fmt"
-	redisv1beta1 "redis-operator/api/v1beta1"
 	"strings"
 	"testing"
+
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 )
 
 func TestCheckRedisNodePresence(t *testing.T) {

--- a/k8sutils/secrets.go
+++ b/k8sutils/secrets.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	redisv1beta1 "redis-operator/api/v1beta1"
 	"strings"
+
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"path"
-	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
 	"strconv"
 	"strings"
+
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	redisv1beta1 "redis-operator/api/v1beta1"
-	"redis-operator/controllers"
+	redisv1beta1 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
+	"github.com/OT-CONTAINER-KIT/redis-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes the inability to import this go module.

```
        github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1: github.com/OT-CONTAINER-KIT/redis-operator@v0.13.0: parsing go.mod:
        module declares its path as: redis-operator
                but was required as: github.com/OT-CONTAINER-KIT/redis-operator
```
