### PR TITLE
feat: add PDB and probes, drop unspecified acl in sentinel helm

### DIFF
--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -48,7 +48,6 @@ helm delete <my-release> --namespace <namespace>
 | TLS.cert | string | `"tls.crt"` |  |
 | TLS.key | string | `"tls.key"` |  |
 | TLS.secret.secretName | string | `""` |  |
-| acl.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
@@ -64,10 +63,23 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
+| livenessProbe.failureThreshold | int | `3` |  |
+| livenessProbe.initialDelaySeconds | int | `1` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
+| pdb.enabled | bool | `false` |  |
+| pdb.maxUnavailable | string | `nil` |  |
+| pdb.minAvailable | int | `1` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | priorityClassName | string | `""` |  |
+| readinessProbe.failureThreshold | int | `3` |  |
+| readinessProbe.initialDelaySeconds | int | `1` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
 | redisExporter.enabled | bool | `false` |  |
 | redisExporter.env | list | `[]` |  |
 | redisExporter.image | string | `"quay.io/opstree/redis-exporter"` |  |

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "common.labels" . | nindent 4 }}
 spec:
   clusterSize: {{ .Values.redisSentinel.clusterSize }}
-# Sentinel Config 
+  # Sentinel Config
   redisSentinelConfig:
     redisReplicationName: {{ .Values.redisSentinelConfig.redisReplicationName}}
     {{- if and .Values.redisSentinelConfig.redisReplicationPassword.secretName .Values.redisSentinelConfig.redisReplicationPassword.secretKey }}
@@ -52,11 +52,11 @@ spec:
     imagePullPolicy: "{{ .Values.redisExporter.imagePullPolicy }}"
     {{- if .Values.redisExporter.resources}}
     resources: {{ toYaml .Values.redisExporter.resources | nindent 6 }}
-    {{- end }}  
+    {{- end }}
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
-  
+
   {{- if .Values.nodeSelector }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   {{- end }}
@@ -83,10 +83,19 @@ spec:
     secret:
       secretName: {{ .Values.TLS.secret.secretName | quote }}
   {{- end }}
-  {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
-  acl:
-    secret:
-      secretName: {{ .Values.acl.secret.secretName | quote }}
+  {{- if .Values.pdb.enabled }}
+  pdb:
+    enabled: {{ .enabled }}
+    minAvailable: {{ .minAvailable }}
+    maxUnavailable: {{ .maxUnavailable }}
+  {{- end }}
+  {{- with .Values.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
   initContainer: {{ include "initContainer.properties" | nindent 4 }}

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -21,7 +21,7 @@ redisSentinel:
   ignoreAnnotations: []
     # - "redis.opstreelabs.in/ignore"
   minReadySeconds: 0
-  
+
 # Overwite name for resources
 # name: ""
 
@@ -143,9 +143,24 @@ TLS:
   secret:
     secretName: ""
 
-acl:
-  secret:
-    secretName: ""
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: null
+
+livenessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
 
 env: []
   # - name: VAR_NAME


### PR DESCRIPTION
**Description**

This pull request includes several updates to the Redis Sentinel Helm chart, focusing on the removal of ACL-related configuration and the addition of Pod Disruption Budget (PDB) and probe configurations.


* Removal of ACL Configuration
  * Redis Sentinel [does not support](https://github.com/OT-CONTAINER-KIT//redis-operator/blob/909d9e4a7fceee98c6e7e5f43efc95882869cde5/api/v1beta2/redissentinel_types.go#L9-L32) ACL
* Added PDB and probe configuration options (`livenessProbe`, `readinessProbe`) to `charts/redis-sentinel/README.md`.
* Added PDB and probe configuration blocks to `charts/redis-sentinel/templates/redis-sentinel.yaml`.
* Added PDB and probe configuration defaults to `charts/redis-sentinel/values.yaml`.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

The probe values were taken from the in-cluster rendered defaults for our RedisSentinel deployment.

In addition, I was wondering if there are any plans to support a PDB for redis-replication.