### PR TITLE
feat:  verify codgen in Makefile and Github workflow

### DIFF
--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -8,11 +8,11 @@ on:
       - master
 
 env:
-  GolangVersion: 1.21
-  ApplicationName: redis-operator
+  GOLANG_VERSION: 1.21
+  APPLICATION_NAME: redis-operator
   DockerImagName: docker.io/opstree/redis-operator
   BuildDocs: true
-  AppVersion: "v0.15.0"
+  AppVersion: "v0.15.2"
   DOCKERFILE_PATH: '**/Dockerfile'
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GolangVersion }}
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Check Go Fmt
         run: |
           gofmt_files=$(go fmt ./... | wc -l)
@@ -39,9 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GolangVersion }}
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run Go Vet
         run: go vet ./...
 
@@ -51,9 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GolangVersion }}
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run Go Tests with coverage
         run: go test ./... -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
@@ -64,14 +64,14 @@ jobs:
           verbose: true
         
   code_quality_golang_ci_lint:
-    needs: [gofmt, govet]
+    needs: [gofmt, govet, gotest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GolangVersion }}
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run GolangCI-Lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -79,7 +79,7 @@ jobs:
           args: --timeout=5m0s ./...
 
   container_quality_dockerfile_lint:
-    needs: [gofmt, govet]
+    needs: [gofmt, govet, gotest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Setup Go Environment
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Set GOARCH

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -7,9 +7,9 @@ on:
       - master
 
 env:
-  ApplicationName: redis-operator
+  APPLICATION_NAME: redis-operator
   QuayImageName: quay.io/opstree/redis-operator
-  AppVersion: "v0.15.1"
+  APP_VERSION: "v0.15.1"
   DOCKERFILE_PATH: '**/Dockerfile'
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         file: ${{ env.DOCKERFILE_PATH }}
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ${{ env.QuayImageName }}:{{ env.AppVersion }}, ${{ env.QuayImageName }}:latest
+        tags: ${{ env.QuayImageName }}:{{ env.APP_VERSION }}, ${{ env.QuayImageName }}:latest
 
   trivy_scan:
     needs: [build_multi_arch]
@@ -56,7 +56,7 @@ jobs:
     - name: Run Trivy vulnerability scanner for multi-arch image
       uses: aquasecurity/trivy-action@master
       with:
-        image-ref: ${{ env.QuayImageName }}:${{ env.AppVersion }}
+        image-ref: ${{ env.QuayImageName }}:${{ env.APP_VERSION }}
         format: 'template'
         template: '@/contrib/sarif.tpl'
         output: 'trivy-results-latest.sarif'

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -1,0 +1,37 @@
+name: Verify Codegen
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  verify-codegen:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.0
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: false
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+        cache-dependency-path: go.sum
+      
+    - name: Run codegen and verify no diffs
+      run: |
+        make verify-codegen

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ codegen: generate manifests ## Rebuild all generated code
 
 # Verify that codegen is up to date.
 .PHONY: verify-codegen
-verify-codegen:
+verify-codegen: codegen
 	@echo Checking codegen is up to date... >&2
 	@git --no-pager diff -- .
 	@echo 'If this test fails, it is because the git diff is non-empty after running "make codegen".' >&2

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,16 @@ bundle: manifests kustomize
 .PHONY: bundle-build
 bundle-build:
 	docker buildx build --platform="linux/arm64,linux/amd64" -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+# Generate bundle manifests and metadata, then validate generated files.
+.PHONY: codegen
+codegen: generate manifests ## Rebuild all generated code
+
+# Verify that codegen is up to date.
+.PHONY: verify-codegen
+verify-codegen:
+	@echo Checking codegen is up to date... >&2
+	@git --no-pager diff -- .
+	@echo 'If this test fails, it is because the git diff is non-empty after running "make codegen".' >&2
+	@echo 'To correct this, locally run "make codegen", commit the changes, and re-run tests.' >&2
+	@git diff --quiet --exit-code -- .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.15.0
+VERSION ?= 0.15.1
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'


### PR DESCRIPTION
verify that the proper code generation is happening or not. 
Fixing the Improper variable name in the workflow.

Now we could use 

`make codegen` - To generate crd + deepcopy 
`make verify-codegen` - To verify if we have any any missing crd ( any other manifests ) or deepcopy 