### PR TITLE
fix: sentinel should not reconcile until replication cluster ready

### DIFF
--- a/controllers/redissentinel_controller.go
+++ b/controllers/redissentinel_controller.go
@@ -11,11 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // RedisSentinelReconciler reconciles a RedisSentinel object
@@ -80,22 +77,13 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	reqLogger.Info("Will reconcile after 600 seconds")
-	return ctrl.Result{RequeueAfter: time.Second * 600}, nil
+	reqLogger.Info("Will reconcile after 10 seconds")
+	return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedisSentinelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta2.RedisSentinel{}).
-		Watches(&redisv1beta2.RedisReplication{}, &handler.Funcs{
-			CreateFunc: nil,
-			UpdateFunc: func(ctx context.Context, event event.UpdateEvent, limitingInterface workqueue.RateLimitingInterface) {
-				_ = event.ObjectNew.GetName()
-				_ = event.ObjectNew.GetNamespace()
-			},
-			DeleteFunc:  nil,
-			GenericFunc: nil,
-		}).
 		Complete(r)
 }

--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -210,6 +210,12 @@ func IsRedisReplicationReady(ctx context.Context, logger logr.Logger, client kub
 	if sts.Status.ReadyReplicas != *sts.Spec.Replicas {
 		return false
 	}
+	if sts.Status.ObservedGeneration != sts.Generation {
+		return false
+	}
+	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
+		return false
+	}
 	// Enhanced check: When the pod is ready, it may not have been
 	// created as part of a replication cluster, so we should verify
 	// whether there is an actual master node.

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
@@ -50,13 +50,6 @@ spec:
             timeout: 10s
             content: |
               kubectl --namespace ${NAMESPACE} delete pod redis-replication-0
-      catch:
-        - description: Redis Operator Logs
-          podLogs:
-            namespace: redis-operator-system
-            selector: control-plane=redis-operator
-            container: manager
-            tail: -1  # tail all logs
 
     - name: Sleep for 3 minutes
       try:

--- a/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/ha-failover/chainsaw-test.yaml
@@ -51,10 +51,10 @@ spec:
             content: |
               kubectl --namespace ${NAMESPACE} delete pod redis-replication-0
 
-    - name: Sleep for 3 minutes
+    - name: Sleep for 5 minutes
       try:
         - sleep:
-            duration: 3m
+            duration: 5m
 
     - name: Test sentinel monitoring
       try:


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #522 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
