### PR TITLE
[Test] : e2e Github Action Workflow 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         testpath:
-        - ./e2e/v1beta2/setup
+        - .tests/e2e/v1beta2/setup
 
     steps:
     - name: Checkout code
@@ -34,15 +34,6 @@ jobs:
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
-
-    # - name: Install kind utility
-    #   run: |
-    #     # For AMD64 / x86_64
-    #     [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
-    #     # For ARM64
-    #     [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-arm64
-    #     chmod +x ./kind
-    #     sudo mv ./kind /usr/local/bin/kind
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install Redis Operator
       run: |
-        make deploy
+        make deploy VERSION=e2e
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,5 +50,10 @@ jobs:
       run: |
         make deploy IMG=redis-operator:e2e
 
+    - name: Logs
+      run: |
+        kubectl get pod -n redis-operator-system
+        k logs -n redis-operator-system redis-operator-redis-operator-5c5c576c69-vlpxd -c manager
+
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,9 +46,9 @@ jobs:
         kubectl cluster-info --context kind-kind
         kind load docker-image redis-operator:e2e --name kind
 
-    # - name: Install Redis Operator
-    #   run: |
-    #     make deploy
+    - name: Install Redis Operator
+      run: |
+        make deploy
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,12 +46,6 @@ jobs:
         kubectl cluster-info --context kind-kind
         kind load docker-image redis-operator:e2e --name kind
 
-    - name: Check images
-      run: |
-        docker exec kind-control-plane docker images
-        docker exec kind-worker docker images
-        docker exec kind-worker2 docker images
-
     - name: Install Redis Operator
       run: |
         make deploy
@@ -60,7 +54,12 @@ jobs:
       run: |
         kubectl get namespace
         kubectl get pod -n redis-operator-system
-        kubectl logs -n redis-operator-system redis-operator-redis-operator-5c5c576c69-vlpxd -c manager
+        kubectl get deployments.apps -n redis-operator-system redis-operator-redis-operator -oyaml 
+
+    - name: Wait for Redis Operator to be ready
+      run: |
+        kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
+
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         testpath:
-        - .tests/e2e/v1beta2/setup
+        - ./tests/e2e/v1beta2/setup
 
     steps:
     - name: Checkout code

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,24 +35,25 @@ jobs:
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
 
