### PR TITLE
fix: Attempt to repair disconnected/failed master nodes before failing over

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 ARG BUILDOS
 ARG BUILDPLATFORM
 ARG BUILDARCH

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ manifests: controller-gen
 fmt:
 	go fmt ./...
 
+lint: golangci-lint
+	$(GOLANGCI_LINT) run
+
 # Run go vet against code
 vet:
 	go vet ./...

--- a/api/status/redis-cluster_status.go
+++ b/api/status/redis-cluster_status.go
@@ -14,6 +14,6 @@ const (
 	RedisClusterInitializing RedisClusterState = "Initializing"
 	RedisClusterBootstrap    RedisClusterState = "Bootstrap"
 	// RedisClusterReady means the RedisCluster is ready for use, we use redis-cli --cluster check 127.0.0.1:6379 to check the cluster status
-	RedisClusterReady RedisClusterState = "Ready"
-	// RedisClusterFailed       RedisClusterState = "Failed"
+	RedisClusterReady  RedisClusterState = "Ready"
+	RedisClusterFailed RedisClusterState = "Failed"
 )

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 
 require (
 	emperror.dev/errors v0.8.0 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/controllers/rediscluster/rediscluster_controller.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller.go
@@ -18,12 +18,14 @@ package rediscluster
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/api/status"
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/pkg/controllerutil"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/k8sutils"
+	retry "github.com/avast/retry-go"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -186,11 +188,34 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return intctrlutil.RequeueAfter(reqLogger, time.Second*60, "Redis cluster count is not desired", "Current.Count", nc, "Desired.Count", totalReplicas)
 	}
 
