### PR TITLE
feat: add serviceMonitor.extraLabels support

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.4
-appVersion: "0.16.4"
+version: 0.16.5
+appVersion: "0.16.5"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -107,6 +107,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | serviceAccountName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.extraLabels | object | `{}` | extraLabels are added to the servicemonitor when enabled set to true |
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `"monitoring"` |  |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |

--- a/charts/redis-cluster/templates/follower-sm.yaml
+++ b/charts/redis-cluster/templates/follower-sm.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-cluster/templates/leader-sm.yaml
+++ b/charts/redis-cluster/templates/leader-sm.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -97,6 +97,10 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 10s
   namespace: monitoring
+  # -- extraLabels are added to the servicemonitor when enabled set to true
+  extraLabels: {}
+    # foo: bar
+    # team: devops
 
 redisExporter:
   enabled: false

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.6
-appVersion: "0.16.6"
+version: 0.16.7
+appVersion: "0.16.7"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -90,6 +90,7 @@ helm delete <my-release> --namespace <namespace>
 | securityContext | object | `{}` |  |
 | serviceAccountName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.extraLabels | object | `{}` | extraLabels are added to the servicemonitor when enabled set to true |
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `"monitoring"` |  |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |

--- a/charts/redis-replication/templates/servicemonitor.yaml
+++ b/charts/redis-replication/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.redisReplication.name | default .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -51,6 +51,10 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 10s
   namespace: monitoring
+  # -- extraLabels are added to the servicemonitor when enabled set to true
+  extraLabels: {}
+    # foo: bar
+    # team: devops
 
 redisExporter:
   enabled: false

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-sentinel
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.8
-appVersion: "0.16.8"
+version: 0.16.9
+appVersion: "0.16.9"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -111,6 +111,7 @@ helm delete <my-release> --namespace <namespace>
 | securityContext | object | `{}` |  |
 | serviceAccountName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.extraLabels | object | `{}` | extraLabels are added to the servicemonitor when enabled set to true |
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `"monitoring"` |  |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |

--- a/charts/redis-sentinel/templates/servicemonitor.yaml
+++ b/charts/redis-sentinel/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.redisSentinel.name | default .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -63,6 +63,10 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 10s
   namespace: monitoring
+  # -- extraLabels are added to the servicemonitor when enabled set to true
+  extraLabels: {}
+    # foo: bar
+    # team: devops
 
 redisExporter:
   enabled: false

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: redis
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.4
-appVersion: "0.16.4"
+version: 0.16.5
+appVersion: "0.16.5"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -88,6 +88,7 @@ helm delete <my-release> --namespace <namespace>
 | securityContext | object | `{}` |  |
 | serviceAccountName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.extraLabels | object | `{}` | extraLabels are added to the servicemonitor when enabled set to true |
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `"monitoring"` |  |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -47,6 +47,10 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 10s
   namespace: monitoring
+  # -- extraLabels are added to the servicemonitor when enabled set to true
+  extraLabels: {}
+    # foo: bar
+    # team: devops
 
 redisExporter:
   enabled: false


### PR DESCRIPTION
- Updated version and appVersion for redis, redis-cluster, redis-replication, and redis-sentinel charts to 0.16.5, 0.16.7, and 0.16.9 respectively.
- Introduced `serviceMonitor.extraLabels` in values.yaml and README.md for all Redis charts, allowing users to add custom labels to the ServiceMonitor when enabled.
- Updated templates to utilize the new `extraLabels` configuration for ServiceMonitor.

This change enhances the flexibility of monitoring configurations for Redis deployments.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1187

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
