### PR TITLE
fix: m/s replication when using ipv6

### DIFF
--- a/k8sutils/cluster-scaling.go
+++ b/k8sutils/cluster-scaling.go
@@ -35,7 +35,7 @@ func ReshardRedisCluster(client kubernetes.Interface, logger logr.Logger, cr *re
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(transferPOD, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, transferPOD)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, transferPOD, *cr.Spec.Port))
 	}
 
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
@@ -157,7 +157,7 @@ func RebalanceRedisClusterEmptyMasters(client kubernetes.Interface, logger logr.
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(pod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, pod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, pod, *cr.Spec.Port))
 	}
 
 	cmd = append(cmd, "--cluster-use-empty-masters")
@@ -209,7 +209,7 @@ func RebalanceRedisCluster(client kubernetes.Interface, logger logr.Logger, cr *
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(pod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, pod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, pod, *cr.Spec.Port))
 	}
 
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
@@ -247,8 +247,8 @@ func AddRedisNodeToCluster(ctx context.Context, client kubernetes.Interface, log
 		cmd = append(cmd, getRedisHostname(newPod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 		cmd = append(cmd, getRedisHostname(existingPod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, newPod)+fmt.Sprintf(":%d", *cr.Spec.Port))
-		cmd = append(cmd, getRedisServerIP(client, logger, existingPod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, newPod, *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, existingPod, *cr.Spec.Port))
 	}
 
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
@@ -326,7 +326,7 @@ func RemoveRedisFollowerNodesFromCluster(ctx context.Context, client kubernetes.
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(existingPod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, existingPod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, existingPod, *cr.Spec.Port))
 	}
 
 	for _, followerNodeID := range followerNodeIDs {
@@ -356,7 +356,7 @@ func RemoveRedisNodeFromCluster(ctx context.Context, client kubernetes.Interface
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(existingPod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, existingPod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, existingPod, *cr.Spec.Port))
 	}
 
 	removePodNodeID := getRedisNodeID(ctx, client, logger, cr, removePod)
@@ -417,7 +417,7 @@ func ClusterFailover(ctx context.Context, client kubernetes.Interface, logger lo
 	if *cr.Spec.ClusterVersion == "v7" {
 		cmd = append(cmd, getRedisHostname(pod, cr, "leader")+fmt.Sprintf(":%d", *cr.Spec.Port))
 	} else {
-		cmd = append(cmd, getRedisServerIP(client, logger, pod)+fmt.Sprintf(":%d", *cr.Spec.Port))
+		cmd = append(cmd, getRedisServerAddress(client, logger, pod, *cr.Spec.Port))
 	}
 
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {

--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -47,7 +47,6 @@ func getRedisServerIP(client kubernetes.Interface, logger logr.Logger, redisInfo
 	// If we're NOT IPv4, assume we're IPv6..
 	if net.ParseIP(redisIP).To4() == nil {
 		logger.V(1).Info("Redis is using IPv6", "ip", redisIP)
-		redisIP = fmt.Sprintf("[%s]", redisIP)
 	}
 
 	logger.V(1).Info("Successfully got the IP for Redis", "ip", redisIP)


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
I couldn't get the master-follower replication working in my IPv6 EKS cluster. When the operator tried to set up the replication, the follower logged errors:
```
13 Mar 2024 16:46:20.357 * Connecting to MASTER [2a05:d028:10:482:cae3::3]:6379
13 Mar 2024 16:46:20.360 # Unable to connect to MASTER: Resource temporarily unavailable
```

If I manually ran the `slaveof` command without using brackets, the replication started successfully:
```
13 Mar 2024 16:46:21.250 * Connecting to MASTER 2a05:d028:10:482:cae3::3:6379
13 Mar 2024 16:46:21.250 * MASTER <-> REPLICA sync started
```

This PR modifies the `getRedisServerIP` function to return the plain IPv6 address, as the brackets should only be added when using `<ipv6_addr>:<port>` pairs, as per [RFC5952](https://www.rfc-editor.org/rfc/rfc5952#section-6).

I also add new function `getRedisServerAddress`, which handles the address formatting.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #309, #139

**Type of change**

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

This fixes the IPv6 support which was working previously only for the standalone instances.