-	reqLogger.Info("Redis cluster count is desired")
-	if int(totalReplicas) > 1 && k8sutils.CheckRedisClusterState(ctx, r.K8sClient, r.Log, instance) >= int(totalReplicas)-1 {
-		reqLogger.Info("Redis leader is not desired, executing failover operation")
-		err = k8sutils.ExecuteFailoverOperation(ctx, r.K8sClient, r.Log, instance)
-		if err != nil {
+	reqLogger.Info("Number of Redis nodes match desired")
+	unhealthyNodeCount, err := k8sutils.UnhealthyNodesInCluster(ctx, r.K8sClient, r.Log, instance)
+	if err != nil {
+		reqLogger.Error(err, "failed to determine unhealthy node count in cluster")
+	}
+	if int(totalReplicas) > 1 && unhealthyNodeCount >= int(totalReplicas)-1 {
+		reqLogger.Info("healthy leader count does not match desired; attempting to repair disconnected masters")
+		if err = k8sutils.RepairDisconnectedMasters(ctx, r.K8sClient, r.Log, instance); err != nil {
+			reqLogger.Error(err, "failed to repair disconnected masters")
+		}
+
+		err = retry.Do(func() error {
+			nc, nErr := k8sutils.UnhealthyNodesInCluster(ctx, r.K8sClient, r.Log, instance)
+			if nErr != nil {
+				return nErr
+			}
+			if nc == 0 {
+				return nil
+			}
+			return fmt.Errorf("%d unhealthy nodes", nc)
+		}, retry.Attempts(3), retry.Delay(time.Second*5))
+
+		if err == nil {
+			reqLogger.Info("repairing unhealthy masters successful, no unhealthy masters left")
+			return intctrlutil.RequeueAfter(reqLogger, time.Second*30, "no unhealthy nodes found after repairing disconnected masters")
+		}
+		reqLogger.Info("unhealthy nodes exist after attempting to repair disconnected masters; starting failover")
+		if err = k8sutils.ExecuteFailoverOperation(ctx, r.K8sClient, r.Log, instance); err != nil {
 			return intctrlutil.RequeueWithError(err, reqLogger, "")
 		}
 	}

--- a/pkg/controllers/rediscluster/rediscluster_controller.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller.go
@@ -194,7 +194,6 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		reqLogger.Error(err, "failed to determine unhealthy node count in cluster")
 	}
 	if int(totalReplicas) > 1 && unhealthyNodeCount >= int(totalReplicas)-1 {
-
 		err = k8sutils.UpdateRedisClusterStatus(instance, status.RedisClusterFailed, "RedisCluster has too many unhealthy nodes", leaderReplicas, followerReplicas, r.Dk8sClient)
 		if err != nil {
 			return intctrlutil.RequeueWithError(err, reqLogger, "")

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   execution:
     failFast: true
-    parallel: 100
   cleanup:
     delayBeforeCleanup: 10s
   timeouts:

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -8,7 +8,8 @@ spec:
   execution:
     failFast: true
     parallel: 100
-  delayBeforeCleanup: 10s
+  cleanup:
+    delayBeforeCleanup: 10s
   timeouts:
     apply: 5m
     delete: 5m

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -5,6 +5,9 @@ kind: Configuration
 metadata:
   name: chainsaw-configuration
 spec:
+  execution:
+    failFast: true
+    parallel: 100
   delayBeforeCleanup: 10s
   timeouts:
     apply: 5m

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
+apiVersion: chainsaw.kyverno.io/v1alpha2
 kind: Configuration
 metadata:
   name: chainsaw-configuration

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/chainsaw-test.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: redis-cluster
+spec:
+  steps:
+    - try:
+        - apply:
+            file: cluster.yaml
+        - assert:
+            file: ready-cluster.yaml
+
+    - name: Try saving a key With Password
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} --container redis-cluster-v1beta2-leader redis-cluster-v1beta2-leader-0 --
+              redis-cli -c set foo-0 bar-0
+            check:
+              (contains($stdout, 'OK')): true
+
+    - name: Restart pods at same time
+      try:
+          - script:
+              timeout: 30s
+              content: >
+                kubectl delete pod --namespace ${NAMESPACE} -l app=redis-cluster-v1beta2-leader
+
+    - name: Wait cluster to be failed
+      try:
+        - assert:
+            file: failed-cluster.yaml
+
+    - name: Wait cluster to be ready
+      try:
+        - assert:
+            file: ready-cluster.yaml
+
+    - name: Get key
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} --container redis-cluster-v1beta2-leader redis-cluster-v1beta2-leader-0 --
+              redis-cli -c get foo-0
+            check:
+              (contains($stdout, 'bar-0')): true
+

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/chainsaw-test.yaml
@@ -24,10 +24,10 @@ spec:
 
     - name: Restart pods at same time
       try:
-          - script:
-              timeout: 30s
-              content: >
-                kubectl delete pod --namespace ${NAMESPACE} -l app=redis-cluster-v1beta2-leader
+        - script:
+            timeout: 30s
+            content: >
+              kubectl delete pod --namespace ${NAMESPACE} -l app=redis-cluster-v1beta2-leader
 
     - name: Wait cluster to be failed
       try:
@@ -48,4 +48,3 @@ spec:
               redis-cli -c get foo-0
             check:
               (contains($stdout, 'bar-0')): true
-

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  redisLeader:
+    replicas: 3
+  redisFollower:
+    replicas: 0
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  redisExporter:
+    enabled: true
+    image: quay.io/opstree/redis-exporter:v1.44.0
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/failed-cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/failed-cluster.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  state: Failed

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/ready-cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/ready-cluster.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  state: Ready
+  reason: RedisCluster is ready


### PR DESCRIPTION
ended up closing https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1101 as I was forgetting to sign commits and the git history was getting out of control with having to rebase

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1100

As stated in the above issue, a cluster that has unhealthy leaders as the result of being scaled to zero nodes can be recovered from without having to issue a failover (which leads to data loss).

The failed/disconnected nodes simply need to have their address updated with the IP of the new leader pods.  `CLUSTER MEET` is able to map the address specified to the existing host & port, meaning we don't need to wipe the master & start afresh. If this fails, we fall back to the failover.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

This is a best-effort attempt 

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.


If new strategy fails, failover still works as expected
```
{"level":"info","ts":"2024-10-13T19:26:29Z","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:31Z","logger":"controllers.RedisCluster","msg":"Number of Redis nodes match desired","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:31Z","logger":"controllers.RedisCluster","msg":"healthy leader count does not match desired; attempting to repair disconnected masters","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:41Z","logger":"controllers.RedisCluster","msg":"unhealthy nodes exist after attempting to repair disconnected masters; starting failover","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:52Z","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:53Z","logger":"controllers.RedisCluster","msg":"Creating redis cluster by executing cluster creation commands","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:26:53Z","logger":"controllers.RedisCluster","msg":"Not all leader are part of the cluster...","Request.Namespace":"default","Request.Name":"redis-cluster","Leaders.Count":1,"Instance.Size":3}
{"level":"info","ts":"2024-10-13T19:27:58Z","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T19:27:59Z","logger":"controllers.RedisCluster","msg":"Number of Redis nodes match desired","Request.Namespace":"default","Request.Name":"redis-cluster"}
```

and new strategy working as expected

```
# existing data
nash:~/code/redis-operator$ k exec redis-cluster-leader-2 -- redis-cli -c get k1
v1

# scale down statefulset & operator
nash:~/code/redis-operator$ k scale -n redis-operator-system deploy -l control-plane=redis-operator --replicas=0
deployment.apps/redis-operator-redis-operator scaled
nash:~/code/redis-operator$ k scale sts redis-cluster-leader --replicas=0
statefulset.apps/redis-cluster-leader scaled

# scale back up
nash:~/code/redis-operator$ k scale sts redis-cluster-leader --replicas=3
statefulset.apps/redis-cluster-leader scaled
nash:~/code/redis-operator$ k scale -n redis-operator-system deploy -l control-plane=redis-operator --replicas=1
deployment.apps/redis-operator-redis-operator scaled

# observe data persisted
nash:~/code/redis-operator$ k exec redis-cluster-leader-2 -- redis-cli -c get k1
v1
```

corresponding logs 
```
{"level":"info","ts":"2024-10-13T20:04:11Z","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T20:04:14Z","logger":"controllers.RedisCluster","msg":"Number of Redis nodes match desired","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T20:04:14Z","logger":"controllers.RedisCluster","msg":"healthy leader count does not match desired; attempting to repair disconnected masters","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T20:04:19Z","logger":"controllers.RedisCluster","msg":"repairing unhealthy masters successful, no unhealthy masters left","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T20:04:49Z","logger":"controllers.RedisCluster","msg":"Reconciling opstree redis Cluster controller","Request.Namespace":"default","Request.Name":"redis-cluster"}
{"level":"info","ts":"2024-10-13T20:04:50Z","logger":"controllers.RedisCluster","msg":"Number of Redis nodes match desired","Request.Namespace":"default","Request.Name":"redis-cluster"}
```

**Additional Context**

There's a small bit of refactoring too
- define type for `CLUSTER NODES` response for a bit more safety on helper functions 
- extract some common functionality that operates on above type, ie `nodeFailedOrDisconnected` and ` nodeIsOfType`
- renames some functions to better represent what they do