### PR TITLE
fix: runtime panic when delete rediscluster which disable persistent

### DIFF
--- a/k8sutils/finalizer.go
+++ b/k8sutils/finalizer.go
@@ -25,7 +25,7 @@ const (
 func HandleRedisFinalizer(ctrlclient client.Client, k8sClient kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.Redis) error {
 	if cr.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(cr, RedisFinalizer) {
-			if !cr.Spec.Storage.KeepAfterDelete {
+			if cr.Spec.Storage != nil && !cr.Spec.Storage.KeepAfterDelete {
 				if err := finalizeRedisPVC(k8sClient, logger, cr); err != nil {
 					return err
 				}
@@ -44,7 +44,7 @@ func HandleRedisFinalizer(ctrlclient client.Client, k8sClient kubernetes.Interfa
 func HandleRedisClusterFinalizer(ctrlclient client.Client, k8sClient kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisCluster) error {
 	if cr.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(cr, RedisClusterFinalizer) {
-			if !cr.Spec.Storage.KeepAfterDelete {
+			if cr.Spec.Storage != nil && !cr.Spec.Storage.KeepAfterDelete {
 				if err := finalizeRedisClusterPVC(k8sClient, logger, cr); err != nil {
 					return err
 				}
@@ -63,7 +63,7 @@ func HandleRedisClusterFinalizer(ctrlclient client.Client, k8sClient kubernetes.
 func HandleRedisReplicationFinalizer(ctrlclient client.Client, k8sClient kubernetes.Interface, logger logr.Logger, cr *redisv1beta2.RedisReplication) error {
 	if cr.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(cr, RedisReplicationFinalizer) {
-			if !cr.Spec.Storage.KeepAfterDelete {
+			if cr.Spec.Storage != nil && !cr.Spec.Storage.KeepAfterDelete {
 				if err := finalizeRedisReplicationPVC(k8sClient, logger, cr); err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #921 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
