### PR TITLE
fix: ClusterSlaves result should be cut

### DIFF
--- a/k8sutils/cluster-scaling.go
+++ b/k8sutils/cluster-scaling.go
@@ -259,10 +259,16 @@ func AddRedisNodeToCluster(ctx context.Context, client kubernetes.Interface, log
 
 // getAttachedFollowerNodeIDs would return a slice of redis followers attached to a redis leader
 func getAttachedFollowerNodeIDs(ctx context.Context, redisClient *redis.Client, logger logr.Logger, masterNodeID string) []string {
-	slaveIDs, err := redisClient.ClusterSlaves(ctx, masterNodeID).Result()
+	// 3acb029fead40752f432c84f9bed2e639119a573 192.168.84.239:6379@16379,redis-cluster-v1beta2-follower-5 slave e3299968586dd457a8dba04fc6c747cecd38510f 0 1713595736542 6 connected
+	slaveNodes, err := redisClient.ClusterSlaves(ctx, masterNodeID).Result()
 	if err != nil {
 		logger.Error(err, "Failed to get attached follower node IDs", "masterNodeID", masterNodeID)
 		return nil
+	}
+	slaveIDs := make([]string, 0, len(slaveNodes))
+	for _, slave := range slaveNodes {
+		stringSlice := strings.Split(slave, " ")
+		slaveIDs = append(slaveIDs, stringSlice[0])
 	}
 	logger.V(1).Info("Slaves Nodes attached to", "node", masterNodeID, "are", slaveIDs)
 	return slaveIDs


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
`ClusterSlaves` get slave info, we should parse it to get slave node id.
<img width="1198" alt="截屏2024-04-20 14 49 45" src="https://github.com/OT-CONTAINER-KIT/redis-operator/assets/32033618/8bef5876-7f72-4611-a47c-1773e1b4a5e5">

otherwise, the error log:
```
{"level":"error","ts":"2024-04-20T14:50:06+08:00","logger":"controllers.RedisCluster","msg":"Could not execute command","Command":["redis-cli","--cluster","del-node","redis-cluster-v1beta2-leader-0.redis-cluster-v1beta2-leader-headless.default.svc:6379","3acb029fead40752f432c84f9bed2e639119a573 192.168.84.239:6379@16379,redis-cluster-v1beta2-follower-5 slave e3299968586dd457a8dba04fc6c747cecd38510f 0 1713595736542 6 connected"],"Output":">>> Removing node 3acb029fead40752f432c84f9bed2e639119a573 192.168.84.239:6379@16379,redis-cluster-v1beta2-follower-5 slave e3299968586dd457a8dba04fc6c747cecd38510f 0 1713595736542 6 connected from cluster redis-cluster-v1beta2-leader-0.redis-cluster-v1beta2-leader-headless.default.svc:6379\n[ERR] No such node ID 3acb029fead40752f432c84f9bed2e639119a573 192.168.84.239:6379@16379,redis-cluster-v1beta2-follower-5 slave e3299968586dd457a8dba04fc6c747cecd38510f 0 1713595736542 6 connected\n","error":"execute command with error: command terminated with exit code 1, stderr: ","stacktrace":"github.com/OT-CONTAINER-KIT/redis-operator/k8sutils.executeCommand\n\t/Users/wuyang/workspace/github.com/drivebyer/redis-operator-1/k8sutils/redis.go:402\ngithub.com/OT-CONTAINER-KIT/redis-operator/k8sutils.RemoveRedisFollowerNodesFromCluster\n\t/Users/wuyang/workspace/github.com/drivebyer/redis-operator-1/k8sutils/cluster-scaling.go:312\ngithub.com/OT-CONTAINER-KIT/redis-operator/controllers.(*RedisClusterReconciler).Reconcile\n\t/Users/wuyang/workspace/github.com/drivebyer/redis-operator-1/controllers/rediscluster_controller.go:95\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/Users/wuyang/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/wuyang/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/wuyang/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/Users/wuyang/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227"}
```

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
