### PR TITLE
fix: add missing topologySpreadConstraint on RedisCluster follower

### DIFF
--- a/pkg/k8sutils/redis-cluster.go
+++ b/pkg/k8sutils/redis-cluster.go
@@ -244,6 +244,7 @@ func CreateRedisFollower(ctx context.Context, cr *redisv1beta2.RedisCluster, cl 
 		Affinity:                      cr.Spec.RedisFollower.Affinity,
 		TerminationGracePeriodSeconds: cr.Spec.RedisFollower.TerminationGracePeriodSeconds,
 		NodeSelector:                  cr.Spec.RedisFollower.NodeSelector,
+		TopologySpreadConstraints:     cr.Spec.RedisFollower.TopologySpreadConstraints,
 		Tolerations:                   cr.Spec.RedisFollower.Tolerations,
 		ReadinessProbe:                cr.Spec.RedisFollower.ReadinessProbe,
 		LivenessProbe:                 cr.Spec.RedisFollower.LivenessProbe,


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
add missing topologySpreadConstraint on RedisCluster follower
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
