### PR TITLE
feat: redis-cluster network policy

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -125,3 +125,7 @@ type InitContainer struct {
 	Command         []string                     `json:"command,omitempty"`
 	Args            []string                     `json:"args,omitempty"`
 }
+
+type NetworkPolicyConfigs struct {
+	ExternalComponentMatchLabels map[string]string `json:"matchLabels,omitempty"`
+}

--- a/api/v1beta1/rediscluster_types.go
+++ b/api/v1beta1/rediscluster_types.go
@@ -42,6 +42,7 @@ type RedisClusterSpec struct {
 	Sidecars           *[]Sidecar                   `json:"sidecars,omitempty"`
 	ServiceAccountName *string                      `json:"serviceAccountName,omitempty"`
 	PersistenceEnabled *bool                        `json:"persistenceEnabled,omitempty"`
+	NetworkPolicy      []NetworkPolicyConfigs       `json:"networkPolicy,omitempty"`
 }
 
 func (cr *RedisClusterSpec) GetReplicaCounts(t string) int32 {
@@ -85,8 +86,7 @@ type RedisFollower struct {
 }
 
 // RedisClusterStatus defines the observed state of RedisCluster
-type RedisClusterStatus struct {
-}
+type RedisClusterStatus struct{}
 
 // RedisPodDisruptionBudget configure a PodDisruptionBudget on the resource (leader/follower)
 type RedisPodDisruptionBudget struct {

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -456,6 +456,15 @@ spec:
                 required:
                 - image
                 type: object
+              networkPolicy:
+                items:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
               persistenceEnabled:
                 type: boolean
               priorityClassName:

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -70,6 +70,11 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: time.Second * 60}, err
 	}
 
+	err = k8sutils.CreateRedisNetworkPolicy(instance)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: time.Second * 60}, err
+	}
+
 	err = k8sutils.CreateRedisLeader(instance)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: time.Second * 60}, err

--- a/example/network_policy/redis-cluster.yaml
+++ b/example/network_policy/redis-cluster.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta1
+kind: RedisCluster
+metadata:
+  name: redis-cluster
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  securityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.5
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+    redisSecret:
+      name: redis-secret
+      key: password
+    # imagePullSecrets:
+    #   - name: regcred
+  redisExporter:
+    enabled: true
+    image: quay.io/opstree/redis-exporter:v1.44.0
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  networkPolicy:
+    - matchLabels:
+        app.kubernetes.io/component: example-proxy-envoy
+  # Environment Variables for Redis Exporter
+  # env:
+  # - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+  #   value: "true"
+  # - name: UI_PROPERTIES_FILE_NAME
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: game-demo
+  #       key: ui_properties_file_name
+  # - name: SECRET_USERNAME
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret
+  #       key: username
+  #  redisLeader:
+  #    redisConfig:
+  #      additionalRedisConfig: redis-external-config
+  #  redisFollower:
+  #    redisConfig:
+  #      additionalRedisConfig: redis-external-config
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+  # nodeSelector:
+  #   kubernetes.io/hostname: minikube
+  # priorityClassName:
+  # Affinity:
+  # Tolerations: []

