### PR TITLE
Add master selector

### DIFF
--- a/controllers/redisreplication_controller.go
+++ b/controllers/redisreplication_controller.go
@@ -88,7 +88,11 @@ func (r *RedisReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			return ctrl.Result{RequeueAfter: time.Second * 60}, err
 		}
-
+		// Set label of redis replication role master or slave
+		err = k8sutils.UpdateRoleLabelPod(ctx, r.K8sClient, r.Log, instance)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: time.Second * 60}, err
+		}
 	}
 
 	reqLogger.Info("Will reconcile redis operator in again 10 seconds")

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -1,8 +1,11 @@
 package k8sutils
 
 import (
+	"context"
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 )
@@ -27,6 +30,7 @@ func CreateReplicationService(cr *redisv1beta2.RedisReplication, cl kubernetes.I
 	}
 	objectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name, cr.Namespace, labels, annotations)
 	headlessObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-headless", cr.Namespace, labels, annotations)
+	masterObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-master", cr.Namespace, labels, annotations)
 	additionalObjectMetaInfo := generateObjectMetaInformation(cr.ObjectMeta.Name+"-additional", cr.Namespace, labels, generateServiceAnots(cr.ObjectMeta, additionalServiceAnnotations, epp))
 	err := CreateOrUpdateService(cr.Namespace, headlessObjectMetaInfo, redisReplicationAsOwner(cr), disableMetrics, true, "ClusterIP", redisPort, cl)
 	if err != nil {
@@ -43,6 +47,11 @@ func CreateReplicationService(cr *redisv1beta2.RedisReplication, cl kubernetes.I
 		additionalServiceType = cr.Spec.KubernetesConfig.Service.ServiceType
 	}
 	err = CreateOrUpdateService(cr.Namespace, additionalObjectMetaInfo, redisReplicationAsOwner(cr), disableMetrics, false, additionalServiceType, redisPort, cl)
+	if err != nil {
+		logger.Error(err, "Cannot create additional service for Redis Replication")
+		return err
+	}
+	err = CreateOrUpdateService(cr.Namespace, masterObjectMetaInfo, redisReplicationAsOwner(cr), disableMetrics, false, additionalServiceType, redisPort, cl)
 	if err != nil {
 		logger.Error(err, "Cannot create additional service for Redis Replication")
 		return err
@@ -197,4 +206,38 @@ func generateRedisReplicationInitContainerParams(cr *redisv1beta2.RedisReplicati
 	}
 
 	return initcontainerProp
+}
+
+func updatePodLabel(ctx context.Context, cl kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisReplication, role string, nodes []string) error {
+	for i := 0; i < len(nodes); i++ {
+		// read Label
+		pod, err := cl.CoreV1().Pods(cr.Namespace).Get(context.TODO(), nodes[i], metav1.GetOptions{})
+		if err != nil {
+			logger.Error(err, "Cannot get redis replication pod")
+			return err
+		}
+		// set Label redis-role
+		metav1.SetMetaDataLabel(&pod.ObjectMeta, "redis-role", role)
+		// update Label
+		_, err = cl.CoreV1().Pods(cr.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+		if err != nil {
+			logger.Error(err, "Cannot update redis replication pod")
+			return err
+		}
+	}
+	return nil
+}
+
+func UpdateRoleLabelPod(ctx context.Context, cl kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisReplication) error {
+	role := "master"
+	err := updatePodLabel(ctx, cl, logger, cr, role, GetRedisNodesByRole(ctx, cl, logger, cr, role))
+	if err != nil {
+		return err
+	}
+	role = "slave"
+	err = updatePodLabel(ctx, cl, logger, cr, role, GetRedisNodesByRole(ctx, cl, logger, cr, role))
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/k8sutils/services.go
+++ b/k8sutils/services.go
@@ -38,13 +38,17 @@ func generateServiceDef(serviceMeta metav1.ObjectMeta, epp exporterPortProvider,
 	} else {
 		PortName = "redis-client"
 	}
+	selectorLabels := serviceMeta.GetLabels()
+	if serviceMeta.GetName() == "redis-replication-master" {
+		selectorLabels["redis-role"] = "master"
+	}
 	service := &corev1.Service{
 		TypeMeta:   generateMetaInformation("Service", "v1"),
 		ObjectMeta: serviceMeta,
 		Spec: corev1.ServiceSpec{
 			Type:      generateServiceType(serviceType),
 			ClusterIP: "",
-			Selector:  serviceMeta.GetLabels(),
+			Selector:  selectorLabels,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       PortName,

--- a/k8sutils/services_test.go
+++ b/k8sutils/services_test.go
@@ -229,6 +229,47 @@ func TestGenerateServiceDef(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test replication-master with ClusterIP service type",
+			serviceMeta: metav1.ObjectMeta{
+				Name: "test-redis-replication-master",
+				Labels: map[string]string{
+					"redis-role": "master",
+				},
+			},
+			enableMetrics: disableMetrics,
+			headless:      false,
+			serviceType:   "ClusterIP",
+			port:          redisPort,
+			expected: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-redis-replication-master",
+					Labels: map[string]string{
+						"redis-role": "master",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "redis-client",
+							Port:       redisPort,
+							TargetPort: intstr.FromInt(int(redisPort)),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+					Selector:  map[string]string{"redis-role": "master"},
+					ClusterIP: "",
+					Type:      corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description**

A Redis client will be able to access the master node of the master-replica without sentinel client.
Redis operator adds label that indicate master node in redis cluster. and creates the service that have selector for master node. the Redis client will be able to access the master node with this the service.


**the summary of the change**

- Adding the label to redis-replication-* pods that indicates role "master" or "slave/replica"
- Adding new service that has new selector for write master role pod.


**Related issue** 

https://github.com/OT-CONTAINER-KIT/redis-operator/issues/765
https://github.com/OT-CONTAINER-KIT/redis-operator/discussions/453


**Type of change**
* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.


**Additional Context**

new service "redis-replication-master"

```
maho-2:takara maho$ kubectl get svc -n ot-operators
NAME                                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
redis-replication                    ClusterIP   10.98.224.240    <none>        6379/TCP    108m
redis-replication-additional         ClusterIP   10.99.82.148     <none>        6379/TCP    108m
redis-replication-headless           ClusterIP   None             <none>        6379/TCP    108m
redis-replication-master             ClusterIP   10.102.232.255   <none>        6379/TCP    108m  <-- Add
redis-sentinel-sentinel              ClusterIP   10.108.182.137   <none>        26379/TCP   106m
redis-sentinel-sentinel-additional   ClusterIP   10.104.130.132   <none>        26379/TCP   106m
redis-sentinel-sentinel-headless     ClusterIP   None             <none>        26379/TCP   106m
webhook-service                      ClusterIP   10.101.135.9     <none>        443/TCP     109m
```

**selector items**

```
maho-2:takara maho$ kubectl get svc redis-replication-master -n ot-operators -o=jsonpath='{.spec.selector}'|jq -r .
{
  "app": "redis-replication",
  "app.kubernetes.io/component": "middleware",
  "app.kubernetes.io/instance": "redis-replication",
  "app.kubernetes.io/managed-by": "Helm",
  "app.kubernetes.io/name": "redis-replication",
  "app.kubernetes.io/version": "0.15.1",
  "helm.sh/chart": "redis-replication-0.15.11",
  "redis-role": "master",
  "redis_setup_type": "replication",
  "role": "replication"
}
```

**new labels in the redis replication node**

```
maho-2:takara maho$ kubectl get pod -n ot-operators --show-labels redis-replication-0 
NAME                  READY   STATUS    RESTARTS   AGE    LABELS
redis-replication-0   1/1     Running   0          117m   app.kubernetes.io/component=middleware,app.kubernetes.io/instance=redis-replication,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=redis-replication,app.kubernetes.io/version=0.15.1,app=redis-replication,apps.kubernetes.io/pod-index=0,controller-revision-hash=redis-replication-5f4b85b78b,helm.sh/chart=redis-replication-0.15.11,redis-role=master,redis_setup_type=replication,role=replication,statefulset.kubernetes.io/pod-name=redis-replication-0
maho-2:takara maho$ kubectl get pod -n ot-operators --show-labels redis-replication-1
NAME                  READY   STATUS    RESTARTS   AGE    LABELS
redis-replication-1   1/1     Running   0          116m   app.kubernetes.io/component=middleware,app.kubernetes.io/instance=redis-replication,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=redis-replication,app.kubernetes.io/version=0.15.1,app=redis-replication,apps.kubernetes.io/pod-index=1,controller-revision-hash=redis-replication-5f4b85b78b,helm.sh/chart=redis-replication-0.15.11,redis-role=slave,redis_setup_type=replication,role=replication,statefulset.kubernetes.io/pod-name=redis-replication-1
maho-2:takara maho$ kubectl get pod -n ot-operators --show-labels redis-replication-2
NAME                  READY   STATUS    RESTARTS   AGE    LABELS
redis-replication-2   1/1     Running   0          116m   app.kubernetes.io/component=middleware,app.kubernetes.io/instance=redis-replication,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=redis-replication,app.kubernetes.io/version=0.15.1,app=redis-replication,apps.kubernetes.io/pod-index=2,controller-revision-hash=redis-replication-5f4b85b78b,helm.sh/chart=redis-replication-0.15.11,redis-role=slave,redis_setup_type=replication,role=replication,statefulset.kubernetes.io/pod-name=redis-replication-2
```

