### PR TITLE
docs: update standalone pod name

### DIFF
--- a/docs/content/en/docs/Getting Started/Standalone/_index.md
+++ b/docs/content/en/docs/Getting Started/Standalone/_index.md
@@ -39,7 +39,7 @@ Verify the standalone redis setup by kubectl command line.
 $ kubectl get pods -n ot-operators
 ...
 NAME                              READY   STATUS    RESTARTS   AGE
-redis-standalone-0                2/2     Running   0          56s
+redis-0                           1/1     Running   0          56s
 ```
 
 ## YAML Installation


### PR DESCRIPTION
**Description**

Update the name and number of pods created by default for redis standalone. When I followed the doc, it worked well but the name of the redis standalone was different.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.