### PR TITLE
fix: initContainer enabled properties not define in template

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.3
-appVersion: "0.16.3"
+version: 0.16.4
+appVersion: "0.16.4"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -64,6 +64,7 @@ env:
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}
 {{- if .enabled }}
+enabled: {{ .enabled }}
 image: {{ .image }}
 {{- if .imagePullPolicy }}
 imagePullPolicy: {{ .imagePullPolicy }}

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.5
-appVersion: "0.16.5"
+version: 0.16.6
+appVersion: "0.16.6"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/templates/_helpers.tpl
+++ b/charts/redis-replication/templates/_helpers.tpl
@@ -19,6 +19,7 @@ app.kubernetes.io/component: middleware
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}
 {{- if .enabled }}
+enabled: {{ .enabled }}
 image: {{ .image }}
 {{- if .imagePullPolicy }}
 imagePullPolicy: {{ .imagePullPolicy }}

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-sentinel
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.7
-appVersion: "0.16.7"
+version: 0.16.8
+appVersion: "0.16.8"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/redis-sentinel/templates/_helpers.tpl
@@ -19,6 +19,7 @@ app.kubernetes.io/component: middleware
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}
 {{- if .enabled }}
+enabled: {{ .enabled }}
 image: {{ .image }}
 {{- if .imagePullPolicy }}
 imagePullPolicy: {{ .imagePullPolicy }}

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: redis
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.3
-appVersion: "0.16.3"
+version: 0.16.4
+appVersion: "0.16.4"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -19,6 +19,7 @@ app.kubernetes.io/component: middleware
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}
 {{- if .enabled }}
+enabled: {{ .enabled }}
 image: {{ .image }}
 {{- if .imagePullPolicy }}
 imagePullPolicy: {{ .imagePullPolicy }}


### PR DESCRIPTION
- Bumped version and appVersion for redis, redis-cluster, redis-replication, and redis-sentinel charts to 0.16.4, 0.16.4, 0.16.6, and 0.16.8 respectively.
- Enhanced initContainer properties in templates to include the 'enabled' field for better configuration management.

This update ensures consistency across the Redis charts and improves template rendering.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1147 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
