### PR TITLE
fix: runtime panic when `storage` param is empty

### DIFF
--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -33,41 +33,53 @@ type RedisClusterService struct {
 }
 
 // generateRedisClusterParams generates Redis cluster information
+
 func generateRedisClusterParams(cr *redisv1beta2.RedisCluster, replicas int32, externalConfig *string, params RedisClusterSTS) statefulSetParameters {
-	res := statefulSetParameters{
-		Replicas:                      &replicas,
-		ClusterMode:                   true,
-		ClusterVersion:                cr.Spec.ClusterVersion,
-		NodeConfVolume:                cr.Spec.Storage.NodeConfVolume,
-		NodeSelector:                  params.NodeSelector,
-		PodSecurityContext:            cr.Spec.PodSecurityContext,
-		PriorityClassName:             cr.Spec.PriorityClassName,
-		Affinity:                      params.Affinity,
-		TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
-		Tolerations:                   params.Tolerations,
-		ServiceAccountName:            cr.Spec.ServiceAccountName,
-		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-		HostNetwork:                   cr.Spec.HostNetwork,
-	}
-	if cr.Spec.RedisExporter != nil {
-		res.EnableMetrics = cr.Spec.RedisExporter.Enabled
-	}
-	if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
-		res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets
-	}
-	if cr.Spec.Storage != nil {
-		res.PersistentVolumeClaim = cr.Spec.Storage.VolumeClaimTemplate
-		res.NodeConfPersistentVolumeClaim = cr.Spec.Storage.NodeConfVolumeClaimTemplate
-	}
-	if externalConfig != nil {
-		res.ExternalConfig = externalConfig
-	}
-	if _, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found {
-		res.RecreateStatefulSet = true
-	}
-	return res
+    if cr == nil {
+        panic("RedisCluster is empty")
+    }
+    if cr.Spec == nil {
+        panic("RedisCluster.Spec cannot be empty")
+    }
+    if cr.Spec.Storage == nil {
+    	cr.Spec.Storage = &redisv1beta2.Storage{}
+    }
+    
+    res := statefulSetParameters{
+        Replicas:                      &replicas,
+        ClusterMode:                   true,
+        ClusterVersion:                cr.Spec.ClusterVersion,
+        NodeConfVolume:                cr.Spec.Storage.NodeConfVolume,
+        NodeSelector:                  params.NodeSelector,
+        PodSecurityContext:            cr.Spec.PodSecurityContext,
+        PriorityClassName:             cr.Spec.PriorityClassName,
+        Affinity:                      params.Affinity,
+        TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
+        Tolerations:                   params.Tolerations,
+        ServiceAccountName:            cr.Spec.ServiceAccountName,
+        UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
+        IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
+        HostNetwork:                   cr.Spec.HostNetwork,
+    }
+    if cr.Spec.RedisExporter != nil {
+        res.EnableMetrics = cr.Spec.RedisExporter.Enabled
+    }
+    if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
+        res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets
+    }
+    if cr.Spec.Storage != nil {
+        res.PersistentVolumeClaim = cr.Spec.Storage.VolumeClaimTemplate
+        res.NodeConfPersistentVolumeClaim = cr.Spec.Storage.NodeConfVolumeClaimTemplate
+    }
+    if externalConfig != nil {
+        res.ExternalConfig = externalConfig
+    }
+    if _, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found {
+        res.RecreateStatefulSet = true
+    }
+    return res
 }
+
 
 func generateRedisClusterInitContainerParams(cr *redisv1beta2.RedisCluster) initContainerParameters {
 	trueProperty := true

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -35,49 +35,39 @@ type RedisClusterService struct {
 // generateRedisClusterParams generates Redis cluster information
 
 func generateRedisClusterParams(cr *redisv1beta2.RedisCluster, replicas int32, externalConfig *string, params RedisClusterSTS) statefulSetParameters {
-    if cr == nil {
-        panic("RedisCluster is empty")
-    }
-    if cr.Spec == nil {
-        panic("RedisCluster.Spec cannot be empty")
-    }
-    if cr.Spec.Storage == nil {
-    	cr.Spec.Storage = &redisv1beta2.Storage{}
-    }
-    
-    res := statefulSetParameters{
-        Replicas:                      &replicas,
-        ClusterMode:                   true,
-        ClusterVersion:                cr.Spec.ClusterVersion,
-        NodeConfVolume:                cr.Spec.Storage.NodeConfVolume,
-        NodeSelector:                  params.NodeSelector,
-        PodSecurityContext:            cr.Spec.PodSecurityContext,
-        PriorityClassName:             cr.Spec.PriorityClassName,
-        Affinity:                      params.Affinity,
-        TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
-        Tolerations:                   params.Tolerations,
-        ServiceAccountName:            cr.Spec.ServiceAccountName,
-        UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-        IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-        HostNetwork:                   cr.Spec.HostNetwork,
-    }
-    if cr.Spec.RedisExporter != nil {
-        res.EnableMetrics = cr.Spec.RedisExporter.Enabled
-    }
-    if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
-        res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets
-    }
-    if cr.Spec.Storage != nil {
-        res.PersistentVolumeClaim = cr.Spec.Storage.VolumeClaimTemplate
-        res.NodeConfPersistentVolumeClaim = cr.Spec.Storage.NodeConfVolumeClaimTemplate
-    }
-    if externalConfig != nil {
-        res.ExternalConfig = externalConfig
-    }
-    if _, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found {
-        res.RecreateStatefulSet = true
-    }
-    return res
+	res := statefulSetParameters{
+		Replicas:                      &replicas,
+		ClusterMode:                   true,
+		ClusterVersion:                cr.Spec.ClusterVersion,
+		NodeSelector:                  params.NodeSelector,
+		PodSecurityContext:            cr.Spec.PodSecurityContext,
+		PriorityClassName:             cr.Spec.PriorityClassName,
+		Affinity:                      params.Affinity,
+		TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
+		Tolerations:                   params.Tolerations,
+		ServiceAccountName:            cr.Spec.ServiceAccountName,
+		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
+		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
+		HostNetwork:                   cr.Spec.HostNetwork,
+	}
+	if cr.Spec.RedisExporter != nil {
+		res.EnableMetrics = cr.Spec.RedisExporter.Enabled
+	}
+	if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
+		res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets
+	}
+	if cr.Spec.Storage != nil {
+		res.PersistentVolumeClaim = cr.Spec.Storage.VolumeClaimTemplate
+		res.NodeConfVolume = cr.Spec.Storage.NodeConfVolume
+		res.NodeConfPersistentVolumeClaim = cr.Spec.Storage.NodeConfVolumeClaimTemplate
+	}
+	if externalConfig != nil {
+		res.ExternalConfig = externalConfig
+	}
+	if _, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found {
+		res.RecreateStatefulSet = true
+	}
+	return res
 }
 
 

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -33,7 +33,6 @@ type RedisClusterService struct {
 }
 
 // generateRedisClusterParams generates Redis cluster information
