### PR TITLE
Fixes #526 Add RBAC for redisreplications and redissentinels.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,10 @@ rules:
   - redisclusters
   - redis
   - rediscluster
+  - redisreplication
+  - redisreplications
+  - redissentinel
+  - redissentinels
   verbs:
   - create
   - delete


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Add missing resources `redisreplications` and `redissentinels` to the ClusterRole.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #526 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Testing has been performed
- [X] No functionality is broken
- [ ] Documentation updated

verified role update directly in the clusterrole in an openshift 4.11 cluster.