### PR TITLE
feat: add environment to customize data pvc prefix

### DIFF
--- a/.github/workflows/e2e-chainsaw.yml
+++ b/.github/workflows/e2e-chainsaw.yml
@@ -21,6 +21,7 @@ jobs:
           - ./tests/e2e-chainsaw/v1beta2/password/
           - ./tests/e2e-chainsaw/v1beta2/ha-setup/
           - ./tests/e2e-chainsaw/v1beta2/nodeport/
+          - ./tests/e2e-chainsaw/v1beta2/pvc-name/
 
     steps:
     - name: Checkout code

--- a/k8sutils/const.go
+++ b/k8sutils/const.go
@@ -3,3 +3,7 @@ package k8sutils
 const (
 	AnnotationKeyRecreateStatefulset = "redis.opstreelabs.in/recreate-statefulset"
 )
+
+const (
+	EnvOperatorSTSPVCTemplateName = "OPERATOR_STS_PVC_TEMPLATE_NAME"
+)

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -3,6 +3,7 @@ package k8sutils
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/env"
 	"path"
 	"sort"
 	"strconv"
@@ -269,7 +270,8 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, createPVCTemplate("node-conf", stsMeta, params.NodeConfPersistentVolumeClaim))
 	}
 	if containerParams.PersistenceEnabled != nil && *containerParams.PersistenceEnabled {
-		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, createPVCTemplate(stsMeta.GetName(), stsMeta, params.PersistentVolumeClaim))
+		pvcTplName := env.GetString(EnvOperatorSTSPVCTemplateName, stsMeta.GetName())
+		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, createPVCTemplate(pvcTplName, stsMeta, params.PersistentVolumeClaim))
 	}
 	if params.ExternalConfig != nil {
 		statefulset.Spec.Template.Spec.Volumes = getExternalConfig(*params.ExternalConfig)
@@ -328,7 +330,7 @@ func createPVCTemplate(volumeName string, stsMeta metav1.ObjectMeta, storageSpec
 	pvcTemplate.CreationTimestamp = metav1.Time{}
 	pvcTemplate.Name = volumeName
 	pvcTemplate.Labels = stsMeta.GetLabels()
-	// We want the same annoations as the StatefulSet here
+	// We want the same annotation as the StatefulSet here
 	pvcTemplate.Annotations = generateStatefulSetsAnots(stsMeta, nil)
 	if storageSpec.Spec.AccessModes == nil {
 		pvcTemplate.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
@@ -542,7 +544,7 @@ func getVolumeMount(name string, persistenceEnabled *bool, clusterMode bool, nod
 
 	if persistenceEnabled != nil && *persistenceEnabled {
 		VolumeMounts = append(VolumeMounts, corev1.VolumeMount{
-			Name:      name,
+			Name:      env.GetString(EnvOperatorSTSPVCTemplateName, name),
 			MountPath: "/data",
 		})
 	}

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -9,5 +9,5 @@ spec:
   timeouts:
     apply: 5m
     delete: 5m
-    assert: 15m
-    error: 15m
+    assert: 10m
+    error: 10m

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -10,19 +10,8 @@ spec:
         - script:
             content: |
               kubectl patch deployment redis-operator-redis-operator --namespace redis-operator-system --type json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "OPERATOR_STS_PVC_TEMPLATE_NAME", "value": "data"}}]'
-              # show the deployment
-              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml
-              # show the operator logs
-              kubectl logs -l control-plane=redis-operator -n redis-operator-system
-              kubectl get po -n redis-operator-system -l control-plane=redis-operator
-              kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
-              kubectl get po -n redis-operator-system -l control-plane=redis-operator
         - sleep:
             duration: 1m
-        - script:
-            content: |
-              kubectl logs -l control-plane=redis-operator -n redis-operator-system
-              kubectl get po -n redis-operator-system -l control-plane=redis-operator
 
     - name: redis-cluster-install
       try:
@@ -36,23 +25,6 @@ spec:
             file: ready-svc.yaml
         - assert:
             file: ready-pvc.yaml
-      catch:
-        - script:
-            content: |
-              # show the deployment
-              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml
-              kubectl get po -n redis-operator-system -l control-plane=redis-operator
-              # show the operator logs
-              kubectl logs -l control-plane=redis-operator -n redis-operator-system
-              # describe the redis pods, which namespace like chainsaw-<random-string>, use grep to get the namespace
-              kubectl describe pod -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
-              kubectl get pods -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
-              # get sts
-              kubectl describe sts redis-cluster-v1beta2-leader -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
-              kubectl describe sts redis-cluster-v1beta2-follower -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
-              kubectl get pvc -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
-              # show redis log
-              kubectl logs -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
 
     - name: redis-cluster-uninstall
       try:

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -37,6 +37,11 @@ spec:
               kubectl logs -l control-plane=redis-operator -n redis-operator-system
               # describe the redis pods, which namespace like chainsaw-<random-string>, use grep to get the namespace
               kubectl describe pod -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+              kubectl get pods -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+              # get sts
+              kubectl describe sts redis-cluster-v1beta2-leader -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+              kubectl describe sts redis-cluster-v1beta2-follower -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+              kubectl get pvc -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
               # show redis log
               kubectl logs -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
 

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pvc-name
+spec:
+  steps:
+    - name: Add PVC name environment
+      try:
+        - script:
+            content: |
+              kubectl patch deployment redis-operator-redis-operator --namespace redis-operator-system --type json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "OPERATOR_STS_PVC_TEMPLATE_NAME", "value": "data"}}]'
+              # show the deployment
+              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml
+              # show the operator logs
+              kubectl logs -l control-plane=redis-operator -n redis-operator-system
+              kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
+
+    - name: redis-cluster-install
+      try:
+        - apply:
+            file: cluster.yaml
+        - assert:
+            file: ready-cluster.yaml
+        - assert:
+            file: ready-sts.yaml
+        - assert:
+            file: ready-svc.yaml
+        - assert:
+            file: ready-pvc.yaml
+      catch:
+        - script:
+            content: |
+              # show the deployment
+              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml              
+              # show the operator logs
+              kubectl logs -l control-plane=redis-operator -n redis-operator-system
+              # describe the redis pods, which namespace like chainsaw-<random-string>, use grep to get the namespace
+              kubectl describe pod -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+              # show redis log
+              kubectl logs -l redis_setup_type=cluster -n $(kubectl get ns | grep chainsaw | awk '{print $1}' | head -n 1)
+
+    - name: redis-cluster-uninstall
+      try:
+        - delete:
+            ref:
+              name: redis-cluster-v1beta2
+              kind: RedisCluster
+              apiVersion: redis.redis.opstreelabs.in/v1beta2
+        - error:
+            file: ready-cluster.yaml
+        - error:
+            file: ready-sts.yaml
+        - error:
+            file: ready-svc.yaml
+        - error:
+            file: ready-pvc.yaml
+
+    - name: Remove PVC name environment
+      try:
+        - script:
+            content: |
+              kubectl patch deployment redis-operator-redis-operator --namespace redis-operator-system --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/env/1"}]'
+              kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -20,6 +20,11 @@ spec:
               # wait new pod ready, old pod be deleted
               sleep 30
               kubectl logs -l control-plane=redis-operator -n redis-operator-system
