### PR TITLE
feat: add redis/redisreplication/redissentinel/rediscluster chart

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Install and test Redis Related Helm charts
         run: |
           kubectl cluster-info --context kind-kind
-          chart_dirs=("redis-operator")
+          chart_dirs=("redis-operator" "redis" "redis-cluster" "redis-replication" "redis-sentinel")
           for dir in "${chart_dirs[@]}"
           do
             if [[ -f ./charts/$dir/Chart.yaml ]]; then
@@ -104,8 +104,15 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm dependency update charts/redis-operator
-          helm package charts/redis-operator -d .cr-release-packages
+          
+          chart_dirs=("redis-operator" "redis" "redis-cluster" "redis-replication" "redis-sentinel")
+          for dir in "${chart_dirs[@]}"
+          do
+            if [[ -f ./charts/$dir/Chart.yaml ]]; then
+              helm dependency update ./charts/$dir/
+            fi
+            helm package charts/$dir -d .cr-release-packages
+          done                    
 
       - name: Install chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: redis-cluster
+description: Provides easy redis setup definitions for Kubernetes services, and deployment.
+version: 0.16.0
+appVersion: "0.16.0"
+home: https://github.com/ot-container-kit/redis-operator
+sources:
+  - https://github.com/ot-container-kit/redis-operator
+maintainers:
+  - name: iamabhishek-dubey
+  - name: sandy724
+  - name: shubham-cmyk
+keywords:
+- operator
+- redis
+- opstree
+- kubernetes
+- openshift
+- redis-exporter
+icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
+type: application

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -1,0 +1,66 @@
+# Redis Cluster
+
+Redis is a key-value based distributed database, this helm chart is for redis cluster setup. This helm chart needs [Redis Operator](../redis-operator) inside Kubernetes cluster. The redis cluster definition can be modified or changed by [values.yaml](./values.yaml).
+
+```shell
+helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
+
+helm install <my-release> ot-helm/redis-cluster \
+    --set redisCluster.clusterSize=3 --namespace <namespace>
+```
+
+Redis setup can be upgraded by using `helm upgrade` command:-
+
+```shell
+helm upgrade <my-release> ot-helm/redis-cluster --install \
+    --set redisCluster.clusterSize=5 --namespace <namespace>
+```
+
+For uninstalling the chart:-
+
+```shell
+helm delete <my-release> --namespace <namespace>
+```
+
+## Pre-Requisities
+
+- Kubernetes 1.15+
+- Helm 3.X
+- Redis Operator 0.7.0
+
+## Parameters
+
+| **Name**                           | **Default Value**              | **Description**                                                                               |
+|------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------|
+| `imagePullSecrets`                 | []                             | List of image pull secrets, in case redis image is getting pull from private registry         |
+| `redisCluster.clusterSize`         | 3                              | Size of the redis cluster leader and follower nodes                                           |
+| `redisCluster.clusterVersion`      | v7                             | Major version of Redis setup, values can be v6 or v7                                          |
+| `redisCluster.persistenceEnabled`  | true                           | Persistence should be enabled or not in the Redis cluster setup                               |
+| `redisCluster.secretName`          | redis-secret                   | Name of the existing secret in Kubernetes                                                     |
+| `redisCluster.secretKey`           | password                       | Name of the existing secret key in Kubernetes                                                 |
+| `redisCluster.image`               | quay.io/opstree/redis          | Name of the redis image                                                                       |
+| `redisCluster.tag`                 | v6.2                           | Tag of the redis image                                                                        |
+| `redisCluster.imagePullPolicy`     | IfNotPresent                   | Image Pull Policy of the redis image                                                          |
+| `redisCluster.leaderServiceType`   | ClusterIP                      | Kubernetes service type for Redis Leader                                                      |
+| `redisCluster.followerServiceType` | ClusterIP                      | Kubernetes service type for Redis Follower                                                    |
+| `redisCluster.name`                            | ""                             | Overwrites the name for the charts resources instead of the Release name |
+| `externalService.enabled`          | false                          | If redis service needs to be exposed using LoadBalancer or NodePort                           |
+| `externalService.annotations`      | {}                             | Kubernetes service related annotations                                                        |
+| `externalService.serviceType`      | NodePort                       | Kubernetes service type for exposing service, values - ClusterIP, NodePort, and LoadBalancer  |
+| `externalService.port`             | 6379                           | Port number on which redis external service should be exposed                                 |
+| `serviceMonitor.enabled`           | false                          | Servicemonitor to monitor redis with Prometheus                                               |
+| `serviceMonitor.interval`          | 30s                            | Interval at which metrics should be scraped.                                                  |
+| `serviceMonitor.scrapeTimeout`     | 10s                            | Timeout after which the scrape is ended                                                       |
+| `serviceMonitor.namespace`         | monitoring                     | Namespace in which Prometheus operator is running                                             |
+| `redisExporter.enabled`            | true                           | Redis exporter should be deployed or not                                                      |
+| `redisExporter.image`              | quay.io/opstree/redis-exporter | Name of the redis exporter image                                                              |
+| `redisExporter.tag`                | v6.2                           | Tag of the redis exporter image                                                               |
+| `redisExporter.imagePullPolicy`    | IfNotPresent                   | Image Pull Policy of the redis exporter image                                                 |
+| `redisExporter.env`                | []                             | Extra environment variables which needs to be added in redis exporter                         |
+| `sidecars`                         | []                             | Sidecar for redis pods                                                                        |
+| `nodeSelector`                     | {}                             | NodeSelector for redis statefulset                                                            |
+| `priorityClassName`                | ""                             | Priority class name for the redis statefulset                                                 |
+| `storageSpec`                      | {}                             | Storage configuration for redis setup                                                         |
+| `securityContext`                  | {}                             | Security Context for redis pods for changing system or kernel level parameters                |
+| `affinity`                         | {}                             | Affinity for node and pods for redis statefulset                                              |
+| `tolerations`                      | []                             | Tolerations for redis statefulset                                                             |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Define common labels */}}
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: middleware
+{{- if .Values.labels }}
+{{- range $labelkey, $labelvalue := .Values.labels }}
+{{ $labelkey}}: {{ $labelvalue }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Helper for Redis Cluster (leader & follower) */}}
+{{- define "redis.role" -}}
+{{- if .affinity }}
+affinity:
+  {{- toYaml .affinity | nindent 2 }}
+{{- end }}
+{{- if .tolerations }}
+tolerations:
+  {{- toYaml .tolerations | nindent 2 }}
+{{- end }}
+{{- if .pdb.enabled  }}
+pdb:
+  enabled: {{ .pdb.enabled }}
+  maxUnavailable: {{ .pdb.maxUnavailable }}
+  minAvailable: {{ .pdb.minAvailable }}
+{{- end }}
+{{- if .nodeSelector }}
+nodeSelector:
+  {{- toYaml .nodeSelector | nindent 2 }}
+{{- end }}
+{{- if .securityContext }}
+securityContext:
+  {{- toYaml .securityContext | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate sidecar properties */}}
+{{- define "sidecar.properties" -}}
+{{- with .Values.sidecars }}
+name: {{ .name }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate init container properties */}}
+{{- define "initContainer.properties" -}}
+{{- with .Values.initContainer }}
+{{- if .enabled }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- if .command }}
+command:
+{{ toYaml .command | nindent 2 }}
+{{- end }}
+{{- if .args }}
+args:
+{{ toYaml .args | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+

--- a/charts/redis-cluster/templates/extra-config.yaml
+++ b/charts/redis-cluster/templates/extra-config.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.externalConfig.enabled true }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}-ext-config
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+data:
+  redis-additional.conf: |
+    {{ .Values.externalConfig.data | nindent 4 }}
+{{- end }}

