### PR TITLE
fix: ensure sentinel does not observes the failover progress in replication cluster

### DIFF
--- a/.github/workflows/e2e-chainsaw.yml
+++ b/.github/workflows/e2e-chainsaw.yml
@@ -20,6 +20,7 @@ jobs:
           - ./tests/e2e-chainsaw/v1beta2/hostnetwork/
           - ./tests/e2e-chainsaw/v1beta2/password/
           - ./tests/e2e-chainsaw/v1beta2/ha-setup/
+          - ./tests/e2e-chainsaw/v1beta2/ha-failover/
           - ./tests/e2e-chainsaw/v1beta2/nodeport/
           - ./tests/e2e-chainsaw/v1beta2/pvc-name/
           - ./tests/e2e-chainsaw/v1beta2/keep-pvc/

--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -79,8 +79,8 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	reqLogger.Info("Will reconcile redis operator in again 10 seconds")
-	return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	reqLogger.Info("Will reconcile after 600 seconds")
+	return ctrl.Result{RequeueAfter: time.Second * 600}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -43,10 +43,7 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
-	if instance.Spec.RedisSentinelConfig != nil && !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, &client.ObjectKey{
-		Namespace: instance.Namespace,
-		Name:      instance.Spec.RedisSentinelConfig.RedisReplicationName,
-	}) {
+	if instance.Spec.RedisSentinelConfig != nil && !k8sutils.IsRedisReplicationReady(ctx, reqLogger, r.K8sClient, r.Dk8sClient, instance) {
 		reqLogger.Info("Redis Replication is specified but not ready, so will reconcile again in 10 seconds")
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
@@ -22,9 +22,9 @@ spec:
         - script:
             timeout: 10s
             content: |
-              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'num-slaves' | tail -n 1
+              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'flags' | tail -n 1
             check:
-              ($stdout=='2'): true
+              ($stdout=='master'): true
 
     # New created cluster, the first pod is master
     - name: Terminate the redis-replication-0 pod
@@ -44,6 +44,6 @@ spec:
         - script:
             timeout: 10s
             content: |
-              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'num-slaves' | tail -n 1
+              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'flags' | tail -n 1
             check:
-              ($stdout=='2'): true
+              ($stdout=='master'): true

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
@@ -1,0 +1,49 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: redis-ha-failover
+spec:
+  steps:
+    - try:
+        - apply:
+            file: replication.yaml
+        - apply:
+            file: sentinel.yaml
+        - create:
+            file: cli-pod.yaml
+
+    - name: Sleep for 3 minutes
+      try:
+        - sleep:
+            duration: 3m
+
+    - name: Test sentinel monitoring
+      try:
+        - script:
+            timeout: 10s
+            content: |
+              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'num-slaves' | tail -n 1
+            check:
+              ($stdout=='2'): true
+
+    # New created cluster, the first pod is master
+    - name: Terminate the redis-replication-0 pod
+      try:
+        - script:
+            timeout: 10s
+            content: |
+              kubectl --namespace ${NAMESPACE} delete pod redis-replication-0
+
+    - name: Sleep for 3 minutes
+      try:
+        - sleep:
+            duration: 3m
+
+    - name: Test sentinel monitoring
+      try:
+        - script:
+            timeout: 10s
+            content: |
+              kubectl exec --namespace ${NAMESPACE} redis -- redis-cli -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 sentinel master myMaster | grep -A 1 'num-slaves' | tail -n 1
+            check:
+              ($stdout=='2'): true

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/cli-pod.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/cli-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  containers:
+  - name: redis
+    image: redis:alpine
+    resources:
+      limits:
+        cpu: 200m
+        memory: 500Mi

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/replication.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: redis-replication
+spec:
+  clusterSize: 3
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/sentinel.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/sentinel.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisSentinel
+metadata:
+  name: redis-sentinel
+spec:
+  clusterSize: 1
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  redisSentinelConfig:
+    redisReplicationName : redis-replication
+    quorum: "1"
+  kubernetesConfig:
+    image: quay.io/opstree/redis-sentinel:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fix #802. 

It's acceptable to extend the RequeueAfter period for reconciliation, as the operations performed during this process are limited and primarily involve creating the sentinel StatefulSet and associated services.
**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
