### PR TITLE
[Fix]  nil ptr when sentinel config is emtpy

### DIFF
--- a/api/v1beta1/redissentinel_conversion.go
+++ b/api/v1beta1/redissentinel_conversion.go
@@ -5,7 +5,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-// ConvertTo converts this RedisSentinel to the Hub version (vbeta2).
+// ConvertTo converts this RedisSentinel to the Hub version (v1beta2).
 func (src *RedisSentinel) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*redisv1beta2.RedisSentinel)
 

--- a/example/v1beta2/redis-cluster.yaml
+++ b/example/v1beta2/redis-cluster.yaml
@@ -20,11 +20,6 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-  env:
-  - name: CUSTOM_ENV_VAR_1
-    value: "custom_value_1"
-  - name: CUSTOM_ENV_VAR_2
-    value: "custom_value_2"      
     # redisSecret:
     #   name: redis-secret
     #   key: password

--- a/k8sutils/redis-sentinel.go
+++ b/k8sutils/redis-sentinel.go
@@ -41,7 +41,7 @@ func CreateRedisSentinel(cr *redisv1beta2.RedisSentinel) error {
 		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
 	}
 
-	if cr.Spec.RedisSentinelConfig.AdditionalSentinelConfig != nil {
+	if cr.Spec.RedisSentinelConfig != nil && cr.Spec.RedisSentinelConfig.AdditionalSentinelConfig != nil {
 		prop.ExternalConfig = cr.Spec.RedisSentinelConfig.AdditionalSentinelConfig
 	}
 
@@ -241,6 +241,10 @@ func (service RedisSentinelService) CreateRedisSentinelService(cr *redisv1beta2.
 }
 
 func getSentinelEnvVariable(cr *redisv1beta2.RedisSentinel) *[]corev1.EnvVar {
+
+	if cr.Spec.RedisSentinelConfig == nil {
+		return &[]corev1.EnvVar{}
+	}
 
 	envVar := &[]corev1.EnvVar{
 		{


### PR DESCRIPTION
**Description**

This PR fixes the nil ptr error that panic the operator when the `redisSentinelConfig` field is empty

**Type of change**
* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.
