### PR TITLE
fix: add default port to enable `SENTINEL_PORT` environment

### DIFF
--- a/k8sutils/redis-replication.go
+++ b/k8sutils/redis-replication.go
@@ -125,7 +125,7 @@ func generateRedisReplicationContainerParams(cr *redisv1beta2.RedisReplication) 
 		ImagePullPolicy: cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:       cr.Spec.KubernetesConfig.Resources,
 		SecurityContext: cr.Spec.SecurityContext,
-		Port:            ptr.To(6379),
+		Port:            ptr.To(redisPort),
 	}
 	if cr.Spec.EnvVars != nil {
 		containerProp.EnvVars = cr.Spec.EnvVars

--- a/k8sutils/redis-sentinel.go
+++ b/k8sutils/redis-sentinel.go
@@ -152,6 +152,7 @@ func generateRedisSentinelContainerParams(ctx context.Context, client kubernetes
 		ImagePullPolicy:       cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:             cr.Spec.KubernetesConfig.Resources,
 		SecurityContext:       cr.Spec.SecurityContext,
+		Port:                  ptr.To(sentinelPort),
 		AdditionalEnvVariable: getSentinelEnvVariable(ctx, client, logger, cr, dcl),
 	}
 	if cr.Spec.EnvVars != nil {

--- a/k8sutils/redis-sentinel_test.go
+++ b/k8sutils/redis-sentinel_test.go
@@ -176,6 +176,7 @@ func Test_generateRedisSentinelContainerParams(t *testing.T) {
 				Value: "custom_value_2",
 			},
 		},
+		Port: ptr.To(26379),
 		AdditionalVolume: []v1.Volume{
 			{
 				Name: "redis-config",

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -121,7 +121,7 @@ func generateRedisStandaloneContainerParams(cr *redisv1beta2.Redis) containerPar
 		ImagePullPolicy: cr.Spec.KubernetesConfig.ImagePullPolicy,
 		Resources:       cr.Spec.KubernetesConfig.Resources,
 		SecurityContext: cr.Spec.SecurityContext,
-		Port:            ptr.To(6379),
+		Port:            ptr.To(redisPort),
 	}
 
 	if cr.Spec.EnvVars != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #995 

When a user uses an old Redis image that does not have SENTINEL_PORT set as the default environment variable, we must configure SENTINEL_PORT to 26379 in the operator. Otherwise, the Sentinel probe will fail.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