+        - sleep:
+            duration: 1m
+        - script:
+            content: |
+              kubectl logs -l control-plane=redis-operator -n redis-operator-system
 
     - name: redis-cluster-install
       try:

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -17,14 +17,12 @@ spec:
               kubectl get po -n redis-operator-system -l control-plane=redis-operator
               kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
               kubectl get po -n redis-operator-system -l control-plane=redis-operator
-              # wait new pod ready, old pod be deleted
-              sleep 30
-              kubectl logs -l control-plane=redis-operator -n redis-operator-system
         - sleep:
             duration: 1m
         - script:
             content: |
               kubectl logs -l control-plane=redis-operator -n redis-operator-system
+              kubectl get po -n redis-operator-system -l control-plane=redis-operator
 
     - name: redis-cluster-install
       try:

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/chainsaw-test.yaml
@@ -14,7 +14,12 @@ spec:
               kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml
               # show the operator logs
               kubectl logs -l control-plane=redis-operator -n redis-operator-system
+              kubectl get po -n redis-operator-system -l control-plane=redis-operator
               kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
+              kubectl get po -n redis-operator-system -l control-plane=redis-operator
+              # wait new pod ready, old pod be deleted
+              sleep 30
+              kubectl logs -l control-plane=redis-operator -n redis-operator-system
 
     - name: redis-cluster-install
       try:
@@ -32,7 +37,8 @@ spec:
         - script:
             content: |
               # show the deployment
-              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml              
+              kubectl get deployment redis-operator-redis-operator -n redis-operator-system -o yaml
+              kubectl get po -n redis-operator-system -l control-plane=redis-operator
               # show the operator logs
               kubectl logs -l control-plane=redis-operator -n redis-operator-system
               # describe the redis pods, which namespace like chainsaw-<random-string>, use grep to get the namespace

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/cluster.yaml
@@ -1,0 +1,47 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  redisExporter:
+    enabled: true
+    image: quay.io/opstree/redis-exporter:v1.44.0
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  readyFollowerReplicas: 3
+  readyLeaderReplicas: 3

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-pvc.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-pvc.yaml
@@ -1,0 +1,181 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-leader-0
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-leader-1
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-leader-2
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-follower-0
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-follower-1
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-conf-redis-cluster-v1beta2-follower-2
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-leader-0
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-leader-1
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-leader-2
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-follower-0
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-follower-1
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-redis-cluster-v1beta2-follower-2
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-sts.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-sts.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-cluster-v1beta2-leader
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+status:
+  replicas: 3
+  readyReplicas: 3
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-cluster-v1beta2-follower
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+status:
+  replicas: 3
+  readyReplicas: 3

--- a/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-svc.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-name/redis-cluster/ready-svc.yaml
@@ -1,0 +1,201 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  name: redis-cluster-v1beta2-leader-additional
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  name: redis-cluster-v1beta2-leader
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+    - name: redis-exporter
+      port: 9121
+      protocol: TCP
+      targetPort: 9121
+  selector:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  name: redis-cluster-v1beta2-leader-headless
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  clusterIP: None
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: redis-cluster-v1beta2-leader
+    redis_setup_type: cluster
+    role: leader
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  name: redis-cluster-v1beta2-follower
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+    - name: redis-exporter
+      port: 9121
+      protocol: TCP
+      targetPort: 9121
+  selector:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  name: redis-cluster-v1beta2-follower-additional
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    redis.opstreelabs.in: "true"
+    redis.opstreelabs.instance: redis-cluster-v1beta2
+  labels:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  name: redis-cluster-v1beta2-follower-headless
+  ownerReferences:
+    - apiVersion: redis.redis.opstreelabs.in/v1beta2
+      controller: true
+      kind: RedisCluster
+      name: redis-cluster-v1beta2
+spec:
+  clusterIP: None
+  ports:
+    - name: redis-client
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: redis-cluster-v1beta2-follower
+    redis_setup_type: cluster
+    role: follower
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
1. user can customize redis pvc prefix by operator environment

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #438 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
