### PR TITLE
refactor: reconcile on statefulset update

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -101,21 +101,24 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	rrLog := ctrl.Log.WithName("controllers").WithName("RedisReplication")
+	rcLog := ctrl.Log.WithName("controllers").WithName("RedisCluster")
 	err = (&RedisClusterReconciler{
 		Client:      k8sManager.GetClient(),
 		K8sClient:   k8sClient,
 		Dk8sClient:  dk8sClient,
 		Scheme:      k8sManager.GetScheme(),
-		StatefulSet: k8sutils.NewStatefulSetService(k8sClient, rrLog),
+		StatefulSet: k8sutils.NewStatefulSetService(k8sClient, rcLog),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	rrLog := ctrl.Log.WithName("controllers").WithName("RedisReplication")
 	err = (&RedisReplicationReconciler{
-		Client:     k8sManager.GetClient(),
-		K8sClient:  k8sClient,
-		Dk8sClient: dk8sClient,
-		Scheme:     k8sManager.GetScheme(),
+		Client:      k8sManager.GetClient(),
+		K8sClient:   k8sClient,
+		Dk8sClient:  dk8sClient,
+		Scheme:      k8sManager.GetScheme(),
+		Pod:         k8sutils.NewPodService(k8sClient, rrLog),
+		StatefulSet: k8sutils.NewStatefulSetService(k8sClient, rrLog),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -138,12 +138,13 @@ func main() {
 	}
 	rrLog := ctrl.Log.WithName("controllers").WithName("RedisReplication")
 	if err = (&controllers.RedisReplicationReconciler{
-		Client:     mgr.GetClient(),
-		K8sClient:  k8sclient,
-		Dk8sClient: dk8sClient,
-		Log:        rrLog,
-		Scheme:     mgr.GetScheme(),
-		Pod:        k8sutils.NewPodService(k8sclient, rrLog),
+		Client:      mgr.GetClient(),
+		K8sClient:   k8sclient,
+		Dk8sClient:  dk8sClient,
+		Log:         rrLog,
+		Scheme:      mgr.GetScheme(),
+		Pod:         k8sutils.NewPodService(k8sclient, rrLog),
+		StatefulSet: k8sutils.NewStatefulSetService(k8sclient, rrLog),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisReplication")
 		os.Exit(1)


### PR DESCRIPTION
This change makes the creation process faster, but we will monitor the StatefulSet update. It's okay because it's the best practice for the operator to reconcile.