### PR TITLE
build: add support for other container engines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+CONTAINER_ENGINE ?= docker
+
 all: manager
 
 # Run tests
@@ -74,15 +76,15 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 docker-create:
-	docker buildx create --platform "linux/amd64,linux/arm64" --use
+	${CONTAINER_ENGINE} buildx create --platform "linux/amd64,linux/arm64" --use
 
 # Build the docker image
 docker-build:
-	docker buildx build --platform="linux/arm64,linux/amd64" -t ${IMG} .
+	${CONTAINER_ENGINE} buildx build --platform="linux/arm64,linux/amd64" -t ${IMG} .
 
 # Push the docker image
 docker-push:
-	docker buildx build --push --platform="linux/arm64,linux/amd64" -t ${IMG} .
+	${CONTAINER_ENGINE} buildx build --push --platform="linux/arm64,linux/amd64" -t ${IMG} .
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
@@ -119,7 +121,7 @@ bundle: manifests kustomize
 # Build the bundle image.
 .PHONY: bundle-build
 bundle-build:
-	docker buildx build --platform="linux/arm64,linux/amd64" -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	${CONTAINER_ENGINE} buildx build --platform="linux/arm64,linux/amd64" -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: codegen
@@ -164,7 +166,7 @@ install-kuttl:
 
 .PHONY: e2e-kind-setup
 e2e-kind-setup:
-	docker build -t redis-operator:e2e -f Dockerfile .
+	${CONTAINER_ENGINE} build -t redis-operator:e2e -f Dockerfile .
 	kind create cluster --config tests/_config/kind-config.yaml
 	kind load docker-image redis-operator:e2e --name kind
 	make deploy IMG=redis-operator:e2e


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Add support for other container engines (podman); still defaults to docker.

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [NA] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [NA] Documentation has been updated or added where necessary.
