### PR TITLE
Fix e2e test

### DIFF
--- a/tests/e2e/v1beta2/setup/ready-cluster.yaml
+++ b/tests/e2e/v1beta2/setup/ready-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: redis.redis.opstreelabs.in/v1beta1
+apiVersion: redis.redis.opstreelabs.in/v1beta2
 kind: RedisCluster
 metadata:
   name: redis-cluster-v1beta2

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -13,8 +13,6 @@ Ensure you have the following tools installed:
 
 ## **Steps**
 
-### **1. Set Up a 3-node Kind Cluster**
-
 ## Steps to Follow
 
 ### 1. Set Up a 3-node Kind Cluster
@@ -22,7 +20,7 @@ Ensure you have the following tools installed:
 Create a 3-node kind cluster using the provided configuration:
 
 ```bash
-kind create cluster --config /redis-operator/tests/_config/kind-example-config.yaml
+kind create cluster --config /redis-operator/tests/_config/kind-config.yaml
 ```
 
 ### 2. Install the Redis Operator

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -38,5 +38,5 @@ Please refer to the repository's README for detailed instructions on installing 
 Execute the kuttl test using the following command:
 
 ```bash
-kubectl kuttl test redis-operator/tests/e2e/v1beta2 --config /redis-operator/tests/_config/kuttl-test.yaml --timeout 10m
+kubectl kuttl test redis-operator/tests/e2e/v1beta2 --config /redis-operator/tests/_config/kuttl-test.yaml --timeout 600
 ```


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
```
➜  redis-operator git:(fix-e2e) kubectl kuttl test ./tests/e2e/v1beta2 --config ./tests/_config/kuttl-test.yaml --timeout 10m
Error: invalid argument "10m" for "--timeout" flag: strconv.ParseInt: parsing "10m": invalid syntax
```

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