--- a/k8sutils/networkpolicy.go
+++ b/k8sutils/networkpolicy.go
@@ -1,0 +1,199 @@
+package k8sutils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta1"
+	"github.com/banzaicloud/k8s-objectmatcher/patch"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	redisClusterPort = 16379
+)
+
+var (
+	protocol         = corev1.ProtocolTCP
+	networkPortRedis = networkv1.NetworkPolicyPort{
+		Protocol: &protocol,
+		Port: &intstr.IntOrString{
+			IntVal: redisPort,
+		},
+	}
+	networkPortRedisCluster = networkv1.NetworkPolicyPort{
+		Protocol: &protocol,
+		Port: &intstr.IntOrString{
+			IntVal: redisClusterPort,
+		},
+	}
+)
+
+func generateNetworkPolicyDef(networkPolicyMeta metav1.ObjectMeta, config []v1beta1.NetworkPolicyConfigs) *networkv1.NetworkPolicy {
+	networkPolicy := &networkv1.NetworkPolicy{
+		ObjectMeta: networkPolicyMeta,
+		Spec: networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: networkPolicyMeta.Labels,
+			},
+			Ingress: getNetworkPolicyIngressConfiguration(
+				networkPolicyMeta,
+				config,
+			),
+			Egress: []networkv1.NetworkPolicyEgressRule{
+				{
+					To: []networkv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: networkPolicyMeta.Labels,
+							},
+						},
+					},
+					Ports: []networkv1.NetworkPolicyPort{
+						networkPortRedis,
+						networkPortRedisCluster,
+					},
+				},
+			},
+			PolicyTypes: []networkv1.PolicyType{
+				networkv1.PolicyTypeIngress,
+				networkv1.PolicyTypeEgress,
+			},
+		},
+	}
+
+	return networkPolicy
+}
+
+func getNetworkPolicyIngressConfiguration(
+	networkPolicyMeta metav1.ObjectMeta,
+	configs []v1beta1.NetworkPolicyConfigs,
+) []networkv1.NetworkPolicyIngressRule {
+	ingresses := []networkv1.NetworkPolicyIngressRule{
+		{
+			From: []networkv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: networkPolicyMeta.Labels,
+					},
+				},
+			},
+			Ports: []networkv1.NetworkPolicyPort{
+				networkPortRedis,
+				networkPortRedisCluster,
+			},
+		},
+	}
+
+	if configs != nil {
+		for _, config := range configs {
+			ingresses = append(ingresses, networkv1.NetworkPolicyIngressRule{
+				From: []networkv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: config.ExternalComponentMatchLabels,
+						},
+					},
+				},
+				Ports: []networkv1.NetworkPolicyPort{
+					networkPortRedis,
+				},
+			})
+		}
+	}
+
+	return ingresses
+}
+
+func createNetworkPolicy(namespace string, networkpolicy *networkv1.NetworkPolicy) error {
+	logger := networkPolicyLogger(namespace, networkpolicy.Name)
+	_, err := generateK8sClient().NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), networkpolicy, metav1.CreateOptions{})
+	if err != nil {
+		logger.Error(err, "NetworkPolicy creation failed")
+		return err
+	}
+	logger.Info("NetworkPolicy creation is successful")
+	return nil
+}
+
+func updateNetworkPolicy(namespace string, networkpolicy *networkv1.NetworkPolicy) error {
+	logger := networkPolicyLogger(namespace, networkpolicy.Name)
+	_, err := generateK8sClient().NetworkingV1().NetworkPolicies(namespace).Update(context.TODO(), networkpolicy, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "NetworkPolicy update failed")
+		return err
+	}
+	logger.Info("NetworkPolicy updated successfully")
+	return nil
+}
+
+func getNetworkPolicy(namespace string, networkpolicy string) (*networkv1.NetworkPolicy, error) {
+	logger := networkPolicyLogger(namespace, networkpolicy)
+	getOpts := metav1.GetOptions{
+		TypeMeta: generateMetaInformation("NetworkPolicy", "networking.k8s.io/v1"),
+	}
+	networkPolicyInfo, err := generateK8sClient().NetworkingV1().NetworkPolicies(namespace).Get(context.TODO(), networkpolicy, getOpts)
+	if err != nil {
+		logger.Info("NetworkPolicy get action failed")
+		return nil, err
+	}
+	logger.Info("NetworkPolicy get action is successful")
+	return networkPolicyInfo, nil
+}
+
+func networkPolicyLogger(namespace string, name string) logr.Logger {
+	reqLogger := log.WithValues("Request.NetworkPolicy.Namespace", namespace, "Request.NetworkPolicy.Name", name)
+	return reqLogger
+}
+
+func CreateOrUpdateNetworkPolicy(namespace string, networkPolicyMeta metav1.ObjectMeta, ownerDef metav1.OwnerReference, config []v1beta1.NetworkPolicyConfigs) error {
+	logger := networkPolicyLogger(namespace, networkPolicyMeta.Name)
+	networkPolicyDef := generateNetworkPolicyDef(networkPolicyMeta, config)
+	storedNetworkPolicy, err := getNetworkPolicy(namespace, networkPolicyMeta.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(networkPolicyDef); err != nil {
+				logger.Error(err, "Unable to patch network policy with compare annotations")
+			}
+			return createNetworkPolicy(namespace, networkPolicyDef)
+		}
+		return err
+	}
+	return patchNetworkPolicy(storedNetworkPolicy, networkPolicyDef, namespace)
+}
+
+func patchNetworkPolicy(storedNetworkPolicy *networkv1.NetworkPolicy, newNetworkPolicy *networkv1.NetworkPolicy, namespace string) error {
+	logger := networkPolicyLogger(namespace, storedNetworkPolicy.Name)
+
+	newNetworkPolicy.ResourceVersion = storedNetworkPolicy.ResourceVersion
+	newNetworkPolicy.CreationTimestamp = storedNetworkPolicy.CreationTimestamp
+	newNetworkPolicy.ManagedFields = storedNetworkPolicy.ManagedFields
+
+	patchResult, err := patch.DefaultPatchMaker.Calculate(storedNetworkPolicy, newNetworkPolicy, patch.IgnoreStatusFields(), patch.IgnoreField("kind"), patch.IgnoreField("apiVersion"))
+	if err != nil {
+		logger.Error(err, "Unable to patch network policy with comparison object")
+		return err
+	}
+	if !patchResult.IsEmpty() {
+		logger.Info("Changes in network policy detected, updating...", "patch", string(patchResult.Patch))
+
+		for key, value := range storedNetworkPolicy.Annotations {
+			if _, present := newNetworkPolicy.Annotations[key]; !present {
+				newNetworkPolicy.Annotations[key] = value
+			}
+		}
+		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(newNetworkPolicy); err != nil {
+			logger.Error(err, "Unable to patch network policy with comparison object")
+			return err
+		}
+		logger.Info("Syncing network policy with defined properties")
+		updateNetworkPolicy(namespace, newNetworkPolicy)
+	}
+	logger.Info("NetworkPolicy already in sync")
+	return nil
+}

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -191,6 +191,11 @@ func CreateRedisFollowerService(cr *redisv1beta1.RedisCluster) error {
 	return prop.CreateRedisClusterService(cr)
 }
 
+func CreateRedisNetworkPolicy(cr *redisv1beta1.RedisCluster) error {
+	networkPolicyMeta := generateObjectMetaInformation(cr.ObjectMeta.Name+"-nodes", cr.ObjectMeta.Namespace, cr.ObjectMeta.Labels, cr.ObjectMeta.Annotations)
+	return CreateOrUpdateNetworkPolicy(cr.Namespace, networkPolicyMeta, redisClusterAsOwner(cr), cr.Spec.NetworkPolicy)
+}
+
 func (service RedisClusterSTS) getReplicaCount(cr *redisv1beta1.RedisCluster) int32 {
 	return cr.Spec.GetReplicaCounts(service.RedisStateFulType)
 }


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

A network policy is required to facilitate communication among the nodes of a redis-cluster. This feature enables the operator to generate a NetworkPolicy resource, which opens communication on ports 6379 and 16379 between the nodes within the same redis-cluster. Furthermore, the redis-cluster Spec now allows the addition of matchLabels, designed to target an external service for opening communication.

* Add NetworkPolicy in redis-cluster Spec
* Add create, update and finalizer for network policy

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Testing has been performed
- [x] No functionality is broken
- [x] Documentation updated
