### PR TITLE
feat: enhance RedisCluster resource management by introducing separate resource handling for leader and follower

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,11 +125,12 @@ codegen: generate manifests ## Rebuild all generated code
 .PHONY: verify-codegen
 verify-codegen: codegen
 	@echo Checking codegen is up to date... >&2
-	@git --no-pager diff -- .
-	@echo 'If this test fails, it is because the git diff is non-empty after running "make codegen".' >&2
-	@echo 'To correct this, locally run "make codegen", commit the changes, and re-run tests.' >&2
-	@git diff --quiet --exit-code -- .
-
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "There are uncommitted changes or untracked files after running codegen:" >&2; \
+		git status --porcelain >&2; \
+		echo "To correct this, locally run 'make codegen', commit the changes, and re-run tests." >&2; \
+		exit 1; \
+	fi
 
 ########
 # TEST #

--- a/api/v1beta2/rediscluster_types.go
+++ b/api/v1beta2/rediscluster_types.go
@@ -31,13 +31,14 @@ type RedisClusterSpec struct {
 	// +kubebuilder:default:=6379
 	Port *int `json:"port,omitempty"`
 	// +kubebuilder:default:=v7
-	ClusterVersion     *string                      `json:"clusterVersion,omitempty"`
-	RedisLeader        RedisLeader                  `json:"redisLeader,omitempty"`
-	RedisFollower      RedisFollower                `json:"redisFollower,omitempty"`
-	RedisExporter      *RedisExporter               `json:"redisExporter,omitempty"`
-	Storage            *ClusterStorage              `json:"storage,omitempty"`
-	PodSecurityContext *corev1.PodSecurityContext   `json:"podSecurityContext,omitempty"`
-	PriorityClassName  string                       `json:"priorityClassName,omitempty"`
+	ClusterVersion     *string                    `json:"clusterVersion,omitempty"`
+	RedisLeader        RedisLeader                `json:"redisLeader,omitempty"`
+	RedisFollower      RedisFollower              `json:"redisFollower,omitempty"`
+	RedisExporter      *RedisExporter             `json:"redisExporter,omitempty"`
+	Storage            *ClusterStorage            `json:"storage,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	PriorityClassName  string                     `json:"priorityClassName,omitempty"`
+	// Deprecated: use kubernetesConfig.Resources instead for both leader and follower
 	Resources          *corev1.ResourceRequirements `json:"resources,omitempty"`
 	TLS                *TLSConfig                   `json:"TLS,omitempty"`
 	ACL                *ACLConfig                   `json:"acl,omitempty"`
@@ -56,6 +57,24 @@ func (cr *RedisClusterSpec) GetReplicaCounts(t string) int32 {
 		replica = cr.RedisFollower.Replicas
 	}
 	return *replica
+}
+
+// GetRedisLeaderResources returns the resources for the redis leader, if not set, it will return the default resources
+func (cr *RedisClusterSpec) GetRedisLeaderResources() *corev1.ResourceRequirements {
+	if cr.RedisLeader.Resources != nil {
+		return cr.RedisLeader.Resources
+	}
+
+	return cr.KubernetesConfig.Resources
+}
+
+// GetRedisFollowerResources returns the resources for the redis follower, if not set, it will return the default resources
+func (cr *RedisClusterSpec) GetRedisFollowerResources() *corev1.ResourceRequirements {
+	if cr.RedisFollower.Resources != nil {
+		return cr.RedisFollower.Resources
+	}
+
+	return cr.KubernetesConfig.Resources
 }
 
 // RedisLeader interface will have the redis leader configuration

--- a/api/v1beta2/rediscluster_types.go
+++ b/api/v1beta2/rediscluster_types.go
@@ -31,14 +31,13 @@ type RedisClusterSpec struct {
 	// +kubebuilder:default:=6379
 	Port *int `json:"port,omitempty"`
 	// +kubebuilder:default:=v7
-	ClusterVersion     *string                    `json:"clusterVersion,omitempty"`
-	RedisLeader        RedisLeader                `json:"redisLeader,omitempty"`
-	RedisFollower      RedisFollower              `json:"redisFollower,omitempty"`
-	RedisExporter      *RedisExporter             `json:"redisExporter,omitempty"`
-	Storage            *ClusterStorage            `json:"storage,omitempty"`
-	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
-	PriorityClassName  string                     `json:"priorityClassName,omitempty"`
-	// Deprecated: use kubernetesConfig.Resources instead for both leader and follower
+	ClusterVersion     *string                      `json:"clusterVersion,omitempty"`
+	RedisLeader        RedisLeader                  `json:"redisLeader,omitempty"`
+	RedisFollower      RedisFollower                `json:"redisFollower,omitempty"`
+	RedisExporter      *RedisExporter               `json:"redisExporter,omitempty"`
+	Storage            *ClusterStorage              `json:"storage,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext   `json:"podSecurityContext,omitempty"`
+	PriorityClassName  string                       `json:"priorityClassName,omitempty"`
 	Resources          *corev1.ResourceRequirements `json:"resources,omitempty"`
 	TLS                *TLSConfig                   `json:"TLS,omitempty"`
 	ACL                *ACLConfig                   `json:"acl,omitempty"`

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -10851,7 +10851,8 @@ spec:
                     type: array
                 type: object
               resources:
-                description: ResourceRequirements describes the compute resource requirements.
+                description: 'Deprecated: use kubernetesConfig.Resources instead for
+                  both leader and follower'
                 properties:
                   claims:
                     description: |-

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -10851,8 +10851,7 @@ spec:
                     type: array
                 type: object
               resources:
-                description: 'Deprecated: use kubernetesConfig.Resources instead for
-                  both leader and follower'
+                description: ResourceRequirements describes the compute resource requirements.
                 properties:
                   claims:
                     description: |-

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-core-v1-pod
+  failurePolicy: Fail
+  name: ot-mutate-pod.opstree.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/pkg/controllers/rediscluster/testdata/full.yaml
+++ b/pkg/controllers/rediscluster/testdata/full.yaml
@@ -20,6 +20,14 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
+  redisLeader:
+    resources:
+      requests:
+        cpu: 102m
+        memory: 129Mi
+      limits:
+        cpu: 102m
+        memory: 129Mi
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0

--- a/pkg/k8sutils/redis-cluster_test.go
+++ b/pkg/k8sutils/redis-cluster_test.go
@@ -433,10 +433,10 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 		t.Fatalf("Failed to unmarshal file %s: %v", path, err)
 	}
 
