### PR TITLE
fix: should get the really leader count when scale in

### DIFF
--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -96,11 +96,7 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Step 3 Rebalance the cluster
 		k8sutils.RebalanceRedisCluster(r.K8sClient, r.Log, instance)
 		reqLogger.Info("Redis cluster is downscaled... Rebalancing the cluster is done")
-		err = k8sutils.UpdateRedisClusterStatus(instance, status.RedisClusterReady, status.ReadyClusterReason, leaderReplicas, leaderReplicas, r.Dk8sClient)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: time.Second * 60}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
 	// Mark the cluster status as initializing if there are no leader or follower nodes

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -9,5 +9,5 @@ spec:
   timeouts:
     apply: 5m
     delete: 5m
-    assert: 10m
-    error: 10m
+    assert: 20m
+    error: 20m

--- a/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
 
     - name: Scale In Redis Cluster
       try:
-        - create:
+        - apply:
             file: cluster.yaml
         - assert:
             file: cluster-status-00.yaml

--- a/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/chainsaw-test.yaml
@@ -37,3 +37,10 @@ spec:
       try:
         - assert:
             file: cluster-scale-out-status-03.yaml
+
+    - name: Scale In Redis Cluster
+      try:
+        - create:
+            file: cluster.yaml
+        - assert:
+            file: cluster-status-00.yaml


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
The operator should rely on the actual status queried from the redis cluster, not just the status it assumes. Otherwise, we might end up with outdated information, leading to downsizing even when the desired leader count is met.

when i scale in cluster from [6 shards](https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/cluster-scale-out.yaml) to [3 shards](https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/tests/e2e-chainsaw/v1beta2/scaling/redis-cluster/cluster.yaml), the log `Redis cluster is downscaling` show more than 3 times.
see:
```
{"level":"info","ts":"2024-04-21T14:23:18+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling...","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","Ready.ReadyLeaderReplicas":6,"Expected.ReadyLeaderReplicas":3}
{"level":"info","ts":"2024-04-21T14:23:18+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","The times of loop":0}
{"level":"info","ts":"2024-04-21T14:24:58+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","The times of loop":1}
{"level":"info","ts":"2024-04-21T14:26:31+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","The times of loop":2}
{"level":"info","ts":"2024-04-21T14:27:51+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaled... Rebalancing the cluster","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2"}
{"level":"info","ts":"2024-04-21T14:29:57+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaled... Rebalancing the cluster is done","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2"}
{"level":"info","ts":"2024-04-21T14:29:58+08:00","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2"}
{"level":"info","ts":"2024-04-21T14:29:58+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling...","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","Ready.ReadyLeaderReplicas":6,"Expected.ReadyLeaderReplicas":3}
{"level":"info","ts":"2024-04-21T14:29:58+08:00","logger":"controllers.RedisCluster","msg":"Redis cluster is downscaling","Request.Namespace":"default","Request.Name":"redis-cluster-v1beta2","The times of loop":0}
```

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
