### PR TITLE
Update configmap example to use correct file key

### DIFF
--- a/example/additional_config/configmap.yaml
+++ b/example/additional_config/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: redis-external-config
 data:
-  redis-additional.conf: |
+  redis-external.conf: |
     tcp-keepalive 400
-    slowlog-max-len 158 
+    slowlog-max-len 158
     stream-node-max-bytes 2048


### PR DESCRIPTION
**Description**

The entrypoint script for the redis image uses `redis-external.conf` as it's external config file. But the example sets the file name to `redis-additional.conf`

**Type of change**

Documentation