### PR TITLE
build: dockerfile multiplatform & caching improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=/root/.cache \
 FROM gcr.io/distroless/static:nonroot
 LABEL maintainer="The Opstree Opensource <opensource@opstree.com>"
 WORKDIR /
-COPY --from=builder --link /workspace/manager .
+COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**Description**
The most useful change here is explicitly specifying the platform for the base Go image. This enables cross-compilation using the Go toolchain.

Full list of changes:
* Use the native host Go image for cross-compiling
* Use a cache mount for Go module dependencies
* Use a cache mount for Go build cache
* ~~Use `--link` in runtime image~~
   * This prevents the need to pull `gcr.io/distroless/static` during image build if the result is being pushed (e.g. in CI)
   * I reverted this, looks like Azure Pipelines does not support this option 😢 

**Type of change**
* Build scripts improvement (sorry the other categories were really N/A)

**Checklist**
- [x] Testing has been performed
- [x] No functionality is broken
- [x] Documentation updated (N/A)
