### PR TITLE
Revert "Optimize pvcTemplate Name for Storage #438 (#445)"

### DIFF
--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -298,7 +298,7 @@ func getExternalConfig(configMapName string) []corev1.Volume {
 func createPVCTemplate(stsMeta metav1.ObjectMeta, storageSpec corev1.PersistentVolumeClaim) corev1.PersistentVolumeClaim {
 	pvcTemplate := storageSpec
 	pvcTemplate.CreationTimestamp = metav1.Time{}
-	pvcTemplate.Name = "data"
+	pvcTemplate.Name = stsMeta.GetName()
 	pvcTemplate.Labels = stsMeta.GetLabels()
 	// We want the same annoations as the StatefulSet here
 	pvcTemplate.Annotations = generateStatefulSetsAnots(stsMeta)
@@ -477,7 +477,7 @@ func getVolumeMount(name string, persistenceEnabled *bool, externalConfig *strin
 
 	if persistenceEnabled != nil && *persistenceEnabled {
 		VolumeMounts = append(VolumeMounts, corev1.VolumeMount{
-			Name:      "data",
+			Name:      name,
 			MountPath: "/data",
 		})
 	}


### PR DESCRIPTION
This reverts commit ff6980f6bd8c1191778cc065b1d18f11f58383a7.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes [#ISSUE](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/507)

**Type of change**

This revert fixes:
* breaking change of existing StatefulSet volume names
* prevent data loss of existing persistent redis deployments

**Checklist**

- [x] Testing has been performed - NA
- [ ] No functionality is broken - this revert will broke deployments from 0.14.0 version
- [x] Documentation updated - NA
