### PR TITLE
feat: generate k8s client only once

### DIFF
--- a/controllers/redis_controller.go
+++ b/controllers/redis_controller.go
@@ -65,11 +65,11 @@ func (r *RedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	err = k8sutils.CreateStandaloneRedis(instance)
+	err = k8sutils.CreateStandaloneRedis(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	err = k8sutils.CreateStandaloneService(instance)
+	err = k8sutils.CreateStandaloneService(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -117,22 +117,22 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if leaderReplicas != 0 {
-		err = k8sutils.CreateRedisLeaderService(instance)
+		err = k8sutils.CreateRedisLeaderService(instance, r.K8sClient)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 	}
-	err = k8sutils.CreateRedisLeader(instance)
+	err = k8sutils.CreateRedisLeader(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	err = k8sutils.ReconcileRedisPodDisruptionBudget(instance, "leader", instance.Spec.RedisLeader.PodDisruptionBudget)
+	err = k8sutils.ReconcileRedisPodDisruptionBudget(instance, "leader", instance.Spec.RedisLeader.PodDisruptionBudget, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	redisLeaderInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name+"-leader")
+	redisLeaderInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name+"-leader", r.K8sClient)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil
@@ -151,21 +151,21 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		// if we have followers create their service.
 		if followerReplicas != 0 {
-			err = k8sutils.CreateRedisFollowerService(instance)
+			err = k8sutils.CreateRedisFollowerService(instance, r.K8sClient)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 		}
-		err = k8sutils.CreateRedisFollower(instance)
+		err = k8sutils.CreateRedisFollower(instance, r.K8sClient)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		err = k8sutils.ReconcileRedisPodDisruptionBudget(instance, "follower", instance.Spec.RedisFollower.PodDisruptionBudget)
+		err = k8sutils.ReconcileRedisPodDisruptionBudget(instance, "follower", instance.Spec.RedisFollower.PodDisruptionBudget, r.K8sClient)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 	}
-	redisFollowerInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name+"-follower")
+	redisFollowerInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name+"-follower", r.K8sClient)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Second * 60}, nil

