### PR TITLE
feat: allow rbac to pe externally provisioned

### DIFF
--- a/charts/redis-operator/readme.md
+++ b/charts/redis-operator/readme.md
@@ -92,6 +92,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | `resources.requests.cpu`                      | CPU request                            | `500m`                                           |
 | `resources.requests.memory`                   | Memory request                         | `500Mi`                                          |
 | `replicas`                                    | Number of replicas                     | `1`                                              |
+| `rbac.enabled`                                | Feature flag for rbac resources        | `true`                                           |
 | `serviceAccountName`                          | Service account name                   | `redis-operator`                                 |
 | `serviceAccount.automountServiceAccountToken` | Automount service account token        | `true`                                           |
 | `certificate.name`                            | Certificate name                       | `serving-cert`                                   |

--- a/charts/redis-operator/templates/role-binding.yaml
+++ b/charts/redis-operator/templates/role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -19,3 +20,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.redisOperator.name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -124,3 +125,4 @@ rules:
   - patch
   - update
   - watch
+{{- end }}

--- a/charts/redis-operator/templates/service-account.yaml
+++ b/charts/redis-operator/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -13,3 +14,4 @@ metadata:
     app.kubernetes.io/version : {{ .Chart.AppVersion }}
     app.kubernetes.io/component: service-account
     app.kubernetes.io/part-of : {{ .Release.Name }}
+{{- end }}

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -30,6 +30,8 @@ resources:
 
 replicas: 1
 
+rbac:
+  enabled: true
 serviceAccountName: redis-operator
 
 serviceAccount:


### PR DESCRIPTION
**Description**

In case of a cluster tenant that is not allowed to apply cluster wide resources, the redis operator helm chart cannot be installed as the cluster role and cluster role binding cannot be applied and the chart has no option to disable those resources. Instead, for such scenarios, allow the user to handle rbac provisioning outside of the chart and only link to an externally provisioned service account.

Fixes #1004

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ x] Tests have been added/modified and all tests pass.
- [ x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ x] I have performed a self-review of my own code.
- [ x] Documentation has been updated or added where necessary.
