### PR TITLE
Added namespace to tls configuration

### DIFF
--- a/k8sutils/secrets.go
+++ b/k8sutils/secrets.go
@@ -66,7 +66,7 @@ func getRedisTLSConfig(client kubernetes.Interface, logger logr.Logger, cr *redi
 
 		return &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			ServerName:   redisInfo.PodName,
+			ServerName:   redisInfo.PodName + "." + redisInfo.Namespace,
 			RootCAs:      tlsCaCertificates,
 			MinVersion:   tls.VersionTLS12,
 			ClientAuth:   tls.NoClientCert,


### PR DESCRIPTION
**Description**

<!-- Please provide a summary of the change here. -->

Changed podName to podName.namespace in redis-client config so that is it possible to issue *.namespace wildcard TLS certificate with cert-manager

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #447 


**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.
