### PR TITLE
+ enhaned docs about additional config configmap format

### DIFF
--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -1501,7 +1501,8 @@ spec:
                     type: integer
                 type: object
               redisConfig:
-                description: RedisConfig defines the external configuration of Redis
+                description: RedisConfig defines the external configuration of
+                  Redis. ConfigMap with key 'redis-additional.conf' is expected.
                 properties:
                   additionalRedisConfig:
                     type: string

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -1748,7 +1748,7 @@ spec:
                     type: object
                   redisConfig:
                     description: RedisConfig defines the external configuration of
-                      Redis
+                      Redis. ConfigMap with key 'redis-additional.conf' is expected.
                     properties:
                       additionalRedisConfig:
                         type: string
@@ -2941,7 +2941,7 @@ spec:
                     type: object
                   redisConfig:
                     description: RedisConfig defines the external configuration of
-                      Redis
+                      Redis. ConfigMap with key 'redis-additional.conf' is expected.
                     properties:
                       additionalRedisConfig:
                         type: string

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -1503,7 +1503,8 @@ spec:
                     type: integer
                 type: object
               redisConfig:
-                description: RedisConfig defines the external configuration of Redis
+                description: RedisConfig defines the external configuration of
+                  Redis. ConfigMap with key 'redis-additional.conf' is expected.
                 properties:
                   additionalRedisConfig:
                     type: string

--- a/example/acl_config/replication.yaml
+++ b/example/acl_config/replication.yaml
@@ -49,3 +49,10 @@ spec:
         resources:
           requests:
             storage: 1Gi
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/acl_config/standalone.yaml
+++ b/example/acl_config/standalone.yaml
@@ -44,3 +44,10 @@ spec:
         resources:
           requests:
             storage: 1Gi
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/additional_config/clusterd.yaml
+++ b/example/additional_config/clusterd.yaml
@@ -36,3 +36,10 @@ spec:
         resources:
           requests:
             storage: 1Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-external-config
+data:
+  redis-additional.conf: |

--- a/example/additional_config/replication.yaml
+++ b/example/additional_config/replication.yaml
@@ -24,3 +24,10 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-external-config
+data:
+  redis-additional.conf: |

--- a/example/additional_config/standalone.yaml
+++ b/example/additional_config/standalone.yaml
@@ -23,3 +23,10 @@ spec:
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:v1.44.0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-external-config
+data:
+  redis-additional.conf: |

--- a/example/redis-cluster.yaml
+++ b/example/redis-cluster.yaml
@@ -75,3 +75,10 @@ spec:
   # priorityClassName:
   # Affinity:
   # Tolerations: []
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/redis-replication.yaml
+++ b/example/redis-replication.yaml
@@ -58,3 +58,10 @@ spec:
         resources:
           requests:
             storage: 1Gi
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/redis-standalone.yaml
+++ b/example/redis-standalone.yaml
@@ -60,3 +60,10 @@ spec:
   # priorityClassName:
   # affinity:
   # Tolerations: []
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/sidecar_features/sidecar.yaml
+++ b/example/sidecar_features/sidecar.yaml
@@ -58,3 +58,10 @@ spec:
           configMap:
             name: example-configmap
   terminationGracePeriodSeconds: 20 #custom terimationgraceperiodseconds
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/volume_mount/redis-replication.yaml
+++ b/example/volume_mount/redis-replication.yaml
@@ -48,3 +48,10 @@ spec:
       mount:
         - mountPath: /config
           name: example-config
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |

--- a/example/volume_mount/redis-standalone.yaml
+++ b/example/volume_mount/redis-standalone.yaml
@@ -47,3 +47,11 @@ spec:
       mount:
         - mountPath: /config
           name: example-config
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: redis-external-config
+#data:
+#  redis-additional.conf: |
+


### PR DESCRIPTION
**Description**

I have struggled a lot about how to add additional Redis configuration - this is not described well in the docs. Our use-case is to have Redis only in-memory and we need extra configuration to disable persistence. I had to go through the sources to understand that only certain key in configMap is expected. So I suggest updating the documentation and examples with this.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Documentation updated
