### PR TITLE
bugfix: when delete RedisCluster CR, finalizer doesn`t delete node-conf pvc because wrong pvcName

### DIFF
--- a/k8sutils/finalizer.go
+++ b/k8sutils/finalizer.go
@@ -151,7 +151,7 @@ func finalizeRedisClusterPVC(cr *redisv1beta1.RedisCluster) error {
 	logger := finalizerLogger(cr.Namespace, RedisClusterFinalizer)
 	for _, role := range []string{"leader", "follower"} {
 		for i := 0; i < int(cr.Spec.GetReplicaCounts(role)); i++ {
-			PVCName := cr.Name + "-" + cr.Name + "-" + role + "-" + strconv.Itoa(i)
+			PVCName := cr.Name + "-" + role + "-" + cr.Name + "-" + role + "-" + strconv.Itoa(i)
 			err := generateK8sClient().CoreV1().PersistentVolumeClaims(cr.Namespace).Delete(context.TODO(), PVCName, metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Could not delete Persistent Volume Claim "+PVCName)

--- a/k8sutils/finalizer.go
+++ b/k8sutils/finalizer.go
@@ -159,7 +159,7 @@ func finalizeRedisClusterPVC(cr *redisv1beta1.RedisCluster) error {
 			}
 		}
 		for i := 0; i < int(cr.Spec.GetReplicaCounts(role)); i++ {
-			PVCName := "node-conf" + cr.Name + "-" + role + "-" + strconv.Itoa(i)
+			PVCName := "node-conf" + "-" + cr.Name + "-" + role + "-" + strconv.Itoa(i)
 			err := generateK8sClient().CoreV1().PersistentVolumeClaims(cr.Namespace).Delete(context.TODO(), PVCName, metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Could not delete Persistent Volume Claim "+PVCName)


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

when delete RedisCluster CR, finalizer doesn`t delete node-conf pvc because wrong pvcName

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [x] Testing has been performed
- [x] No functionality is broken
- [x] Documentation updated
