### PR TITLE
[Fix] - Cluster leader failover loop if there is only a single leader

### DIFF
--- a/.azure-pipelines/pipeline.yaml
+++ b/.azure-pipelines/pipeline.yaml
@@ -15,7 +15,7 @@ resources:
   - repository: golang-template
     type: github
     name: opstree/azure-devops-template
-    endpoint: OT-CONTAINER-KIT
+    endpoint: shubham-cmyk
 
 extends:
   template: operator-ci.yaml@golang-template

--- a/.azure-pipelines/pipeline.yaml
+++ b/.azure-pipelines/pipeline.yaml
@@ -1,27 +1,24 @@
 ---
 trigger:
   - master
-
 pr:
   branches:
     include:
     - master
-
 variables:
   - group: RuntimeVariables
-
 resources:
   repositories:
   - repository: golang-template
     type: github
-    name: shubham-cmyk/azure-devops-template
-    endpoint: shubham-cmyk
+    name: opstree/azure-devops-template
+    endpoint: OT-CONTAINER-KIT
 
 extends:
   template: operator-ci.yaml@golang-template
   parameters:
     ApplicationName: redis-operator
-    QuayImageName: shubham-cmyk/redis-operator
+    QuayImageName: opstree/redis-operator
     GithubImageName: ot-container-kit/redis-operator/redis-operator
     BuildDocs: false
     AppVersion: "v0.15.0"

--- a/.azure-pipelines/pipeline.yaml
+++ b/.azure-pipelines/pipeline.yaml
@@ -14,14 +14,14 @@ resources:
   repositories:
   - repository: golang-template
     type: github
-    name: opstree/azure-devops-template
+    name: shubham-cmyk/azure-devops-template
     endpoint: shubham-cmyk
 
 extends:
   template: operator-ci.yaml@golang-template
   parameters:
     ApplicationName: redis-operator
-    QuayImageName: opstree/redis-operator
+    QuayImageName: shubham-cmyk/redis-operator
     GithubImageName: ot-container-kit/redis-operator/redis-operator
     BuildDocs: false
     AppVersion: "v0.15.0"

--- a/.azure-pipelines/pipeline.yaml
+++ b/.azure-pipelines/pipeline.yaml
@@ -1,12 +1,15 @@
 ---
 trigger:
   - master
+
 pr:
   branches:
     include:
     - master
+
 variables:
   - group: RuntimeVariables
+
 resources:
   repositories:
   - repository: golang-template

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -173,7 +173,7 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	} else {
 		reqLogger.Info("Redis leader count is desired")
-		if k8sutils.CheckRedisClusterState(instance) >= int(totalReplicas)-1 {
+		if int(totalReplicas) > 1 && k8sutils.CheckRedisClusterState(instance) >= int(totalReplicas)-1 {
 			reqLogger.Info("Redis leader is not desired, executing failover operation")
 			err = k8sutils.ExecuteFailoverOperation(instance)
 			if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Redis Cluster would go down in the broken state if the leader = 1 and follower = 0. 
This PR tries to prevent that broken state. 


Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/497

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Testing has been performed
- [ ] No functionality is broken
- [ ] Documentation updated
