### PR TITLE
ci: remove strategy from test

### DIFF
--- a/.github/workflows/e2e-chainsaw.yml
+++ b/.github/workflows/e2e-chainsaw.yml
@@ -22,23 +22,8 @@ jobs:
       run: yamllint --strict ./tests/
 
   test:
-    name: ${{ matrix.testpath }}
+    name: "E2E chainsaw tests"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        testpath:
-          - ./tests/e2e-chainsaw/v1beta2/teardown/
-          - ./tests/e2e-chainsaw/v1beta2/setup/
-          - ./tests/e2e-chainsaw/v1beta2/hostnetwork/
-          - ./tests/e2e-chainsaw/v1beta2/password/
-          - ./tests/e2e-chainsaw/v1beta2/ha-setup/
-          - ./tests/e2e-chainsaw/v1beta2/ha-failover/
-          - ./tests/e2e-chainsaw/v1beta2/nodeport/
-          - ./tests/e2e-chainsaw/v1beta2/pvc-name/
-          - ./tests/e2e-chainsaw/v1beta2/keep-pvc/
-          - ./tests/e2e-chainsaw/v1beta2/acl-user/
-          - ./tests/e2e-chainsaw/v1beta2/scaling/
-          - ./tests/e2e-chainsaw/v1beta2/ignore-annots/
 
     steps:
     - name: Checkout code
@@ -84,4 +69,4 @@ jobs:
         kubectl wait --for=condition=available --timeout=300s deployment/redis-operator-redis-operator -n redis-operator-system
 
     - name: Run chainsaw test
-      run: chainsaw test --test-dir ${{ matrix.testpath }} --config tests/_config/chainsaw-configuration.yaml
+      run: chainsaw test --config tests/_config/chainsaw-configuration.yaml tests/e2e-chainsaw


### PR DESCRIPTION
**Description**

Consider removing strategy from the CI since chainsaw can read the nested directory. 

I am not sure we should do it or not it. We can consider this since it would less github runner. 
we can make the test run in parallel that is done by default. 

WDYT ? 
@drivebyer 