-	actualLeaderContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader")
+	actualLeaderContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader", input.Spec.GetRedisLeaderResources())
 	assert.EqualValues(t, expectedLeaderContainer, actualLeaderContainer, "Expected %+v, got %+v", expectedLeaderContainer, actualLeaderContainer)
 
-	actualFollowerContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower")
+	actualFollowerContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower", input.Spec.GetRedisFollowerResources())
 	assert.EqualValues(t, expectedFollowerContainer, actualFollowerContainer, "Expected %+v, got %+v", expectedFollowerContainer, actualFollowerContainer)
 }
 

--- a/pkg/webhook/pod_webhook.go
+++ b/pkg/webhook/pod_webhook.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-//+kubebuilder:webhook:path=/mutate-core-v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups=core,resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-core-v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups=core,resources=pods,verbs=create,versions=v1,name=ot-mutate-pod.opstree.com,admissionReviewVersions=v1
 
 // PodAntiAffiniytMutate mutate Pods
 type PodAntiAffiniytMutate struct {


### PR DESCRIPTION
- Added methods to retrieve resources for Redis leader and follower, allowing for more granular resource management.
- Updated RedisClusterSpec to deprecate the unified resources field in favor of individual configurations for leader and follower.
- Adjusted related tests and YAML configurations to reflect these changes, ensuring consistency and correctness in resource allocation.

This update improves the flexibility and efficiency of resource management in RedisCluster deployments.

PS: this PR is part of https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1188; https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1186

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
