### PR TITLE
chore: update redis-operator chart version to 0.18.3

### DIFF
--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.18.2
+version: 0.18.3
 appVersion: "0.18.0"
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
 engine: gotpl


### PR DESCRIPTION
Signed-off-by: Shubham Gupta <iamshubhamgupta2001@gmail.com>

