### PR TITLE
Feat: sentinel cluster size must be odd number

### DIFF
--- a/api/v1beta1/redissentinel_types.go
+++ b/api/v1beta1/redissentinel_types.go
@@ -7,7 +7,6 @@ import (
 
 type RedisSentinelSpec struct {
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Not=2
 	// +kubebuilder:default=3
 	Size                *int32                     `json:"clusterSize"`
 	KubernetesConfig    KubernetesConfig           `json:"kubernetesConfig"`


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
There is not `Not` validation in kubebuilder. We can use `Enum` to limit sentinel size to some odd number. https://book.kubebuilder.io/reference/markers/crd-validation.html

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Testing has been performed
- [ ] No functionality is broken
- [ ] Documentation updated
