### PR TITLE
chore: remove latest version for conversion webhook

### DIFF
--- a/config/crd/patches/webhook_in_redis.yaml
+++ b/config/crd/patches/webhook_in_redis.yaml
@@ -12,4 +12,4 @@ spec:
           namespace: ot-operators
           name: webhook-service
           path: /convert
-      conversionReviewVersions: ["v1beta2", "v1beta1"]
+      conversionReviewVersions: ["v1beta1"]

--- a/config/crd/patches/webhook_in_redisclusters.yaml
+++ b/config/crd/patches/webhook_in_redisclusters.yaml
@@ -12,4 +12,4 @@ spec:
           namespace: ot-operators
           name: webhook-service
           path: /convert
-      conversionReviewVersions: ["v1beta2", "v1beta1"]
+      conversionReviewVersions: ["v1beta1"]

--- a/config/crd/patches/webhook_in_redisreplications.yaml
+++ b/config/crd/patches/webhook_in_redisreplications.yaml
@@ -12,4 +12,4 @@ spec:
           namespace: ot-operators
           name: webhook-service
           path: /convert
-      conversionReviewVersions: ["v1beta2", "v1beta1"]
+      conversionReviewVersions: ["v1beta1"]

--- a/config/crd/patches/webhook_in_redissentinels.yaml
+++ b/config/crd/patches/webhook_in_redissentinels.yaml
@@ -12,4 +12,4 @@ spec:
           namespace: ot-operators
           name: webhook-service
           path: /convert
-      conversionReviewVersions: ["v1beta2", "v1beta1"]
+      conversionReviewVersions: ["v1beta1"]


### PR DESCRIPTION
**Description**

The point of the conversion webhook is too update some v1beta1 fields basically and it does nothing for v1beta2. I removed the conversion webhook for v1beta2 version because there is no need to call the conversion for them.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.