### PR TITLE
feat: add image pull secret for redis operator

### DIFF
--- a/charts/redis-operator/templates/operator-deployment.yaml
+++ b/charts/redis-operator/templates/operator-deployment.yaml
@@ -22,6 +22,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: {{ .Values.redisOperator.automountServiceAccountToken }}
+      {{- if .Values.redisOperator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.redisOperator.imagePullSecrets | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -5,6 +5,7 @@ redisOperator:
   # Overrides the image tag whose default is the chart appVersion.
   imageTag: ""
   imagePullPolicy: Always
+  imagePullSecrets: []
 
   # Additional pod annotations
   podAnnotations: {}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

This PR introduces the addition of imagePullSecrets support in the redis-operator Helm chart. This allows users to specify image pull secrets, which is essential for pulling images from private Docker registries.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
