### PR TITLE
fix: sentinel waiting for replication pod got ready

### DIFF
--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -43,6 +43,14 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
+	if !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, &client.ObjectKey{
+		Namespace: instance.Namespace,
+		Name:      instance.Spec.RedisSentinelConfig.RedisReplicationName,
+	}) {
+		reqLogger.Info("Redis Replication is not ready yet, waiting for 10 seconds")
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	}
+
 	// Get total Sentinel Replicas
 	// sentinelReplicas := instance.Spec.GetSentinelCounts("sentinel")
 

--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -43,11 +43,11 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
-	if !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, &client.ObjectKey{
+	if instance.Spec.RedisSentinelConfig != nil && !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, &client.ObjectKey{
 		Namespace: instance.Namespace,
 		Name:      instance.Spec.RedisSentinelConfig.RedisReplicationName,
 	}) {
-		reqLogger.Info("Redis Replication is not ready yet, waiting for 10 seconds")
+		reqLogger.Info("Redis Replication is specified but not ready, so will reconcile again in 10 seconds")
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -2,6 +2,7 @@ package k8sutils
 
 import (
 	"context"
+
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -1,10 +1,13 @@
 package k8sutils
 
 import (
+	"context"
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateReplicationService method will create replication service for Redis
@@ -193,4 +196,16 @@ func generateRedisReplicationInitContainerParams(cr *redisv1beta2.RedisReplicati
 		}
 	}
 	return initcontainerProp
+}
+
+func IsRedisReplicationReady(ctx context.Context, ki kubernetes.Interface, o *client.ObjectKey) bool {
+	// statefulset name the same as the redis replication name
+	sts, err := ki.AppsV1().StatefulSets(o.Namespace).Get(ctx, o.Name, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	if sts.Status.ReadyReplicas != *sts.Spec.Replicas {
+		return false
+	}
+	return true
 }

--- a/tests/e2e-chainsaw/v1beta2/teardown/redis-sentinel/sentinel.yaml
+++ b/tests/e2e-chainsaw/v1beta2/teardown/redis-sentinel/sentinel.yaml
@@ -8,8 +8,9 @@ spec:
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
-  redisSentinelConfig:
-    redisReplicationName : redis-replication
+   # If we specify the redisReplicationName, we should wait for the redis cluster to be ready before deploying the sentinel
+#  redisSentinelConfig:
+#    redisReplicationName : redis-replication
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:latest
     imagePullPolicy: Always


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
We should wait for the replication cluster to be ready before creating the sentinel cluster.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
