### PR TITLE
fix: bad indentation on redis standalone additional configs

### DIFF
--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -25,21 +25,21 @@ spec:
     {{- if .Values.redisStandalone.minReadySeconds }}
     minReadySeconds: {{ .Values.redisStandalone.minReadySeconds }}
     {{- end }}
-    
+
   redisExporter:
     enabled: {{ .Values.redisExporter.enabled }}
     image: "{{ .Values.redisExporter.image }}:{{ .Values.redisExporter.tag }}"
     imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
     {{- if .Values.redisExporter.resources}}
     resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
-    {{- end }}  
+    {{- end }}
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
-  
+
   {{- if .Values.externalConfig.enabled }}
-    redisConfig:
-      additionalRedisConfig: "{{ .Values.redisStandalone.name | default .Release.Name }}-ext-config"
+  redisConfig:
+    additionalRedisConfig: "{{ .Values.redisStandalone.name | default .Release.Name }}-ext-config"
   {{- end }}
   {{- if .Values.storageSpec }}
   storage: {{ toYaml .Values.storageSpec | nindent 4 }}


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The standalone redis template had the incorrect indentation for additionalRedisConfig. As a result any external configs passed through the helm chart were not added to the redis manifest and apply.  A simple indentation fix is all that was needed.


**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