-
 func generateRedisClusterParams(cr *redisv1beta2.RedisCluster, replicas int32, externalConfig *string, params RedisClusterSTS) statefulSetParameters {
 	res := statefulSetParameters{
 		Replicas:                      &replicas,

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -69,7 +69,6 @@ func generateRedisClusterParams(cr *redisv1beta2.RedisCluster, replicas int32, e
 	return res
 }
 
-
 func generateRedisClusterInitContainerParams(cr *redisv1beta2.RedisCluster) initContainerParameters {
 	trueProperty := true
 	initcontainerProp := initContainerParameters{}


### PR DESCRIPTION
> Disclaimer:  new to Go lang. Feel free to author this PR, feedback is welcome.

The `nil` checks in `func generateRedisClusterParams` are ran before `cr.Spec.Storage.$` is referenced, hence causing a runtime panic when the `storage field isn't defined in the manifest.


<!-- Please provide a summary of the change here. -->

- Moved `nil` checks on objects before initializing the `statefulSetParameters` struct
- If `cr.Spec.Storage` fails `nil` check,  it initializes it to a new instance of redisv1beta2.Storage{}


⚠️ This might not be the ideal place to perform objects initializations. Please carefully review whether this should exist elsewhere according to your design

**Type of change**

<!-- Please delete options that are not relevant. -->

* Breaking change / bug fix


**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.




**Additional Context**



```
{"level":"info","ts":"2024-04-19T17:24:45Z","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"rediscluster","controllerGroup":"redis.redis.opstreelabs.in","controllerKind":"RedisCluster","RedisCluster":{"name":"yup","namespace":"redis"},"namespace":"redis","name":"yup","reconcileID":"a85b8c91-956f-4eaa-a387-1cdf9c9cdb46"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x128db1c]

goroutine 173 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:116 +0x1a4
panic({0x14ce4c0?, 0x2788ce0?})
    /usr/local/go/src/runtime/panic.go:914 +0x218
github.com/teocns/redis-operator/k8sutils.generateRedisClusterParams(_, _, _, {{_, _}, _, _, _, _, _, ...})
    /workspace/k8sutils/redis-cluster.go:41 +0xbc
github.com/teocns/redis-operator/k8sutils.RedisClusterSTS.CreateRedisClusterSetup({{0x1755ad1, 0x6}, 0x0, 0x0, 0x0, 0x0, 0x400063c390, 0x400063c3a8, 0x0, 0x0}, ...)
    /workspace/k8sutils/redis-cluster.go:275 +0x5d0
github.com/teocns/redis-operator/k8sutils.CreateRedisLeader(0x1755ad1?, {0x1a109f0?, 0x40004fd040?})
    /workspace/k8sutils/redis-cluster.go:222 +0xd0
github.com/teocns/redis-operator/controllers.(*RedisClusterReconciler).Reconcile(0x400002de50, {0x19f7088, 0x40006478c0}, {{{0x400062c269?, 0x5?}, {0x400062c266?, 0x4000577cf8?}}})
    /workspace/controllers/rediscluster_controller.go:125 +0x518
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x19fa370?, {0x19f7088?, 0x40006478c0?}, {{{0x400062c269?, 0xb?}, {0x400062c266?, 0x0?}}})
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:119 +0x8c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x40000a6280, {0x19f70c0, 0x400002c320}, {0x15851c0?, 0x4000268820?})
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:316 +0x2e8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x40000a6280, {0x19f70c0, 0x400002c320})
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266 +0x16c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227 +0x74
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 62
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:223 +0x43c
Stream closed EOF for kube-system/redis-operator-6d7bdcc486-879gf (redis-operator)
```

