### PR TITLE
Manage (Pod and Container) security Context

### DIFF
--- a/api/v1beta1/redis_types.go
+++ b/api/v1beta1/redis_types.go
@@ -26,17 +26,18 @@ import (
 
 // RedisSpec defines the desired state of Redis
 type RedisSpec struct {
-	KubernetesConfig  KubernetesConfig           `json:"kubernetesConfig"`
-	RedisExporter     *RedisExporter             `json:"redisExporter,omitempty"`
-	RedisConfig       *RedisConfig               `json:"redisConfig,omitempty"`
-	Storage           *Storage                   `json:"storage,omitempty"`
-	NodeSelector      map[string]string          `json:"nodeSelector,omitempty"`
-	SecurityContext   *corev1.PodSecurityContext `json:"securityContext,omitempty"`
-	PriorityClassName string                     `json:"priorityClassName,omitempty"`
-	Affinity          *corev1.Affinity           `json:"affinity,omitempty"`
-	Tolerations       *[]corev1.Toleration       `json:"tolerations,omitempty"`
-	TLS               *TLSConfig                 `json:"TLS,omitempty"`
-	ACL               *ACLConfig                 `json:"acl,omitempty"`
+	KubernetesConfig   KubernetesConfig           `json:"kubernetesConfig"`
+	RedisExporter      *RedisExporter             `json:"redisExporter,omitempty"`
+	RedisConfig        *RedisConfig               `json:"redisConfig,omitempty"`
+	Storage            *Storage                   `json:"storage,omitempty"`
+	NodeSelector       map[string]string          `json:"nodeSelector,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	SecurityContext    *corev1.SecurityContext    `json:"securityContext,omitempty"`
+	PriorityClassName  string                     `json:"priorityClassName,omitempty"`
+	Affinity           *corev1.Affinity           `json:"affinity,omitempty"`
+	Tolerations        *[]corev1.Toleration       `json:"tolerations,omitempty"`
+	TLS                *TLSConfig                 `json:"TLS,omitempty"`
+	ACL                *ACLConfig                 `json:"acl,omitempty"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}
 	ReadinessProbe *Probe `json:"readinessProbe,omitempty" protobuf:"bytes,11,opt,name=readinessProbe"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}

--- a/api/v1beta1/rediscluster_types.go
+++ b/api/v1beta1/rediscluster_types.go
@@ -33,7 +33,7 @@ type RedisClusterSpec struct {
 	RedisFollower      RedisFollower                `json:"redisFollower,omitempty"`
 	RedisExporter      *RedisExporter               `json:"redisExporter,omitempty"`
 	Storage            *Storage                     `json:"storage,omitempty"`
-	SecurityContext    *corev1.PodSecurityContext   `json:"securityContext,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext   `json:"podSecurityContext,omitempty"`
 	PriorityClassName  string                       `json:"priorityClassName,omitempty"`
 	Resources          *corev1.ResourceRequirements `json:"resources,omitempty"`
 	TLS                *TLSConfig                   `json:"TLS,omitempty"`
@@ -58,6 +58,7 @@ func (cr *RedisClusterSpec) GetReplicaCounts(t string) int32 {
 type RedisLeader struct {
 	Replicas            *int32                    `json:"replicas,omitempty"`
 	RedisConfig         *RedisConfig              `json:"redisConfig,omitempty"`
+	SecurityContext     *corev1.SecurityContext   `json:"securityContext,omitempty"`
 	Affinity            *corev1.Affinity          `json:"affinity,omitempty"`
 	PodDisruptionBudget *RedisPodDisruptionBudget `json:"pdb,omitempty"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}
@@ -73,6 +74,7 @@ type RedisLeader struct {
 type RedisFollower struct {
 	Replicas            *int32                    `json:"replicas,omitempty"`
 	RedisConfig         *RedisConfig              `json:"redisConfig,omitempty"`
+	SecurityContext     *corev1.SecurityContext   `json:"securityContext,omitempty"`
 	Affinity            *corev1.Affinity          `json:"affinity,omitempty"`
 	PodDisruptionBudget *RedisPodDisruptionBudget `json:"pdb,omitempty"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}

--- a/api/v1beta1/redisreplication_types.go
+++ b/api/v1beta1/redisreplication_types.go
@@ -6,18 +6,19 @@ import (
 )
 
 type RedisReplicationSpec struct {
-	Size              *int32                     `json:"clusterSize"`
-	KubernetesConfig  KubernetesConfig           `json:"kubernetesConfig"`
-	RedisExporter     *RedisExporter             `json:"redisExporter,omitempty"`
-	RedisConfig       *RedisConfig               `json:"redisConfig,omitempty"`
-	Storage           *Storage                   `json:"storage,omitempty"`
-	NodeSelector      map[string]string          `json:"nodeSelector,omitempty"`
-	SecurityContext   *corev1.PodSecurityContext `json:"securityContext,omitempty"`
-	PriorityClassName string                     `json:"priorityClassName,omitempty"`
-	Affinity          *corev1.Affinity           `json:"affinity,omitempty"`
-	Tolerations       *[]corev1.Toleration       `json:"tolerations,omitempty"`
-	TLS               *TLSConfig                 `json:"TLS,omitempty"`
-	ACL               *ACLConfig                 `json:"acl,omitempty"`
+	Size               *int32                     `json:"clusterSize"`
+	KubernetesConfig   KubernetesConfig           `json:"kubernetesConfig"`
+	RedisExporter      *RedisExporter             `json:"redisExporter,omitempty"`
+	RedisConfig        *RedisConfig               `json:"redisConfig,omitempty"`
+	Storage            *Storage                   `json:"storage,omitempty"`
+	NodeSelector       map[string]string          `json:"nodeSelector,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	SecurityContext    *corev1.SecurityContext    `json:"securityContext,omitempty"`
+	PriorityClassName  string                     `json:"priorityClassName,omitempty"`
+	Affinity           *corev1.Affinity           `json:"affinity,omitempty"`
+	Tolerations        *[]corev1.Toleration       `json:"tolerations,omitempty"`
+	TLS                *TLSConfig                 `json:"TLS,omitempty"`
+	ACL                *ACLConfig                 `json:"acl,omitempty"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}
 	ReadinessProbe *Probe `json:"readinessProbe,omitempty" protobuf:"bytes,11,opt,name=readinessProbe"`
 	// +kubebuilder:default:={initialDelaySeconds: 1, timeoutSeconds: 1, periodSeconds: 10, successThreshold: 1, failureThreshold:3}

--- a/api/v1beta1/redissentinel_types.go
+++ b/api/v1beta1/redissentinel_types.go
@@ -14,7 +14,8 @@ type RedisSentinelSpec struct {
 	RedisExporter       *RedisExporter             `json:"redisExporter,omitempty"`
 	RedisSentinelConfig *RedisSentinelConfig       `json:"redisSentinelConfig,omitempty"`
 	NodeSelector        map[string]string          `json:"nodeSelector,omitempty"`
-	SecurityContext     *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	PodSecurityContext  *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	SecurityContext     *corev1.SecurityContext    `json:"securityContext,omitempty"`
 	PriorityClassName   string                     `json:"priorityClassName,omitempty"`
 	Affinity            *corev1.Affinity           `json:"affinity,omitempty"`
 	Tolerations         *[]corev1.Toleration       `json:"tolerations,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -313,8 +313,8 @@ func (in *RedisClusterSpec) DeepCopyInto(out *RedisClusterSpec) {
 		*out = new(Storage)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SecurityContext != nil {
-		in, out := &in.SecurityContext, &out.SecurityContext
+	if in.PodSecurityContext != nil {
+		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
@@ -720,9 +720,14 @@ func (in *RedisReplicationSpec) DeepCopyInto(out *RedisReplicationSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PodSecurityContext != nil {
+		in, out := &in.PodSecurityContext, &out.PodSecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
+		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Affinity != nil {
@@ -919,9 +924,14 @@ func (in *RedisSentinelSpec) DeepCopyInto(out *RedisSentinelSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PodSecurityContext != nil {
+		in, out := &in.PodSecurityContext, &out.PodSecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
+		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Affinity != nil {
@@ -1039,9 +1049,14 @@ func (in *RedisSpec) DeepCopyInto(out *RedisSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PodSecurityContext != nil {
+		in, out := &in.PodSecurityContext, &out.PodSecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
+		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Affinity != nil {

--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -1297,6 +1297,172 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              podSecurityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
               priorityClassName:
                 type: string
               readinessProbe:
@@ -1492,39 +1658,62 @@ spec:
                 - image
                 type: object
               securityContext:
-                description: PodSecurityContext holds pod-level security attributes
-                  and common container settings. Some fields are also present in container.securityContext.  Field
-                  values of container.securityContext take precedence over field values
-                  of PodSecurityContext.
+                description: SecurityContext holds security configuration that will
+                  be applied to a container. Some fields are present in both SecurityContext
+                  and PodSecurityContext.  When both are set, the values in SecurityContext
+                  take precedence.
                 properties:
-                  fsGroup:
-                    description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                  allowPrivilegeEscalation:
+                    description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.'
+                    type: boolean
+                  capabilities:
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
+                  privileged:
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
+                  procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
                     type: string
+                  readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
                   runAsGroup:
                     description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
@@ -1532,26 +1721,26 @@ spec:
                       user. If true, the Kubelet will validate the image at runtime
                       to ensure that it does not run as UID 0 (root) and fail to start
                       the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
+                      will be performed. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
                     description: The UID to run the entrypoint of the container process.
                       Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
+                      May also be set in PodSecurityContext.  If set in both SecurityContext
                       and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
+                      takes precedence. Note that this field cannot be set when spec.os.name
+                      is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to all containers.
+                    description: The SELinux context to be applied to the container.
                       If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      SELinux context for each container.  May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       level:
                         description: Level is SELinux level label that applies to
@@ -1571,9 +1760,10 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by the containers in this
-                      pod. Note that this field cannot be set when spec.os.name is
-                      windows.
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
                         description: localhostProfile indicates a profile defined
@@ -1592,38 +1782,10 @@ spec:
                     required:
                     - type
                     type: object
-                  supplementalGroups:
-                    description: A list of groups applied to the first process run
-                      in each container, in addition to the container's primary GID.  If
-                      unspecified, no groups will be added to any container. Note
-                      that this field cannot be set when spec.os.name is windows.
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for
-                      the pod. Pods with unsupported sysctls (by the container runtime)
-                      might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
-                    items:
-                      description: Sysctl defines a kernel parameter to be set
-                      properties:
-                        name:
-                          description: Name of a property to set
-                          type: string
-                        value:
-                          description: Value of a property to set
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
                   windowsOptions:
                     description: The Windows specific settings applied to all containers.
-                      If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      If unspecified, the options from the PodSecurityContext will
+                      be used. If set in both SecurityContext and PodSecurityContext,
                       the value specified in SecurityContext takes precedence. Note
                       that this field cannot be set when spec.os.name is linux.
                     properties:

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -458,6 +458,172 @@ spec:
                 type: object
               persistenceEnabled:
                 type: boolean
+              podSecurityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
               priorityClassName:
                 type: string
               redisExporter:
@@ -1590,6 +1756,177 @@ spec:
                   replicas:
                     format: int32
                     type: integer
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN Note that this field cannot be set
+                          when spec.os.name is windows.'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is
+                          linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   terminationGracePeriodSeconds:
                     format: int64
                     type: integer
@@ -2612,6 +2949,177 @@ spec:
                   replicas:
                     format: int32
                     type: integer
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN Note that this field cannot be set
+                          when spec.os.name is windows.'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options. Note
+                          that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is
+                          linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   terminationGracePeriodSeconds:
                     format: int64
                     type: integer
@@ -2680,172 +3188,6 @@ spec:
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                type: object
-              securityContext:
-                description: PodSecurityContext holds pod-level security attributes
-                  and common container settings. Some fields are also present in container.securityContext.  Field
-                  values of container.securityContext take precedence over field values
-                  of PodSecurityContext.
-                properties:
-                  fsGroup:
-                    description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
-                    type: string
-                  runAsGroup:
-                    description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
-                    format: int64
-                    type: integer
-                  runAsNonRoot:
-                    description: Indicates that the container must run as a non-root
-                      user. If true, the Kubelet will validate the image at runtime
-                      to ensure that it does not run as UID 0 (root) and fail to start
-                      the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
-                    type: boolean
-                  runAsUser:
-                    description: The UID to run the entrypoint of the container process.
-                      Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
-                      and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
-                    format: int64
-                    type: integer
-                  seLinuxOptions:
-                    description: The SELinux context to be applied to all containers.
-                      If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
-                    properties:
-                      level:
-                        description: Level is SELinux level label that applies to
-                          the container.
-                        type: string
-                      role:
-                        description: Role is a SELinux role label that applies to
-                          the container.
-                        type: string
-                      type:
-                        description: Type is a SELinux type label that applies to
-                          the container.
-                        type: string
-                      user:
-                        description: User is a SELinux user label that applies to
-                          the container.
-                        type: string
-                    type: object
-                  seccompProfile:
-                    description: The seccomp options to use by the containers in this
-                      pod. Note that this field cannot be set when spec.os.name is
-                      windows.
-                    properties:
-                      localhostProfile:
-                        description: localhostProfile indicates a profile defined
-                          in a file on the node should be used. The profile must be
-                          preconfigured on the node to work. Must be a descending
-                          path, relative to the kubelet's configured seccomp profile
-                          location. Must only be set if type is "Localhost".
-                        type: string
-                      type:
-                        description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  supplementalGroups:
-                    description: A list of groups applied to the first process run
-                      in each container, in addition to the container's primary GID.  If
-                      unspecified, no groups will be added to any container. Note
-                      that this field cannot be set when spec.os.name is windows.
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for
-                      the pod. Pods with unsupported sysctls (by the container runtime)
-                      might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
-                    items:
-                      description: Sysctl defines a kernel parameter to be set
-                      properties:
-                        name:
-                          description: Name of a property to set
-                          type: string
-                        value:
-                          description: Value of a property to set
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
-                  windowsOptions:
-                    description: The Windows specific settings applied to all containers.
-                      If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
-                      the value specified in SecurityContext takes precedence. Note
-                      that this field cannot be set when spec.os.name is linux.
-                    properties:
-                      gmsaCredentialSpec:
-                        description: GMSACredentialSpec is where the GMSA admission
-                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                          inlines the contents of the GMSA credential spec named by
-                          the GMSACredentialSpecName field.
-                        type: string
-                      gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA
-                          credential spec to use.
-                        type: string
-                      hostProcess:
-                        description: HostProcess determines if a container should
-                          be run as a 'Host Process' container. This field is alpha-level
-                          and will only be honored by components that enable the WindowsHostProcessContainers
-                          feature flag. Setting this field without the feature flag
-                          will result in errors when validating the Pod. All of a
-                          Pod's containers must have the same effective HostProcess
-                          value (it is not allowed to have a mix of HostProcess containers
-                          and non-HostProcess containers).  In addition, if HostProcess
-                          is true then HostNetwork must also be set to true.
-                        type: boolean
-                      runAsUserName:
-                        description: The UserName in Windows to run the entrypoint
-                          of the container process. Defaults to the user specified
-                          in image metadata if unspecified. May also be set in PodSecurityContext.
-                          If set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        type: string
                     type: object
                 type: object
               serviceAccountName:

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -1299,6 +1299,172 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              podSecurityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
               priorityClassName:
                 type: string
               readinessProbe:
@@ -1494,39 +1660,62 @@ spec:
                 - image
                 type: object
               securityContext:
-                description: PodSecurityContext holds pod-level security attributes
-                  and common container settings. Some fields are also present in container.securityContext.  Field
-                  values of container.securityContext take precedence over field values
-                  of PodSecurityContext.
+                description: SecurityContext holds security configuration that will
+                  be applied to a container. Some fields are present in both SecurityContext
+                  and PodSecurityContext.  When both are set, the values in SecurityContext
+                  take precedence.
                 properties:
-                  fsGroup:
-                    description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                  allowPrivilegeEscalation:
+                    description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.'
+                    type: boolean
+                  capabilities:
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
+                  privileged:
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
+                  procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
                     type: string
+                  readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
                   runAsGroup:
                     description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
@@ -1534,26 +1723,26 @@ spec:
                       user. If true, the Kubelet will validate the image at runtime
                       to ensure that it does not run as UID 0 (root) and fail to start
                       the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
+                      will be performed. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
                     description: The UID to run the entrypoint of the container process.
                       Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
+                      May also be set in PodSecurityContext.  If set in both SecurityContext
                       and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
+                      takes precedence. Note that this field cannot be set when spec.os.name
+                      is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to all containers.
+                    description: The SELinux context to be applied to the container.
                       If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      SELinux context for each container.  May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       level:
                         description: Level is SELinux level label that applies to
@@ -1573,9 +1762,10 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by the containers in this
-                      pod. Note that this field cannot be set when spec.os.name is
-                      windows.
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
                         description: localhostProfile indicates a profile defined
@@ -1594,38 +1784,10 @@ spec:
                     required:
                     - type
                     type: object
-                  supplementalGroups:
-                    description: A list of groups applied to the first process run
-                      in each container, in addition to the container's primary GID.  If
-                      unspecified, no groups will be added to any container. Note
-                      that this field cannot be set when spec.os.name is windows.
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for
-                      the pod. Pods with unsupported sysctls (by the container runtime)
-                      might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
-                    items:
-                      description: Sysctl defines a kernel parameter to be set
-                      properties:
-                        name:
-                          description: Name of a property to set
-                          type: string
-                        value:
-                          description: Value of a property to set
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
                   windowsOptions:
                     description: The Windows specific settings applied to all containers.
-                      If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      If unspecified, the options from the PodSecurityContext will
+                      be used. If set in both SecurityContext and PodSecurityContext,
                       the value specified in SecurityContext takes precedence. Note
                       that this field cannot be set when spec.os.name is linux.
                     properties:

--- a/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
@@ -1245,6 +1245,172 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              podSecurityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
               priorityClassName:
                 type: string
               readinessProbe:
@@ -1461,39 +1627,62 @@ spec:
                 - redisReplicationName
                 type: object
               securityContext:
-                description: PodSecurityContext holds pod-level security attributes
-                  and common container settings. Some fields are also present in container.securityContext.  Field
-                  values of container.securityContext take precedence over field values
-                  of PodSecurityContext.
+                description: SecurityContext holds security configuration that will
+                  be applied to a container. Some fields are present in both SecurityContext
+                  and PodSecurityContext.  When both are set, the values in SecurityContext
+                  take precedence.
                 properties:
-                  fsGroup:
-                    description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                  allowPrivilegeEscalation:
+                    description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.'
+                    type: boolean
+                  capabilities:
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
+                  privileged:
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
+                  procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
                     type: string
+                  readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
                   runAsGroup:
                     description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
@@ -1501,26 +1690,26 @@ spec:
                       user. If true, the Kubelet will validate the image at runtime
                       to ensure that it does not run as UID 0 (root) and fail to start
                       the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
+                      will be performed. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
                     description: The UID to run the entrypoint of the container process.
                       Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
+                      May also be set in PodSecurityContext.  If set in both SecurityContext
                       and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
+                      takes precedence. Note that this field cannot be set when spec.os.name
+                      is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to all containers.
+                    description: The SELinux context to be applied to the container.
                       If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      SELinux context for each container.  May also be set in PodSecurityContext.  If
                       set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       level:
                         description: Level is SELinux level label that applies to
@@ -1540,9 +1729,10 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by the containers in this
-                      pod. Note that this field cannot be set when spec.os.name is
-                      windows.
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
                         description: localhostProfile indicates a profile defined
@@ -1561,38 +1751,10 @@ spec:
                     required:
                     - type
                     type: object
-                  supplementalGroups:
-                    description: A list of groups applied to the first process run
-                      in each container, in addition to the container's primary GID.  If
-                      unspecified, no groups will be added to any container. Note
-                      that this field cannot be set when spec.os.name is windows.
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for
-                      the pod. Pods with unsupported sysctls (by the container runtime)
-                      might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
-                    items:
-                      description: Sysctl defines a kernel parameter to be set
-                      properties:
-                        name:
-                          description: Name of a property to set
-                          type: string
-                        value:
-                          description: Value of a property to set
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
                   windowsOptions:
                     description: The Windows specific settings applied to all containers.
-                      If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      If unspecified, the options from the PodSecurityContext will
+                      be used. If set in both SecurityContext and PodSecurityContext,
                       the value specified in SecurityContext takes precedence. Note
                       that this field cannot be set when spec.os.name is linux.
                     properties:

--- a/example/acl_config/cluster.yaml
+++ b/example/acl_config/cluster.yaml
@@ -7,7 +7,7 @@ spec:
   clusterSize: 3
   clusterVersion: v7
   persistenceEnabled: true
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/acl_config/replication.yaml
+++ b/example/acl_config/replication.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  redis-replication
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   # redisConfig:

--- a/example/additional_config/clusterd.yaml
+++ b/example/additional_config/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/additional_config/replication.yaml
+++ b/example/additional_config/replication.yaml
@@ -10,7 +10,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/additional_config/standalone.yaml
+++ b/example/additional_config/standalone.yaml
@@ -9,7 +9,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/advance_config/clusterd.yaml
+++ b/example/advance_config/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true
@@ -33,7 +33,7 @@ spec:
           requests:
             storage: 1Gi
   # nodeSelector: {}
-  # securityContext: {}
+  # podSecurityContext: {}
   # priorityClassName: ""
   # affinity: {}
   # Tolerations: []

--- a/example/advance_config/standalone.yaml
+++ b/example/advance_config/standalone.yaml
@@ -14,7 +14,7 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:
@@ -29,7 +29,7 @@ spec:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
   # nodeSelector: {}
-  # securityContext: {}
+  # podSecurityContext: {}
   # priorityClassName: ""
   # affinity: {}
   # Tolerations: []

--- a/example/affinity/clusterd.yaml
+++ b/example/affinity/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/affinity/replication.yaml
+++ b/example/affinity/replication.yaml
@@ -8,7 +8,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/affinity/standalone.yaml
+++ b/example/affinity/standalone.yaml
@@ -7,7 +7,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/disruption_budget/clusterd.yaml
+++ b/example/disruption_budget/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/external_service/clusterd.yaml
+++ b/example/external_service/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/external_service/replication.yaml
+++ b/example/external_service/replication.yaml
@@ -8,7 +8,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/external_service/standalone.yaml
+++ b/example/external_service/standalone.yaml
@@ -7,7 +7,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/node-selector/clusterd.yaml
+++ b/example/node-selector/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/node-selector/replication.yaml
+++ b/example/node-selector/replication.yaml
@@ -8,7 +8,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/node-selector/standalone.yaml
+++ b/example/node-selector/standalone.yaml
@@ -7,7 +7,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/password_protected/clusterd.yaml
+++ b/example/password_protected/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/password_protected/replication.yaml
+++ b/example/password_protected/replication.yaml
@@ -22,6 +22,6 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/password_protected/standalone.yaml
+++ b/example/password_protected/standalone.yaml
@@ -21,6 +21,6 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/private_registry/clusterd.yaml
+++ b/example/private_registry/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/private_registry/replication.yaml
+++ b/example/private_registry/replication.yaml
@@ -21,6 +21,6 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/private_registry/standalone.yaml
+++ b/example/private_registry/standalone.yaml
@@ -20,6 +20,6 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/probes/clusterd.yaml
+++ b/example/probes/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/probes/replication.yaml
+++ b/example/probes/replication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-replication
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/probes/standalone.yaml
+++ b/example/probes/standalone.yaml
@@ -4,7 +4,7 @@ kind: Redis
 metadata:
   name: redis-standalone
 spec:
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/recreate-statefulset/clusterd.yaml
+++ b/example/recreate-statefulset/clusterd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/recreate-statefulset/replication.yaml
+++ b/example/recreate-statefulset/replication.yaml
@@ -10,7 +10,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/recreate-statefulset/standalone.yaml
+++ b/example/recreate-statefulset/standalone.yaml
@@ -9,7 +9,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/redis-cluster.yaml
+++ b/example/redis-cluster.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  persistenceEnabled: true
-  securityContext:
+  persistenceEnabled: false
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
@@ -20,13 +20,13 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-    redisSecret:
-      name: redis-secret
-      key: password
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
     # imagePullSecrets:
     #   - name: regcred
   redisExporter:
-    enabled: true
+    enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
     imagePullPolicy: Always
     resources:

--- a/example/redis-replication.yaml
+++ b/example/redis-replication.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  redis-replication
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   # redisConfig:

--- a/example/redis-sentinel.yaml
+++ b/example/redis-sentinel.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-sentinel
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig: 

--- a/example/redis-standalone.yaml
+++ b/example/redis-standalone.yaml
@@ -56,7 +56,7 @@ spec:
             storage: 1Gi
   # nodeSelector:
   #   kubernetes.io/hostname: minikube
-  # securityContext: {}
+  # podSecurityContext: {}
   # priorityClassName:
   # affinity:
   # Tolerations: []

--- a/example/redis_monitoring/clusterd.yaml
+++ b/example/redis_monitoring/clusterd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/redis_monitoring/replication.yaml
+++ b/example/redis_monitoring/replication.yaml
@@ -25,6 +25,6 @@ spec:
     # env:
     # - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
     #   value: "true"
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/redis_monitoring/standalone.yaml
+++ b/example/redis_monitoring/standalone.yaml
@@ -24,6 +24,6 @@ spec:
     # env:
     # - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
     #   value: "true"
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/redis_sentinel/sentinel.yaml
+++ b/example/redis_sentinel/sentinel.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-sentinel
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig: 

--- a/example/tls_enabled/redis-cluster.yaml
+++ b/example/tls_enabled/redis-cluster.yaml
@@ -14,7 +14,7 @@ spec:
       secretName: redis-tls-cert
   clusterVersion: v7
   persistenceEnabled: true
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/tls_enabled/redis-replication.yaml
+++ b/example/tls_enabled/redis-replication.yaml
@@ -12,7 +12,7 @@ spec:
     key: tls.key
     secret:
       secretName: redis-tls-cert
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/tls_enabled/redis-standalone.yaml
+++ b/example/tls_enabled/redis-standalone.yaml
@@ -11,7 +11,7 @@ spec:
     key: tls.key
     secret:
       secretName: redis-tls-cert
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/example/tolerations/clusterd.yaml
+++ b/example/tolerations/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/tolerations/standalone.yaml
+++ b/example/tolerations/standalone.yaml
@@ -7,7 +7,7 @@ spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.5
     imagePullPolicy: IfNotPresent
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/upgrade-strategy/clusterd.yaml
+++ b/example/upgrade-strategy/clusterd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true

--- a/example/upgrade-strategy/standalone.yaml
+++ b/example/upgrade-strategy/standalone.yaml
@@ -10,7 +10,7 @@ spec:
     updateStrategy:
       type: OnDelete
 #      type: RollingUpdate
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   storage:

--- a/example/volume_mount/redis-cluster.yaml
+++ b/example/volume_mount/redis-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   clusterSize: 3
   clusterVersion: v7
   persistenceEnabled: true
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -70,7 +70,7 @@ func generateRedisReplicationParams(cr *redisv1beta1.RedisReplication) statefulS
 	res := statefulSetParameters{
 		Replicas:                      &replicas,
 		NodeSelector:                  cr.Spec.NodeSelector,
-		SecurityContext:               cr.Spec.SecurityContext,
+		PodSecurityContext:            cr.Spec.PodSecurityContext,
 		PriorityClassName:             cr.Spec.PriorityClassName,
 		Affinity:                      cr.Spec.Affinity,
 		Tolerations:                   cr.Spec.Tolerations,
@@ -104,6 +104,7 @@ func generateRedisReplicationContainerParams(cr *redisv1beta1.RedisReplication) 
 		Image:           cr.Spec.KubernetesConfig.Image,
 		ImagePullPolicy: cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:       cr.Spec.KubernetesConfig.Resources,
+		SecurityContext: cr.Spec.SecurityContext,
 	}
 
 	if cr.Spec.Storage != nil {

--- a/k8sutils/redis-sentinel.go
+++ b/k8sutils/redis-sentinel.go
@@ -89,7 +89,7 @@ func generateRedisSentinelParams(cr *redisv1beta1.RedisSentinel, replicas int32,
 		Metadata:                      cr.ObjectMeta,
 		Replicas:                      &replicas,
 		NodeSelector:                  cr.Spec.NodeSelector,
-		SecurityContext:               cr.Spec.SecurityContext,
+		PodSecurityContext:            cr.Spec.PodSecurityContext,
 		PriorityClassName:             cr.Spec.PriorityClassName,
 		Affinity:                      affinity,
 		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
@@ -145,6 +145,7 @@ func generateRedisSentinelContainerParams(cr *redisv1beta1.RedisSentinel, readin
 		Image:                 cr.Spec.KubernetesConfig.Image,
 		ImagePullPolicy:       cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:             cr.Spec.KubernetesConfig.Resources,
+		SecurityContext:       cr.Spec.SecurityContext,
 		AdditionalEnvVariable: getSentinelEnvVariable(cr),
 	}
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -74,7 +74,7 @@ func generateRedisStandaloneParams(cr *redisv1beta1.Redis) statefulSetParameters
 	res := statefulSetParameters{
 		Replicas:                      &replicas,
 		NodeSelector:                  cr.Spec.NodeSelector,
-		SecurityContext:               cr.Spec.SecurityContext,
+		PodSecurityContext:            cr.Spec.PodSecurityContext,
 		PriorityClassName:             cr.Spec.PriorityClassName,
 		Affinity:                      cr.Spec.Affinity,
 		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
@@ -112,6 +112,7 @@ func generateRedisStandaloneContainerParams(cr *redisv1beta1.Redis) containerPar
 		Image:           cr.Spec.KubernetesConfig.Image,
 		ImagePullPolicy: cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:       cr.Spec.KubernetesConfig.Resources,
+		SecurityContext: cr.Spec.SecurityContext,
 	}
 
 	if cr.Spec.Storage != nil {

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -30,7 +30,7 @@ type statefulSetParameters struct {
 	Replicas                      *int32
 	Metadata                      metav1.ObjectMeta
 	NodeSelector                  map[string]string
-	SecurityContext               *corev1.PodSecurityContext
+	PodSecurityContext            *corev1.PodSecurityContext
 	PriorityClassName             string
 	Affinity                      *corev1.Affinity
 	Tolerations                   *[]corev1.Toleration
@@ -50,6 +50,7 @@ type containerParameters struct {
 	Image                        string
 	ImagePullPolicy              corev1.PullPolicy
 	Resources                    *corev1.ResourceRequirements
+	SecurityContext              *corev1.SecurityContext
 	RedisExporterImage           string
 	RedisExporterImagePullPolicy corev1.PullPolicy
 	RedisExporterResources       *corev1.ResourceRequirements
@@ -222,7 +223,7 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 				Spec: corev1.PodSpec{
 					Containers:                    generateContainerDef(stsMeta.GetName(), containerParams, params.EnableMetrics, params.ExternalConfig, containerParams.AdditionalMountPath, sidecars),
 					NodeSelector:                  params.NodeSelector,
-					SecurityContext:               params.SecurityContext,
+					SecurityContext:               params.PodSecurityContext,
 					PriorityClassName:             params.PriorityClassName,
 					Affinity:                      params.Affinity,
 					TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
@@ -324,6 +325,7 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 			Name:            name,
 			Image:           containerParams.Image,
 			ImagePullPolicy: containerParams.ImagePullPolicy,
+			SecurityContext: containerParams.SecurityContext,
 			Env: getEnvironmentVariables(
 				containerParams.Role,
 				false,


### PR DESCRIPTION
**Description**

Redis pods' SecurityContext at the container level. 
Now the SecurityContext could be added at the Container level or the Pod level. 

Pod security context should be set using: `podSecurityContext`
Container security context should be set using: `securityContext`. 

In Redis Cluster Setup Leader and Follower could have different container `securityContext`


Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/516

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Testing has been performed
- [ ] No functionality is broken
- [ ] Documentation updated
