### PR TITLE
test: remove redundant running spec

### DIFF
--- a/controllers/redis_controller_test.go
+++ b/controllers/redis_controller_test.go
@@ -44,10 +44,11 @@ var _ = Describe("Redis standalone test", func() {
 	})
 
 	Context("When creating a redis standalone CR", func() {
-		It("should create a statefulset", func() {
-			var sts *appsv1.StatefulSet
+		It("should create a statefulset, service", func() {
+			sts := &appsv1.StatefulSet{}
+			svc := &corev1.Service{}
+
 			Eventually(func() error {
-				sts = &appsv1.StatefulSet{}
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisCRName,
 					Namespace: ns,
@@ -62,12 +63,8 @@ var _ = Describe("Redis standalone test", func() {
 
 			Expect(*sts.Spec.Replicas).To(BeEquivalentTo(1))
 			Expect(sts.Spec.ServiceName).To(Equal(redisCRName + "-headless"))
-		})
 
-		It("should create a service", func() {
-			var svc *corev1.Service
 			Eventually(func() error {
-				svc = &corev1.Service{}
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisCR.Name,
 					Namespace: ns,
@@ -79,12 +76,8 @@ var _ = Describe("Redis standalone test", func() {
 				"redis_setup_type": "standalone",
 				"role":             "standalone",
 			}))
-		})
 
-		It("should create a headless service", func() {
-			var svc *corev1.Service
 			Eventually(func() error {
-				svc = &corev1.Service{}
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisCR.Name + "-headless",
 					Namespace: ns,
@@ -96,12 +89,7 @@ var _ = Describe("Redis standalone test", func() {
 				"redis_setup_type": "standalone",
 				"role":             "standalone",
 			}))
-		})
-
-		It("should create additional service", func() {
-			var svc *corev1.Service
 			Eventually(func() error {
-				svc = &corev1.Service{}
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisCR.Name + "-additional",
 					Namespace: ns,

--- a/controllers/rediscluster_controller_test.go
+++ b/controllers/rediscluster_controller_test.go
@@ -50,8 +50,10 @@ var _ = Describe("Redis cluster test", func() {
 	})
 
 	Context("When creating a redis cluster CR", func() {
-		It("should create a statefulset", func() {
+		It("should create a statefulset, service", func() {
 			sts := &appsv1.StatefulSet{}
+			svc := &corev1.Service{}
+
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisClusterCRName + "-leader",
@@ -67,10 +69,7 @@ var _ = Describe("Redis cluster test", func() {
 
 			Expect(*sts.Spec.Replicas).To(BeEquivalentTo(3))
 			Expect(sts.Spec.ServiceName).To(Equal(redisClusterCRName + "-leader-headless"))
-		})
 
-		It("should create a service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisClusterCRName + "-leader",
@@ -83,10 +82,7 @@ var _ = Describe("Redis cluster test", func() {
 				"redis_setup_type": "cluster",
 				"role":             "leader",
 			}))
-		})
 
-		It("should create a headless service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisClusterCRName + "-leader-headless",
@@ -99,10 +95,6 @@ var _ = Describe("Redis cluster test", func() {
 				"redis_setup_type": "cluster",
 				"role":             "leader",
 			}))
-		})
-
-		It("should create additional service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisClusterCRName + "-leader-additional",

--- a/controllers/redisreplication_controller_test.go
+++ b/controllers/redisreplication_controller_test.go
@@ -48,9 +48,11 @@ var _ = Describe("Redis replication test", func() {
 	})
 
 	Context("When creating a redis replication CR", func() {
-		It("should create a statefulset", func() {
+		It("should create a statefulset, service", func() {
 
+			svc := &corev1.Service{}
 			sts := &appsv1.StatefulSet{}
+
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisReplicationCRName,
@@ -60,10 +62,7 @@ var _ = Describe("Redis replication test", func() {
 
 			Expect(*sts.Spec.Replicas).To(BeEquivalentTo(3))
 			Expect(sts.Spec.ServiceName).To(Equal(redisReplicationCRName + "-headless"))
-		})
 
-		It("should create a service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisReplicationCRName,
@@ -76,10 +75,7 @@ var _ = Describe("Redis replication test", func() {
 				"redis_setup_type": "replication",
 				"role":             "replication",
 			}))
-		})
 
-		It("should create a headless service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisReplicationCRName + "-headless",
@@ -92,10 +88,7 @@ var _ = Describe("Redis replication test", func() {
 				"redis_setup_type": "replication",
 				"role":             "replication",
 			}))
-		})
 
-		It("should create additional service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisReplicationCRName + "-additional",
@@ -108,6 +101,7 @@ var _ = Describe("Redis replication test", func() {
 				"redis_setup_type": "replication",
 				"role":             "replication",
 			}))
+
 		})
 
 		Context("then deleting the redis replication CR", func() {

--- a/controllers/redissentinel_controller_test.go
+++ b/controllers/redissentinel_controller_test.go
@@ -47,8 +47,10 @@ var _ = Describe("Redis sentinel test", func() {
 	})
 
 	Context("When creating a redis sentinel CR", func() {
-		It("should create a statefulset", func() {
+		It("should create a statefulset, service", func() {
 			sts := &appsv1.StatefulSet{}
+			svc := &corev1.Service{}
+
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisSentinelCRName + "-sentinel",
@@ -58,10 +60,7 @@ var _ = Describe("Redis sentinel test", func() {
 
 			Expect(*sts.Spec.Replicas).To(BeEquivalentTo(3))
 			Expect(sts.Spec.ServiceName).To(Equal(redisSentinelCRName + "-sentinel-headless"))
-		})
 
-		It("should create a service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisSentinelCRName + "-sentinel",
@@ -74,10 +73,7 @@ var _ = Describe("Redis sentinel test", func() {
 				"redis_setup_type": "sentinel",
 				"role":             "sentinel",
 			}))
-		})
 
-		It("should create a headless service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisSentinelCRName + "-sentinel-headless",
@@ -90,10 +86,7 @@ var _ = Describe("Redis sentinel test", func() {
 				"redis_setup_type": "sentinel",
 				"role":             "sentinel",
 			}))
-		})
 
-		It("should create additional service", func() {
-			svc := &corev1.Service{}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{
 					Name:      redisSentinelCRName + "-sentinel-additional",


### PR DESCRIPTION
<img width="1825" alt="截屏2024-02-08 18 30 28" src="https://github.com/OT-CONTAINER-KIT/redis-operator/assets/32033618/d9608e85-6345-497d-b66b-7f54c89dddd0">

after remove:

<img width="1432" alt="截屏2024-02-08 18 29 16" src="https://github.com/OT-CONTAINER-KIT/redis-operator/assets/32033618/8549685d-29fc-4ab3-95b3-d83a84584621">

the duration has been reduced from 10 seconds to 6 seconds.