### PR TITLE
fix:resize cluster's pvc with wrong label

### DIFF
--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -151,7 +151,6 @@ func patchStatefulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 								map[string]string{
 									"app":                         storedStateful.Name,
 									"app.kubernetes.io/component": "redis",
-									"app.kubernetes.io/name":      storedStateful.Name,
 								},
 							),
 						}


### PR DESCRIPTION
Resize pvc for RedisCluster

**Description**

<!-- Please provide a summary of the change here. -->
1. pvc for RedisCluster have labels：
```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: xxxx
  labels:
    app: test-redis-c-leader
    app.kubernetes.io/component: redis
    app.kubernetes.io/name: test-redis-c
    redis_setup_type: cluster
    role: leader
```
Here `app` is sts's Name,app. `kubernetes.io/name` is CR's name,so we match label just `app` and `redis`
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->
Bug fix
* Bug fix 

**Checklist**

- [x] Testing has been performed
- [x] No functionality is broken
- [x] Documentation updated