--- a/controllers/redisreplication_controller.go
+++ b/controllers/redisreplication_controller.go
@@ -56,18 +56,18 @@ func (r *RedisReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	err = k8sutils.CreateReplicationRedis(instance)
+	err = k8sutils.CreateReplicationRedis(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	err = k8sutils.CreateReplicationService(instance)
+	err = k8sutils.CreateReplicationService(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Set Pod distruptiuon Budget Later
 
-	redisReplicationInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name)
+	redisReplicationInfo, err := k8sutils.GetStatefulSet(instance.Namespace, instance.ObjectMeta.Name, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: time.Second * 60}, err
 	}

--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -55,18 +55,18 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Create Redis Sentinel
-	err = k8sutils.CreateRedisSentinel(ctx, r.K8sClient, r.Log, instance)
+	err = k8sutils.CreateRedisSentinel(ctx, r.K8sClient, r.Log, instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	err = k8sutils.ReconcileSentinelPodDisruptionBudget(instance, instance.Spec.PodDisruptionBudget)
+	err = k8sutils.ReconcileSentinelPodDisruptionBudget(instance, instance.Spec.PodDisruptionBudget, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Create the Service for Redis Sentinel
-	err = k8sutils.CreateRedisSentinelService(instance)
+	err = k8sutils.CreateRedisSentinelService(instance, r.K8sClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/k8sutils/poddisruption.go
+++ b/k8sutils/poddisruption.go
@@ -12,10 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 )
 
 // CreateRedisLeaderPodDisruptionBudget check and create a PodDisruptionBudget for Leaders
-func ReconcileRedisPodDisruptionBudget(cr *redisv1beta2.RedisCluster, role string, pdbParams *commonapi.RedisPodDisruptionBudget) error {
+func ReconcileRedisPodDisruptionBudget(cr *redisv1beta2.RedisCluster, role string, pdbParams *commonapi.RedisPodDisruptionBudget, cl kubernetes.Interface) error {
 	pdbName := cr.ObjectMeta.Name + "-" + role
 	logger := pdbLogger(cr.Namespace, pdbName)
 	if pdbParams != nil && pdbParams.Enabled {
@@ -23,12 +24,12 @@ func ReconcileRedisPodDisruptionBudget(cr *redisv1beta2.RedisCluster, role strin
 		annotations := generateStatefulSetsAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.IgnoreAnnotations)
 		pdbMeta := generateObjectMetaInformation(pdbName, cr.Namespace, labels, annotations)
 		pdbDef := generatePodDisruptionBudgetDef(cr, role, pdbMeta, cr.Spec.RedisLeader.PodDisruptionBudget)
-		return CreateOrUpdatePodDisruptionBudget(pdbDef)
+		return CreateOrUpdatePodDisruptionBudget(pdbDef, cl)
 	} else {
 		// Check if one exists, and delete it.
-		_, err := GetPodDisruptionBudget(cr.Namespace, pdbName)
+		_, err := GetPodDisruptionBudget(cr.Namespace, pdbName, cl)
 		if err == nil {
-			return deletePodDisruptionBudget(cr.Namespace, pdbName)
+			return deletePodDisruptionBudget(cr.Namespace, pdbName, cl)
 		} else if err != nil && errors.IsNotFound(err) {
 			logger.V(1).Info("Reconciliation Successful, no PodDisruptionBudget Found.")
 			// Its ok if its not found, as we're deleting anyway
@@ -38,7 +39,7 @@ func ReconcileRedisPodDisruptionBudget(cr *redisv1beta2.RedisCluster, role strin
 	}
 }
 
-func ReconcileSentinelPodDisruptionBudget(cr *redisv1beta2.RedisSentinel, pdbParams *commonapi.RedisPodDisruptionBudget) error {
+func ReconcileSentinelPodDisruptionBudget(cr *redisv1beta2.RedisSentinel, pdbParams *commonapi.RedisPodDisruptionBudget, cl kubernetes.Interface) error {
 	pdbName := cr.ObjectMeta.Name + "-sentinel"
 	logger := pdbLogger(cr.Namespace, pdbName)
 	if pdbParams != nil && pdbParams.Enabled {
@@ -46,12 +47,12 @@ func ReconcileSentinelPodDisruptionBudget(cr *redisv1beta2.RedisSentinel, pdbPar
 		annotations := generateStatefulSetsAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.IgnoreAnnotations)
 		pdbMeta := generateObjectMetaInformation(pdbName, cr.Namespace, labels, annotations)
 		pdbDef := generateSentinelPodDisruptionBudgetDef(cr, "sentinel", pdbMeta, pdbParams)
-		return CreateOrUpdatePodDisruptionBudget(pdbDef)
+		return CreateOrUpdatePodDisruptionBudget(pdbDef, cl)
 	} else {
 		// Check if one exists, and delete it.
-		_, err := GetPodDisruptionBudget(cr.Namespace, pdbName)
+		_, err := GetPodDisruptionBudget(cr.Namespace, pdbName, cl)
 		if err == nil {
-			return deletePodDisruptionBudget(cr.Namespace, pdbName)
+			return deletePodDisruptionBudget(cr.Namespace, pdbName, cl)
 		} else if err != nil && errors.IsNotFound(err) {
 			logger.V(1).Info("Reconciliation Successful, no PodDisruptionBudget Found.")
 			// Its ok if its not found, as we're deleting anyway
@@ -116,24 +117,24 @@ func generateSentinelPodDisruptionBudgetDef(cr *redisv1beta2.RedisSentinel, role
 }
 
 // CreateOrUpdateService method will create or update Redis service
-func CreateOrUpdatePodDisruptionBudget(pdbDef *policyv1.PodDisruptionBudget) error {
+func CreateOrUpdatePodDisruptionBudget(pdbDef *policyv1.PodDisruptionBudget, cl kubernetes.Interface) error {
 	logger := pdbLogger(pdbDef.Namespace, pdbDef.Name)
-	storedPDB, err := GetPodDisruptionBudget(pdbDef.Namespace, pdbDef.Name)
+	storedPDB, err := GetPodDisruptionBudget(pdbDef.Namespace, pdbDef.Name, cl)
 	if err != nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(pdbDef); err != nil { //nolint
 			logger.Error(err, "Unable to patch redis PodDisruptionBudget with comparison object")
 			return err
 		}
 		if errors.IsNotFound(err) {
-			return createPodDisruptionBudget(pdbDef.Namespace, pdbDef)
+			return createPodDisruptionBudget(pdbDef.Namespace, pdbDef, cl)
 		}
 		return err
 	}
-	return patchPodDisruptionBudget(storedPDB, pdbDef, pdbDef.Namespace)
+	return patchPodDisruptionBudget(storedPDB, pdbDef, pdbDef.Namespace, cl)
 }
 
 // patchPodDisruptionBudget will patch Redis Kubernetes PodDisruptionBudgets
-func patchPodDisruptionBudget(storedPdb *policyv1.PodDisruptionBudget, newPdb *policyv1.PodDisruptionBudget, namespace string) error {
+func patchPodDisruptionBudget(storedPdb *policyv1.PodDisruptionBudget, newPdb *policyv1.PodDisruptionBudget, namespace string, cl kubernetes.Interface) error {
 	logger := pdbLogger(namespace, storedPdb.Name)
 	// We want to try and keep this atomic as possible.
 	newPdb.ResourceVersion = storedPdb.ResourceVersion
@@ -169,20 +170,15 @@ func patchPodDisruptionBudget(storedPdb *policyv1.PodDisruptionBudget, newPdb *p
 			logger.Error(err, "Unable to patch redis PodDisruptionBudget with comparison object")
 			return err
 		}
-		return updatePodDisruptionBudget(namespace, newPdb)
+		return updatePodDisruptionBudget(namespace, newPdb, cl)
 	}
 	return nil
 }
 
 // createPodDisruptionBudget is a method to create PodDisruptionBudgets in Kubernetes
-func createPodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudget) error {
+func createPodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudget, cl kubernetes.Interface) error {
 	logger := pdbLogger(namespace, pdb.Name)
-	client, err := GenerateK8sClient(GenerateK8sConfig)
-	if err != nil {
-		logger.Error(err, "Could not generate kubernetes client")
-		return err
-	}
-	_, err = client.PolicyV1().PodDisruptionBudgets(namespace).Create(context.TODO(), pdb, metav1.CreateOptions{})
+	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Create(context.TODO(), pdb, metav1.CreateOptions{})
 	if err != nil {
 		logger.Error(err, "Redis PodDisruptionBudget creation failed")
 		return err
@@ -192,14 +188,9 @@ func createPodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudg
 }
 
 // updatePodDisruptionBudget is a method to update PodDisruptionBudgets in Kubernetes
-func updatePodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudget) error {
+func updatePodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudget, cl kubernetes.Interface) error {
 	logger := pdbLogger(namespace, pdb.Name)
-	client, err := GenerateK8sClient(GenerateK8sConfig)
-	if err != nil {
-		logger.Error(err, "Could not generate kubernetes client")
-		return err
-	}
-	_, err = client.PolicyV1().PodDisruptionBudgets(namespace).Update(context.TODO(), pdb, metav1.UpdateOptions{})
+	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Update(context.TODO(), pdb, metav1.UpdateOptions{})
 	if err != nil {
 		logger.Error(err, "Redis PodDisruptionBudget update failed")
 		return err
@@ -209,14 +200,9 @@ func updatePodDisruptionBudget(namespace string, pdb *policyv1.PodDisruptionBudg
 }
 
 // deletePodDisruptionBudget is a method to delete PodDisruptionBudgets in Kubernetes
-func deletePodDisruptionBudget(namespace string, pdbName string) error {
+func deletePodDisruptionBudget(namespace string, pdbName string, cl kubernetes.Interface) error {
 	logger := pdbLogger(namespace, pdbName)
-	client, err := GenerateK8sClient(GenerateK8sConfig)
-	if err != nil {
-		logger.Error(err, "Could not generate kubernetes client")
-		return err
-	}
-	err = client.PolicyV1().PodDisruptionBudgets(namespace).Delete(context.TODO(), pdbName, metav1.DeleteOptions{})
+	err := cl.PolicyV1().PodDisruptionBudgets(namespace).Delete(context.TODO(), pdbName, metav1.DeleteOptions{})
 	if err != nil {
 		logger.Error(err, "Redis PodDisruption deletion failed")
 		return err
@@ -226,17 +212,12 @@ func deletePodDisruptionBudget(namespace string, pdbName string) error {
 }
 
 // GetPodDisruptionBudget is a method to get PodDisruptionBudgets in Kubernetes
-func GetPodDisruptionBudget(namespace string, pdb string) (*policyv1.PodDisruptionBudget, error) {
+func GetPodDisruptionBudget(namespace string, pdb string, cl kubernetes.Interface) (*policyv1.PodDisruptionBudget, error) {
 	logger := pdbLogger(namespace, pdb)
-	client, err := GenerateK8sClient(GenerateK8sConfig)
-	if err != nil {
-		logger.Error(err, "Could not generate kubernetes client")
-		return nil, err
-	}
 	getOpts := metav1.GetOptions{
 		TypeMeta: generateMetaInformation("PodDisruptionBudget", "policy/v1"),
 	}
-	pdbInfo, err := client.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), pdb, getOpts)
+	pdbInfo, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), pdb, getOpts)
 	if err != nil {
 		logger.V(1).Info("Redis PodDisruptionBudget get action failed")
 		return nil, err

--- a/k8sutils/redis-cluster_test.go
+++ b/k8sutils/redis-cluster_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"k8s.io/client-go/kubernetes/fake"
+
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api"
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/stretchr/testify/assert"
@@ -427,10 +429,10 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 		t.Fatalf("Failed to unmarshal file %s: %v", path, err)
 	}
 
-	actualLeaderContainer := generateRedisClusterContainerParams(input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader")
+	actualLeaderContainer := generateRedisClusterContainerParams(input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader", fake.NewSimpleClientset())
 	assert.EqualValues(t, expectedLeaderContainer, actualLeaderContainer, "Expected %+v, got %+v", expectedLeaderContainer, actualLeaderContainer)
 
-	actualFollowerContainer := generateRedisClusterContainerParams(input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower")
+	actualFollowerContainer := generateRedisClusterContainerParams(input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower", fake.NewSimpleClientset())
 	assert.EqualValues(t, expectedFollowerContainer, actualFollowerContainer, "Expected %+v, got %+v", expectedFollowerContainer, actualFollowerContainer)
 }
 

--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -476,8 +476,8 @@ func configureRedisReplicationClient(client kubernetes.Interface, logger logr.Lo
 }
 
 // Get Redis nodes by it's role i.e. master, slave and sentinel
-func GetRedisNodesByRole(ctx context.Context, client kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisReplication, redisRole string) []string {
-	statefulset, err := GetStatefulSet(cr.Namespace, cr.Name)
+func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisReplication, redisRole string) []string {
+	statefulset, err := GetStatefulSet(cr.Namespace, cr.Name, cl)
 	if err != nil {
 		logger.Error(err, "Failed to Get the Statefulset of the", "custom resource", cr.Name, "in namespace", cr.Namespace)
 	}
@@ -488,7 +488,7 @@ func GetRedisNodesByRole(ctx context.Context, client kubernetes.Interface, logge
 	for i := 0; i < int(replicas); i++ {
 
 		podName := statefulset.Name + "-" + strconv.Itoa(i)
-		podRole := checkRedisServerRole(ctx, client, logger, cr, podName)
+		podRole := checkRedisServerRole(ctx, cl, logger, cr, podName)
 		if podRole == redisRole {
 			pods = append(pods, podName)
 		}

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -35,7 +35,7 @@ Please refer to the repository's README for detailed instructions on installing 
 
 Execute the kuttl test using the following command:
 
-To run all default tests ( _config/kuttl-test.yaml is the default config file )
+To run all default tests ( \_config/kuttl-test.yaml is the default config file )
 
 ```bash
 kubectl kuttl test --config tests/_config/kuttl-test.yaml


### PR DESCRIPTION
**Description**

I realised that we create a new k8s client every time we need it. It's quite consuming, we should create it at the start of the controller and use it for his lifetime. We then pass the client down to each functions.

I realised this because we cannot add integration tests with EnvTest if we create a new client every time we need one #748

PS: It looks like the coverage test fail because some code removed was tested so it technically lowers the coverage.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.