--- a/charts/redis-cluster/templates/follower-service.yaml
+++ b/charts/redis-cluster/templates/follower-service.yaml
@@ -1,0 +1,29 @@
+{{- if and (gt (int .Values.redisCluster.follower.replicas) 0) (eq .Values.externalService.enabled true) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}-follower-external-service
+{{- if .Values.externalService.annotations }}
+  annotations:
+{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  type: {{ .Values.externalService.serviceType }}
+  selector:
+    app: {{ .Values.redisCluster.name | default .Release.Name }}-follower
+    redis_setup_type: cluster
+    role: follower
+  ports:
+    - protocol: TCP
+      port: {{ .Values.externalService.port }}
+      targetPort: 6379
+      name: client
+{{- end }}

--- a/charts/redis-cluster/templates/follower-sm.yaml
+++ b/charts/redis-cluster/templates/follower-sm.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq .Values.serviceMonitor.enabled true)  (gt (int .Values.redisCluster.follower.replicas) 0) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}-follower-prometheus-monitoring
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.redisCluster.name | default .Release.Name }}-follower
+      redis_setup_type: cluster
+      role: follower
+  endpoints:
+  - port: redis-exporter
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.serviceMonitor.namespace }}
+{{- end }}

--- a/charts/redis-cluster/templates/leader-service.yaml
+++ b/charts/redis-cluster/templates/leader-service.yaml
@@ -1,0 +1,29 @@
+{{- if and (gt (int .Values.redisCluster.leader.replicas) 0) (eq .Values.externalService.enabled true) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}-leader-external-service
+{{- if .Values.externalService.annotations }}
+  annotations:
+{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  type: {{ .Values.externalService.serviceType }}
+  selector:
+    app: {{ .Values.redisCluster.name | default .Release.Name }}-leader
+    redis_setup_type: cluster
+    role: leader
+  ports:
+    - protocol: TCP
+      port: {{ .Values.externalService.port }}
+      targetPort: 6379
+      name: client
+{{- end }}

--- a/charts/redis-cluster/templates/leader-sm.yaml
+++ b/charts/redis-cluster/templates/leader-sm.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq .Values.serviceMonitor.enabled true) (gt (int .Values.redisCluster.leader.replicas) 0) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}-leader-prometheus-monitoring
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.redisCluster.name | default .Release.Name }}-leader
+      redis_setup_type: cluster
+      role: leader
+  endpoints:
+  - port: redis-exporter
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.serviceMonitor.namespace }}
+{{- end }}

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: {{ .Values.redisCluster.name | default .Release.Name }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+spec:
+  clusterSize: {{ .Values.redisCluster.clusterSize }}
+  persistenceEnabled: {{ .Values.redisCluster.persistenceEnabled }}
+  clusterVersion: {{ .Values.redisCluster.clusterVersion }}
+
+  redisLeader: {{- include "redis.role" .Values.redisCluster.leader | nindent 4 }}
+    replicas: {{ .Values.redisCluster.leader.replicas }}
+  {{- if .Values.externalConfig.enabled }}
+    redisConfig:
+      additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
+  {{- end }}
+  
+  redisFollower: {{-  include "redis.role" .Values.redisCluster.follower | nindent 4 }}
+    replicas: {{ .Values.redisCluster.follower.replicas }}
+  {{- if .Values.externalConfig.enabled }}
+    redisConfig:
+      additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
+  {{- end }}
+
+  redisExporter:
+    enabled: {{ .Values.redisExporter.enabled }}
+    image: "{{ .Values.redisExporter.image }}:{{ .Values.redisExporter.tag }}"
+    imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
+    {{- if .Values.redisExporter.resources}}
+    resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
+    {{- end }}
+    {{- if .Values.redisExporter.env }}
+    env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
+    {{- end }}
+    
+  kubernetesConfig:
+    image: "{{ .Values.redisCluster.image }}:{{ .Values.redisCluster.tag }}"
+    imagePullPolicy: "{{ .Values.redisCluster.imagePullPolicy }}"
+    {{- if .Values.redisCluster.imagePullSecrets}}
+    imagePullSecrets: {{ toYaml .Values.redisCluster.imagePullSecrets | nindent 4 }}
+    {{- end }}
+    {{- if .Values.redisCluster.resources}}
+    resources: {{ toYaml .Values.redisCluster.resources | nindent 6 }}
+    {{- end }}
+    {{- if and .Values.redisCluster.redisSecret.secretName .Values.redisCluster.redisSecret.secretKey }}
+    redisSecret:
+      name: {{ .Values.redisCluster.redisSecret.secretName | quote }}
+      key: {{ .Values.redisCluster.redisSecret.secretKey | quote }}
+    {{- end }}
+
+  {{- if .Values.storageSpec }}
+  storage: {{ toYaml .Values.storageSpec | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.priorityClassName (ne .Values.priorityClassName "") }}
+  priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+  {{- if .Values.podSecurityContext }}
+  podSecurityContext: {{ toYaml .Values.podSecurityContext | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
+  TLS:
+    ca: {{ .Values.TLS.ca | quote }}
+    cert: {{ .Values.TLS.cert | quote }}
+    key: {{ .Values.TLS.key | quote }}
+    secret:
+      secretName: {{ .Values.TLS.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
+  acl:
+    secret:
+      secretName: {{ .Values.acl.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
+  sidecars: {{ include "sidecar.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
+  initContainer: {{ include "initContainer.properties" | nindent 4 }}
+  {{- end }}
+  {{- if .Values.env }}
+  env: {{ toYaml .Values.env | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
+  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  {{- end }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1,0 +1,184 @@
+---
+redisCluster:
+  name: ""
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  image: quay.io/opstree/redis
+  tag: v7.0.12
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: {}
+    # - name:  Secret with Registry credentials
+  redisSecret:
+    secretName: ""
+    secretKey: ""
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  leader:
+    replicas: 3
+    serviceType: ClusterIP
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: disktype
+      #         operator: In
+      #         values:
+      #         - ssd
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    nodeSelector: null
+      # memory: medium
+    securityContext: {}
+    pdb:
+      enabled: false
+      maxUnavailable: 1
+      minAvailable: 1
+
+  follower:
+    replicas: 3
+    serviceType: ClusterIP
+    affinity: null
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: disktype
+      #         operator: In
+      #         values:
+      #         - ssd
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    nodeSelector: null
+      # memory: medium
+    securityContext: {}
+    pdb:
+      enabled: false
+      maxUnavailable: 1
+      minAvailable: 1
+
+labels: {}
+#   foo: bar
+#   test: echo
+
+
+externalConfig:
+  enabled: false
+  data: |
+    tcp-keepalive 400
+    slowlog-max-len 158
+    stream-node-max-bytes 2048
+
+externalService:
+  enabled: false
+  # annotations:
+  #   foo: bar
+  serviceType: LoadBalancer
+  port: 6379
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  namespace: monitoring
+
+redisExporter:
+  enabled: false
+  image: quay.io/opstree/redis-exporter
+  tag: "v1.44.0"
+  imagePullPolicy: IfNotPresent
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  env: []
+    # - name: VAR_NAME
+    #   value: "value1"
+
+sidecars:
+  name: ""
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+  env: {}
+    # - name: MY_ENV_VAR
+    #   value: "my-env-var-value"
+
+initContainer:
+  enabled: false
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources: {}
+    # requests:
+    #   memory: "64Mi"
+    #   cpu: "250m"
+    # limits:
+    #   memory: "128Mi"
+    #   cpu: "500m"
+  env: []
+  command: []
+  args: []
+
+priorityClassName: ""
+
+storageSpec:
+  volumeClaimTemplate:
+    spec:
+      # storageClassName: standard
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+  nodeConfVolume: true
+  nodeConfVolumeClaimTemplate:
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+  #   selector: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+
+
+# serviceAccountName: redis-sa
+
+TLS:
+  ca: ca.key
+  cert: tls.crt
+  key: tls.key
+  secret:
+    secretName: ""
+
+acl:
+  secret:
+    secretName: ""
+
+env: []
+  # - name: VAR_NAME
+  #   value: "value1"
+
+serviceAccountName: ""

--- a/charts/redis-replication/.helmignore
+++ b/charts/redis-replication/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: redis-replication
+description: Provides easy redis setup definitions for Kubernetes services, and deployment.
+type: application
+engine: gotpl
+maintainers:
+  - name: iamabhishek-dubey
+  - name: sandy724
+  - name: shubham-cmyk
+sources:
+  - https://github.com/ot-container-kit/redis-operator
+version: 0.16.0
+appVersion: "0.16.0"
+home: https://github.com/ot-container-kit/redis-operator
+keywords:
+- operator
+- redis
+- opstree
+- kubernetes
+- openshift
+- redis-exporter
+icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg

--- a/charts/redis-replication/templates/_helpers.tpl
+++ b/charts/redis-replication/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Define common labels */}}
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: middleware
+{{- if .Values.labels }}
+{{- range $labelkey, $labelvalue := .Values.labels }}
+{{ $labelkey}}: {{ $labelvalue }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate init container properties */}}
+{{- define "initContainer.properties" -}}
+{{- with .Values.initContainer }}
+{{- if .enabled }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- if .command }}
+command:
+{{ toYaml .command | nindent 2 }}
+{{- end }}
+{{- if .args }}
+args:
+{{ toYaml .args | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate sidecar properties */}}
+{{- define "sidecar.properties" -}}
+{{- with .Values.sidecars }}
+name: {{ .name }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/redis-replication/templates/extra-config.yaml
+++ b/charts/redis-replication/templates/extra-config.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.externalConfig.enabled true }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.redisReplication.name | default .Release.Name }}-ext-config
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisReplication.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisReplication.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+data:
+  redis-additional.conf: |
+    {{ .Values.externalConfig.data | nindent 4 }}
+{{- end }}

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: {{ .Values.redisReplication.name | default .Release.Name }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+spec:
+  clusterSize: {{ .Values.redisReplication.clusterSize }}  
+  kubernetesConfig:
+    image: "{{ .Values.redisReplication.image }}:{{ .Values.redisReplication.tag }}"
+    imagePullPolicy: "{{ .Values.redisReplication.imagePullPolicy }}"
+    {{- if .Values.redisReplication.imagePullSecrets }}
+    imagePullSecrets: {{ toYaml .Values.redisReplication.imagePullSecrets | nindent 4 }}
+    {{- end }}
+    {{- if .Values.redisReplication.resources}}
+    resources: {{ toYaml .Values.redisReplication.resources | nindent 6 }}
+    {{- end }}
+    {{- if and .Values.redisReplication.redisSecret.secretName .Values.redisReplication.redisSecret.secretKey }}
+    redisSecret:
+      name: {{ .Values.redisReplication.redisSecret.secretName | quote }}
+      key: {{ .Values.redisReplication.redisSecret.secretKey | quote }}
+    {{- end }}
+    {{- if .Values.redisReplication.ignoreAnnotations}}
+    ignoreAnnotations: {{ toYaml .Values.redisReplication.ignoreAnnotations | nindent 6 }}
+    {{- end }}
+
+  redisExporter:
+    enabled: {{ .Values.redisExporter.enabled }}
+    image: "{{ .Values.redisExporter.image }}:{{ .Values.redisExporter.tag }}"
+    imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
+    {{- if .Values.redisExporter.resources}}
+    resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
+    {{- end }}  
+    {{- if .Values.redisExporter.env }}
+    env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
+    {{- end }}
+  
+  {{- if .Values.externalConfig.enabled }}
+    redisConfig:
+      additionalRedisConfig: "{{ .Values.redisReplication.name | default .Release.Name }}-ext-config"
+  {{- end }}
+  {{- if .Values.storageSpec }}
+  storage: {{ toYaml .Values.storageSpec | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSecurityContext }}
+  podSecurityContext: {{ toYaml .Values.podSecurityContext | nindent 4 }}
+  {{- end }}
+  {{- if .Values.securityContext }}
+  securityContext: {{ toYaml .Values.securityContext | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.priorityClassName (ne .Values.priorityClassName "") }}
+  priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+  {{- if .Values.affinity }}
+  affinity: {{ toYaml .Values.affinity | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
+  TLS:
+    ca: {{ .Values.TLS.ca | quote }}
+    cert: {{ .Values.TLS.cert | quote }}
+    key: {{ .Values.TLS.key | quote }}
+    secret:
+      secretName: {{ .Values.TLS.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
+  acl:
+    secret:
+      secretName: {{ .Values.acl.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
+  initContainer: {{ include "initContainer.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
+  sidecars: {{ include "sidecar.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
+  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  {{- end }}
+  {{- if .Values.env }}
+  env: {{ toYaml .Values.env | nindent 4 }}
+  {{- end }}
+  

--- a/charts/redis-replication/templates/replication-service.yaml
+++ b/charts/redis-replication/templates/replication-service.yaml
@@ -1,0 +1,29 @@
+{{- if eq .Values.externalService.enabled true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redisReplication.name | default .Release.Name }}-external-service
+{{- if .Values.externalService.annotations }}
+  annotations:
+{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisReplication.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisReplication.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  type: {{ .Values.externalService.serviceType }}
+  selector:
+    app: {{ .Values.redisReplication.name | default .Release.Name }}
+    redis_setup_type: replication
+    role: replication
+  ports:
+    - protocol: TCP
+      port: {{ .Values.externalService.port }}
+      targetPort: 6379
+      name: client
+{{- end }}

--- a/charts/redis-replication/templates/servicemonitor.yaml
+++ b/charts/redis-replication/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.serviceMonitor.enabled true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.redisReplication.name | default .Release.Name }}-prometheus-monitoring
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisReplication.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisReplication.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.redisReplication.name | default .Release.Name }}
+      redis_setup_type: replication
+      role: replication
+  endpoints:
+  - port: redis-exporter
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.serviceMonitor.namespace }}
+{{- end }}

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -1,0 +1,149 @@
+---
+redisReplication:
+  name: ""
+  clusterSize: 3
+  image: quay.io/opstree/redis
+  tag: v7.0.12
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+    # - name:  Secret with Registry credentials
+  redisSecret:
+    secretName: ""
+    secretKey: ""
+  serviceType: ClusterIP
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ignoreAnnotations: []
+    # - "redis.opstreelabs.in/ignore"
+
+# Overwite name for resources
+# name: ""
+
+labels: {}
+#   foo: bar
+#   test: echo
+
+externalConfig:
+  enabled: false
+  data: |
+    tcp-keepalive 400
+    slowlog-max-len 158
+    stream-node-max-bytes 2048
+
+externalService:
+  enabled: false
+  # annotations:
+  #   foo: bar
+  serviceType: NodePort
+  port: 6379
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  namespace: monitoring
+
+redisExporter:
+  enabled: false
+  image: quay.io/opstree/redis-exporter
+  tag: "v1.44.0"
+  imagePullPolicy: IfNotPresent
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  env: []
+    # - name: VAR_NAME
+    #   value: "value1"
+
+initContainer:
+  enabled: false
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources: {}
+    # requests:
+    #   memory: "64Mi"
+    #   cpu: "250m"
+    # limits:
+    #   memory: "128Mi"
+    #   cpu: "500m"
+  env: []
+  command: []
+  args: []
+
+sidecars:
+  name: ""
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+  env: []
+    # - name: MY_ENV_VAR
+    #   value: "my-env-var-value"
+
+priorityClassName: ""
+
+nodeSelector: {}
+  # memory: medium
+
+storageSpec:
+  volumeClaimTemplate:
+    spec:
+      # storageClassName: standard
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+  #   selector: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext: {}
+
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: disktype
+  #         operator: In
+  #         values:
+  #         - ssd
+
+tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+serviceAccountName: ""
+
+TLS:
+  ca: ca.key
+  cert: tls.crt
+  key: tls.key
+  secret:
+    secretName: ""
+
+acl:
+  secret:
+    secretName: ""
+
+env: []
+  # - name: VAR_NAME
+  #   value: "value1"

--- a/charts/redis-sentinel/.helmignore
+++ b/charts/redis-sentinel/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: redis-sentinel
+description: Provides easy redis setup definitions for Kubernetes services, and deployment.
+version: 0.16.0
+appVersion: "0.16.0"
+home: https://github.com/ot-container-kit/redis-operator
+sources:
+  - https://github.com/ot-container-kit/redis-operator
+maintainers:
+  - name: iamabhishek-dubey
+  - name: sandy724
+  - name: shubham-cmyk
+keywords:
+- operator
+- redis
+- opstree
+- kubernetes
+- openshift
+- redis-exporter
+icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
+type: application

--- a/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/redis-sentinel/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Define common labels */}}
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: middleware
+{{- if .Values.labels }}
+{{- range $labelkey, $labelvalue := .Values.labels }}
+{{ $labelkey}}: {{ $labelvalue }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate init container properties */}}
+{{- define "initContainer.properties" -}}
+{{- with .Values.initContainer }}
+{{- if .enabled }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- if .command }}
+command:
+{{ toYaml .command | nindent 2 }}
+{{- end }}
+{{- if .args }}
+args:
+{{ toYaml .args | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate sidecar properties */}}
+{{- define "sidecar.properties" -}}
+{{- with .Values.sidecars }}
+name: {{ .name }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/redis-sentinel/templates/extra-config.yaml
+++ b/charts/redis-sentinel/templates/extra-config.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.externalConfig.enabled true }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.redisSentinel.name | default .Release.Name }}-ext-config
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisSentinel.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisSentinel.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+data:
+  redis-sentinel-additional.conf: |
+    {{ .Values.externalConfig.data | nindent 4 }}
+{{- end }}

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisSentinel
+metadata:
+  name: {{ .Values.redisSentinel.name | default .Release.Name }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+spec:
+  clusterSize: {{ .Values.redisSentinel.clusterSize }}
+# Sentinel Config 
+  redisSentinelConfig:
+    redisReplicationName: {{ .Values.redisSentinelConfig.redisReplicationName}}
+    masterGroupName : {{ .Values.redisSentinelConfig.masterGroupName | default "myMaster" | quote}}
+    redisPort:  {{ .Values.redisSentinelConfig.redisPort | default "6379" | quote}}
+    quorum: {{ .Values.redisSentinelConfig.quorum | default "2" | quote}}
+    parallelSyncs: {{ .Values.redisSentinelConfig.parallelSyncs | default "1" | quote}}
+    failoverTimeout: {{ .Values.redisSentinelConfig.failoverTimeout | default "180000" | quote}}
+    downAfterMilliseconds:  {{ .Values.redisSentinelConfig.downAfterMilliseconds | default "30000" | quote}}
+    {{- if eq .Values.externalConfig.enabled true }}
+    additionalSentinelConfig: {{ .Values.redisSentinel.name | default .Release.Name }}-ext-config
+    {{- end }}
+
+  kubernetesConfig:
+    image: "{{ .Values.redisSentinel.image }}:{{ .Values.redisSentinel.tag }}"
+    imagePullPolicy: "{{ .Values.redisSentinel.imagePullPolicy }}"
+    {{- if .Values.redisSentinel.imagePullSecrets }}
+    imagePullSecrets: {{ toYaml .Values.redisSentinel.imagePullSecrets | nindent 4 }}
+    {{- end }}
+    {{- if .Values.redisSentinel.resources}}
+    resources: {{ toYaml .Values.redisSentinel.resources | nindent 6 }}
+    {{- end }}
+    {{- if and .Values.redisSentinel.redisSecret.secretName .Values.redisSentinel.redisSecret.secretKey }}
+    redisSecret:
+      name: {{ .Values.redisSentinel.redisSecret.secretName | quote }}
+      key: {{ .Values.redisSentinel.redisSecret.secretKey | quote }}
+    {{- end }}
+    {{- if .Values.redisSentinel.ignoreAnnotations}}
+    ignoreAnnotations: {{ toYaml .Values.redisSentinel.ignoreAnnotations | nindent 6 }}
+    {{- end }}
+
+  redisExporter:
+    enabled: {{ .Values.redisExporter.enabled }}
+    image: "{{ .Values.redisExporter.image }}:{{ .Values.redisExporter.tag }}"
+    imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
+    {{- if .Values.redisExporter.resources}}
+    resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
+    {{- end }}  
+    {{- if .Values.redisExporter.env }}
+    env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
+    {{- end }}
+  
+  {{- if .Values.externalConfig.enabled }}
+    redisConfig:
+      additionalRedisConfig: "{{ .Values.redisSentinel.name | default .Release.Name }}-ext-config"
+  {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSecurityContext }}
+  podSecurityContext: {{ toYaml .Values.podSecurityContext | nindent 4 }}
+  {{- end }}
+  {{- if .Values.securityContext }}
+  securityContext: {{ toYaml .Values.securityContext | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.priorityClassName (ne .Values.priorityClassName "") }}
+  priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+  {{- if .Values.affinity }}
+  affinity: {{ toYaml .Values.affinity | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
+  TLS:
+    ca: {{ .Values.TLS.ca | quote }}
+    cert: {{ .Values.TLS.cert | quote }}
+    key: {{ .Values.TLS.key | quote }}
+    secret:
+      secretName: {{ .Values.TLS.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
+  acl:
+    secret:
+      secretName: {{ .Values.acl.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
+  initContainer: {{ include "initContainer.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
+  sidecars: {{ include "sidecar.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
+  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  {{- end }}
+  {{- if .Values.env }}
+  env: {{ toYaml .Values.env | nindent 4 }}
+  {{- end }}

--- a/charts/redis-sentinel/templates/service.yaml
+++ b/charts/redis-sentinel/templates/service.yaml
@@ -1,0 +1,29 @@
+{{- if eq .Values.externalService.enabled true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redisSentinel.name | default .Release.Name }}-external-service
+{{- if .Values.externalService.annotations }}
+  annotations:
+{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisSentinel.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisSentinel.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  type: {{ .Values.externalService.serviceType }}
+  selector:
+    app: {{ .Values.redisSentinel.name | default .Release.Name }}
+    redis_setup_type: sentinel
+    role: sentinel
+  ports:
+    - protocol: TCP
+      port: {{ .Values.externalService.port }}
+      targetPort: 26379
+      name: client
+{{- end }}

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -1,0 +1,148 @@
+---
+redisSentinel:
+  name: ""
+  clusterSize: 3
+  image: quay.io/opstree/redis-sentinel
+  tag: v7.0.12
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+    # - name:  Secret with Registry credentials
+  redisSecret:
+    secretName: ""
+    secretKey: ""
+  serviceType: ClusterIP
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ignoreAnnotations: []
+    # - "redis.opstreelabs.in/ignore"
+
+# Overwite name for resources
+# name: ""
+
+labels: {}
+#   foo: bar
+#   test: echo
+
+redisSentinelConfig:
+  redisReplicationName: "redis-replication"
+  masterGroupName: ""
+  redisPort: ""
+  quorum: ""
+  parallelSyncs: ""
+  failoverTimeout: ""
+  downAfterMilliseconds: ""
+
+externalConfig:
+  enabled: false
+  data: |
+    tcp-keepalive 400
+    slowlog-max-len 158
+    stream-node-max-bytes 2048
+
+externalService:
+  enabled: false
+  # annotations:
+  #   foo: bar
+  serviceType: NodePort
+  port: 26379
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  namespace: monitoring
+
+redisExporter:
+  enabled: false
+  image: quay.io/opstree/redis-exporter
+  tag: "v1.44.0"
+  imagePullPolicy: IfNotPresent
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  env: []
+    # - name: VAR_NAME
+    #   value: "value1"
+
+initContainer:
+  enabled: false
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources: {}
+    # requests:
+    #   memory: "64Mi"
+    #   cpu: "250m"
+    # limits:
+    #   memory: "128Mi"
+    #   cpu: "500m"
+  env: []
+  command: []
+  args: []
+
+sidecars:
+  name: ""
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+  env: []
+    # - name: MY_ENV_VAR
+    #   value: "my-env-var-value"
+
+priorityClassName: ""
+
+nodeSelector: {}
+  # memory: medium
+
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext: {}
+
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: disktype
+  #         operator: In
+  #         values:
+  #         - ssd
+
+tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+serviceAccountName: ""
+
+TLS:
+  ca: ca.key
+  cert: tls.crt
+  key: tls.key
+  secret:
+    secretName: ""
+
+acl:
+  secret:
+    secretName: ""
+
+env: []
+  # - name: VAR_NAME
+  #   value: "value1"

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v2
+name: redis
+description: Provides easy redis setup definitions for Kubernetes services, and deployment.
+version: 0.16.0
+appVersion: "0.16.0"
+home: https://github.com/ot-container-kit/redis-operator
+sources:
+  - https://github.com/ot-container-kit/redis-operator
+maintainers:
+  - name: iamabhishek-dubey
+  - name: sandy724
+  - name: shubham-cmyk
+keywords:
+- operator
+- redis
+- opstree
+- kubernetes
+- openshift
+- redis-exporter
+icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
+type: application

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,0 +1,60 @@
+# Redis
+
+Redis is a key-value based distributed database, this helm chart is for only standalone setup. This helm chart needs [Redis Operator](../redis-operator) inside Kubernetes cluster. The redis definition can be modified or changed by [values.yaml](./values.yaml).
+
+```shell
+helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
+helm install <my-release> ot-helm/redis --namespace <namespace>
+```
+
+Redis setup can be upgraded by using `helm upgrade` command:-
+
+```shell
+helm upgrade <my-release> ot-helm/redis --install --namespace <namespace>
+```
+
+For uninstalling the chart:-
+
+```shell
+helm delete <my-release> --namespace <namespace>
+```
+
+## Pre-Requisities
+
+- Kubernetes 1.15+
+- Helm 3.X
+- Redis Operator 0.7.0
+
+## Parameters
+
+| **Name**                          | **Value**                      | **Description**                                                                               |
+|-----------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------|
+| `imagePullSecrets`                | []                             | List of image pull secrets, in case redis image is getting pull from private registry         |
+| `redisStandalone.secretName`      | redis-secret                   | Name of the existing secret in Kubernetes                                                     |
+| `redisStandalone.secretKey`       | password                       | Name of the existing secret key in Kubernetes                                                 |
+| `redisStandalone.image`           | quay.io/opstree/redis          | Name of the redis image                                                                       |
+| `redisStandalone.tag`             | v6.2                           | Tag of the redis image                                                                        |
+| `redisStandalone.imagePullPolicy` | IfNotPresent                   | Image Pull Policy of the redis image                                                          |
+| `redisStandalone.serviceType`     | ClusterIP                      | Kubernetes service type for Redis                                                             |
+| `redisStandalone.resources`       | {}                             | Request and limits for redis statefulset                                                      |
+| `redisStandalone.name`                            | ""                             | Overwrites the name for the charts resources instead of the Release name |
+| `externalService.enabled`         | false                          | If redis service needs to be exposed using LoadBalancer or NodePort                           |
+| `externalService.annotations`     | {}                             | Kubernetes service related annotations                                                        |
+| `externalService.serviceType`     | NodePort                       | Kubernetes service type for exposing service, values - ClusterIP, NodePort, and LoadBalancer  |
+| `externalService.port`            | 6379                           | Port number on which redis external service should be exposed                                 |
+| `serviceMonitor.enabled`          | false                          | Servicemonitor to monitor redis with Prometheus                                               |
+| `serviceMonitor.interval`         | 30s                            | Interval at which metrics should be scraped.                                                  |
+| `serviceMonitor.scrapeTimeout`    | 10s                            | Timeout after which the scrape is ended                                                       |
+| `serviceMonitor.namespace`        | monitoring                     | Namespace in which Prometheus operator is running                                             |
+| `redisExporter.enabled`           | true                           | Redis exporter should be deployed or not                                                      |
+| `redisExporter.image`             | quay.io/opstree/redis-exporter | Name of the redis exporter image                                                              |
+| `redisExporter.tag`               | v6.2                           | Tag of the redis exporter image                                                               |
+| `redisExporter.imagePullPolicy`   | IfNotPresent                   | Image Pull Policy of the redis exporter image                                                 |
+| `redisExporter.env`               | []                             | Extra environment variables which needs to be added in redis exporter                         |
+| `sidecars`                        | []                             | Sidecar for redis pods                                                                        |
+| `nodeSelector`                    | {}                             | NodeSelector for redis statefulset                                                            |
+| `priorityClassName`               | ""                             | Priority class name for the redis statefulset                                                 |
+| `storageSpec`                     | {}                             | Storage configuration for redis setup                                                         |
+| `securityContext`                 | {}                             | Security Context for redis pods for changing system or kernel level parameters                |
+| `affinity`                        | {}                             | Affinity for node and pod for redis statefulset                                               |
+| `tolerations`                     | []                             | Tolerations for redis statefulset                                                             |

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Define common labels */}}
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ .Values.redisStandalone.name | default .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: middleware
+{{- if .Values.labels }}
+{{- range $labelkey, $labelvalue := .Values.labels }}
+{{ $labelkey}}: {{ $labelvalue }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate init container properties */}}
+{{- define "initContainer.properties" -}}
+{{- with .Values.initContainer }}
+{{- if .enabled }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- if .command }}
+command:
+{{ toYaml .command | nindent 2 }}
+{{- end }}
+{{- if .args }}
+args:
+{{ toYaml .args | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate sidecar properties */}}
+{{- define "sidecar.properties" -}}
+{{- with .Values.sidecars }}
+name: {{ .name }}
+image: {{ .image }}
+{{- if .imagePullPolicy }}
+imagePullPolicy: {{ .imagePullPolicy }}
+{{- end }}
+{{- if .resources }}
+resources:
+  {{ toYaml .resources | nindent 2 }}
+{{- end }}
+{{- if .env }}
+env:
+{{ toYaml .env | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/redis/templates/extra-config.yaml
+++ b/charts/redis/templates/extra-config.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.externalConfig.enabled true }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.redisStandalone.name | default .Release.Name }}-ext-config
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisStandalone.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+data:
+  redis-additional.conf: |
+    {{ .Values.externalConfig.data | nindent 4 }}
+{{- end }}

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name:  {{ .Values.redisStandalone.name | default .Release.Name }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+spec:
+  kubernetesConfig:
+    image: "{{ .Values.redisStandalone.image }}:{{ .Values.redisStandalone.tag }}"
+    imagePullPolicy: "{{ .Values.redisStandalone.imagePullPolicy }}"
+    {{- if .Values.redisStandalone.imagePullSecrets }}
+    imagePullSecrets: {{ toYaml .Values.redisStandalone.imagePullSecrets | nindent 4 }}
+    {{- end }}
+    {{- if .Values.redisStandalone.resources}}
+    resources: {{ toYaml .Values.redisStandalone.resources | nindent 6 }}
+    {{- end }}
+    {{- if and .Values.redisStandalone.redisSecret.secretName .Values.redisStandalone.redisSecret.secretKey }}
+    redisSecret:
+      name: {{ .Values.redisStandalone.redisSecret.secretName | quote }}
+      key: {{ .Values.redisStandalone.redisSecret.secretKey | quote }}
+    {{- end }}
+    {{- if .Values.redisStandalone.ignoreAnnotations}}
+    ignoreAnnotations: {{ toYaml .Values.redisStandalone.ignoreAnnotations | nindent 6 }}
+    {{- end }}
+
+  redisExporter:
+    enabled: {{ .Values.redisExporter.enabled }}
+    image: "{{ .Values.redisExporter.image }}:{{ .Values.redisExporter.tag }}"
+    imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
+    {{- if .Values.redisExporter.resources}}
+    resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
+    {{- end }}  
+    {{- if .Values.redisExporter.env }}
+    env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
+    {{- end }}
+  
+  {{- if .Values.externalConfig.enabled }}
+    redisConfig:
+      additionalRedisConfig: "{{ .Values.redisStandalone.name | default .Release.Name }}-ext-config"
+  {{- end }}
+  {{- if .Values.storageSpec }}
+  storage: {{ toYaml .Values.storageSpec | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSecurityContext }}
+  podSecurityContext: {{ toYaml .Values.podSecurityContext | nindent 4 }}
+  {{- end }}
+  {{- if .Values.securityContext }}
+  securityContext: {{ toYaml .Values.securityContext | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.priorityClassName (ne .Values.priorityClassName "") }}
+  priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+  {{- if .Values.affinity }}
+  affinity: {{ toYaml .Values.affinity | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
+  TLS:
+    ca: {{ .Values.TLS.ca | quote }}
+    cert: {{ .Values.TLS.cert | quote }}
+    key: {{ .Values.TLS.key | quote }}
+    secret:
+      secretName: {{ .Values.TLS.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
+  acl:
+    secret:
+      secretName: {{ .Values.acl.secret.secretName | quote }}
+  {{- end }}
+  {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
+  initContainer: {{ include "initContainer.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
+  sidecars: {{ include "sidecar.properties" | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
+  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  {{- end }}
+  {{- if .Values.env }}
+  env: {{ toYaml .Values.env | nindent 4 }}
+  {{- end }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -1,0 +1,29 @@
+{{- if eq .Values.externalService.enabled true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redisStandalone.name | default .Release.Name }}-external-service
+{{- if .Values.externalService.annotations }}
+  annotations:
+{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisStandalone.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  type: {{ .Values.externalService.serviceType }}
+  selector:
+    app: {{ .Values.redisStandalone.name | default .Release.Name }}
+    redis_setup_type: standalone
+    role: standalone
+  ports:
+    - protocol: TCP
+      port: {{ .Values.externalService.port }}
+      targetPort: 6379
+      name: client
+{{- end }}

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.serviceMonitor.enabled true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.redisStandalone.name | default .Release.Name }}-prometheus-monitoring
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisStandalone.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.redisStandalone.name | default .Release.Name }}
+      redis_setup_type: standalone
+      role: standalone
+  endpoints:
+  - port: redis-exporter
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.serviceMonitor.namespace }}
+{{- end }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -1,0 +1,145 @@
+---
+redisStandalone:
+  name: ""
+  image: quay.io/opstree/redis
+  tag: v7.0.12
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+    # - name:  Secret with Registry credentials
+  redisSecret:
+    secretName: ""
+    secretKey: ""
+  serviceType: ClusterIP
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ignoreAnnotations: []
+    # - "redis.opstreelabs.in/ignore"
+
+labels: {}
+#   foo: bar
+#   test: echo
+
+externalConfig:
+  enabled: false
+  data: |
+    tcp-keepalive 400
+    slowlog-max-len 158
+    stream-node-max-bytes 2048
+
+externalService:
+  enabled: false
+  # annotations:
+  #   foo: bar
+  serviceType: NodePort
+  port: 6379
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  namespace: monitoring
+
+redisExporter:
+  enabled: false
+  image: quay.io/opstree/redis-exporter
+  tag: "v1.44.0"
+  imagePullPolicy: IfNotPresent
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  env: []
+    # - name: VAR_NAME
+    #   value: "value1"
+
+initContainer:
+  enabled: false
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources: {}
+    # requests:
+    #   memory: "64Mi"
+    #   cpu: "250m"
+    # limits:
+    #   memory: "128Mi"
+    #   cpu: "500m"
+  env: []
+  command: []
+  args: []
+
+sidecars:
+  name: ""
+  image: ""
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+  env: []
+    # - name: MY_ENV_VAR
+    #   value: "my-env-var-value"
+
+priorityClassName: ""
+
+nodeSelector: {}
+  # memory: medium
+
+storageSpec:
+  volumeClaimTemplate:
+    spec:
+      # storageClassName: standard
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+  #   selector: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext: {}
+
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: disktype
+  #         operator: In
+  #         values:
+  #         - ssd
+
+tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+serviceAccountName: ""
+
+TLS:
+  ca: ca.key
+  cert: tls.crt
+  key: tls.key
+  secret:
+    secretName: ""
+
+acl:
+  secret:
+    secretName: ""
+
+env: []
+  # - name: VAR_NAME
+  #   value: "value1"


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
This pull request adds the Redis/RedisReplication/RedisSentinel/RedisCluster chart, which was migrated from https://github.com/OT-CONTAINER-KIT/helm-charts. This enables us to manage the related resources more effectively.

NOTICE: The user interface remains the same as usual.

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