-    - name: Install kind utility
-      run: |
-        # For AMD64 / x86_64
-        [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
-        # For ARM64
-        [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-arm64
-        chmod +x ./kind
-        sudo mv ./kind /usr/local/bin/kind
+    # - name: Install kind utility
+    #   run: |
+    #     # For AMD64 / x86_64
+    #     [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
+    #     # For ARM64
+    #     [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-arm64
+    #     chmod +x ./kind
+    #     sudo mv ./kind /usr/local/bin/kind
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0
       with:
         config: tests/_config/kind-config.yaml
+        cluster_name: kind
 
     - name: Load Docker image into Kind
       run: | 
-        kubectl cluster-info --context kind-chart-testing
-        kind load docker-image redis-operator:e2e
+        kubectl cluster-info --context kind-kind
+        kind load docker-image redis-operator:e2e --name kind
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install Redis Operator
       run: |
-        make deploy VERSION=e2e
+        make deploy IMG=redis-operator:e2e
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,12 @@ jobs:
     - name: Wait for Redis Operator to be ready
       run: |
         kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
-
+  
+    - name: Logs 2
+      run: |
+        kubectl get namespace
+        kubectl get pod -n redis-operator-system
+        kubectl get deployments.apps -n redis-operator-system redis-operator-redis-operator -oyaml 
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,42 @@
+name: E2E tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: e2e - ${{ matrix.testpath }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        testpath:
+        - ./e2e/v1beta2/setup
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Build Dockerfile
+      run: docker build . --file Dockerfile --tag redis-operator:e2e
+
+    - name: Install kuttl
+      run: |
+        curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 -o /usr/local/bin/kuttl
+        chmod +x /usr/local/bin/kuttl
+
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.5.0
+      with:
+        cluster_name: e2e - ${{ matrix.testpath }}
+        config: tests/_config/kind-config.yaml
+
+    - name: Load Docker image into Kind
+      run: kind load docker-image redis-operator:e2e
+
+    - name: Run kuttl test
+      run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,12 @@ jobs:
         kubectl cluster-info --context kind-kind
         kind load docker-image redis-operator:e2e --name kind
 
+    - name: Check images
+      run: |
+        docker exec kind-control-plane docker images
+        docker exec kind-worker docker images
+        docker exec kind-worker2 docker images
+
     - name: Install Redis Operator
       run: |
         make deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,15 @@ jobs:
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
 
+    - name: Install kind utility
+      run: |
+        # For AMD64 / x86_64
+        [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
+        # For ARM64
+        [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-arm64
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0
       with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,9 +46,9 @@ jobs:
         kubectl cluster-info --context kind-kind
         kind load docker-image redis-operator:e2e --name kind
 
-    - name: Install Redis Operator
-      run: |
-        make deploy
+    # - name: Install Redis Operator
+    #   run: |
+    #     make deploy
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,12 +48,13 @@ jobs:
 
     - name: Install Redis Operator
       run: |
-        make deploy IMG=redis-operator:e2e
+        make deploy
 
     - name: Logs
       run: |
+        kubectl get namespace
         kubectl get pod -n redis-operator-system
-        k logs -n redis-operator-system redis-operator-redis-operator-5c5c576c69-vlpxd -c manager
+        kubectl logs -n redis-operator-system redis-operator-redis-operator-5c5c576c69-vlpxd -c manager
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,21 +50,9 @@ jobs:
       run: |
         make deploy
 
-    - name: Logs
-      run: |
-        kubectl get namespace
-        kubectl get pod -n redis-operator-system
-        kubectl get deployments.apps -n redis-operator-system redis-operator-redis-operator -oyaml 
-
     - name: Wait for Redis Operator to be ready
       run: |
         kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
   
-    - name: Logs 2
-      run: |
-        kubectl get namespace
-        kubectl get pod -n redis-operator-system
-        kubectl get deployments.apps -n redis-operator-system redis-operator-redis-operator -oyaml 
-
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,5 +55,9 @@ jobs:
         kubectl cluster-info --context kind-kind
         kind load docker-image redis-operator:e2e --name kind
 
+    - name: Install Redis Operator
+      run: |
+        make deploy
+
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,12 @@ jobs:
       run: |
         curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 -o /usr/local/bin/kuttl
         chmod +x /usr/local/bin/kuttl
+    
+    - name: Install kubectl
+      run: |
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0
@@ -35,7 +41,9 @@ jobs:
         config: tests/_config/kind-config.yaml
 
     - name: Load Docker image into Kind
-      run: kind load docker-image redis-operator:e2e
+      run: | 
+        kubectl cluster-info --context kind-chart-testing
+        kind load docker-image redis-operator:e2e
 
     - name: Run kuttl test
       run: kuttl test ${{ matrix.testpath }} --config tests/_config/kuttl-test.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: e2e - ${{ matrix.testpath }}
+    name: ${{ matrix.testpath }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,7 +32,6 @@ jobs:
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0
       with:
-        cluster_name: e2e - ${{ matrix.testpath }}
         config: tests/_config/kind-config.yaml
 
     - name: Load Docker image into Kind

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ controller-gen:
 # Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize:
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/opstree/redis-operator
-  newTag: v0.15.0
+  newName: redis-operator
+  newTag: e2e

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         args:
         - --leader-elect
         - -zap-log-level=info
-        image: quay.io/opstree/redis-operator:v0.12.0
+        image: redis-operator:e2e
         imagePullPolicy: Always
         name: manager
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
         - --leader-elect
         - -zap-log-level=info
         image: redis-operator:e2e
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,7 @@ spec:
         args:
         - --leader-elect
         - -zap-log-level=info
+        - -enable-webhooks=false
         image: redis-operator:e2e
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,9 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+          - name: ENABLE_WEBHOOKS
+            value: "false"
         args:
         - --leader-elect
         - -zap-log-level=info


### PR DESCRIPTION
This is the correct version of: https://github.com/OT-CONTAINER-KIT/redis-operator/pull/579/files

Description : 

1. Every test dir would be overwritten in this workflow and should be launched a separate action
2. Docker image would be built from ./Dockerfile 
3. Operator would be installed from the present manifest in the dir : config
