### PR TITLE
feat: update redis-operator cert manager configuration.

### DIFF
--- a/charts/redis-operator/Chart.lock
+++ b/charts/redis-operator/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.12.4
-digest: sha256:026d03c56e2f8369b0f7d79f9560d5a33b2c5ae8a7d751213e56e2a0176cb874
-generated: "2023-10-02T14:14:45.164829041+05:30"

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.19.1
+version: 0.19.2
 appVersion: "0.19.0"
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
 engine: gotpl
@@ -19,10 +19,3 @@ keywords:
 - opstree
 - kubernetes
 - openshift
-
-dependencies:
-  - name: cert-manager
-    version: v1.12.4
-    repository: https://charts.jetstack.io
-    alias: certmanager
-    condition: certmanager.enabled

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -16,7 +16,7 @@ This Helm chart deploys the redis-operator into your Kubernetes cluster. The ope
 
 - Helm v3+
 - Kubernetes v1.16+
-- If you intend to use the cert-manager, ensure that the cert-manager CRDs are installed before deploying the redis-operator.
+- If you plan to use cert-manager integration (certmanager.enabled=true), cert-manager must be pre-installed in your cluster
 
 ## Source Code
 
@@ -30,13 +30,10 @@ This Helm chart deploys the redis-operator into your Kubernetes cluster. The ope
 helm repo add ot-helm https://ot-container-kit.github.io/helm-charts
 ```
 
-### 2. Install Cert-Manager CRDs (if using cert-manager)
+### 2. Install Cert-Manager (Optional)
 
-If you plan to use cert-manager with the redis-operator, you need to install the cert-manager CRDs before deploying the operator.
-
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.4/cert-manager.crds.yaml
-```
+If you plan to use cert-manager with the redis-operator, you need to install cert-manager before deploying the operator.
+You can follow the [official cert-manager installation guide](https://cert-manager.io/docs/installation/).
 
 ### 3. Install Redis Operator
 
@@ -91,6 +88,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | affinity | object | `{}` |  |
 | certificate.name | string | `"serving-cert"` |  |
 | certificate.secretName | string | `"webhook-server-cert"` |  |
+| certmanager.apiVersion | string | `"cert-manager.io/v1"` |  |
 | certmanager.enabled | bool | `false` |  |
 | issuer.email | string | `"shubham.gupta@opstree.com"` |  |
 | issuer.name | string | `"redis-operator-issuer"` |  |

--- a/charts/redis-operator/README.md.gotmpl
+++ b/charts/redis-operator/README.md.gotmpl
@@ -16,7 +16,7 @@ This Helm chart deploys the redis-operator into your Kubernetes cluster. The ope
 
 - Helm v3+
 - Kubernetes v1.16+
-- If you intend to use the cert-manager, ensure that the cert-manager CRDs are installed before deploying the redis-operator.
+- If you plan to use cert-manager integration (certmanager.enabled=true), cert-manager must be pre-installed in your cluster
 
 ## Source Code
 
@@ -30,13 +30,10 @@ This Helm chart deploys the redis-operator into your Kubernetes cluster. The ope
 helm repo add ot-helm https://ot-container-kit.github.io/helm-charts
 ```
 
-### 2. Install Cert-Manager CRDs (if using cert-manager)
+### 2. Install Cert-Manager (Optional)
 
-If you plan to use cert-manager with the redis-operator, you need to install the cert-manager CRDs before deploying the operator.
-
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.4/cert-manager.crds.yaml
-```
+If you plan to use cert-manager with the redis-operator, you need to install cert-manager before deploying the operator.
+You can follow the [official cert-manager installation guide](https://cert-manager.io/docs/installation/).
 
 ### 3. Install Redis Operator
 

--- a/charts/redis-operator/templates/NOTES.txt
+++ b/charts/redis-operator/templates/NOTES.txt
@@ -1,0 +1,10 @@
+{{- template "redis-operator.validateConfig" . -}}
+
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }} 

--- a/charts/redis-operator/templates/_helpers.tpl
+++ b/charts/redis-operator/templates/_helpers.tpl
@@ -32,3 +32,12 @@ app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- define "redisOperator.selectorLabels" -}}
 name: {{ .Values.redisOperator.name }}
 {{- end }}
+
+{{/*
+Validate webhook and cert-manager configuration
+*/}}
+{{- define "redis-operator.validateConfig" -}}
+{{- if and (not .Values.redisOperator.webhook) .Values.certmanager.enabled -}}
+{{- fail "certmanager.enabled should not be true when webhook is disabled" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -17,7 +17,10 @@ redisOperator:
   # When not specified, the operator will watch all namespaces. It can be set to a specific namespace or multiple namespaces separated by commas.
   watchNamespace: ""
   env: []
-  # If you want to enable masterSlaveAntiAffinity, you need to set webhook to true.
+  # If set to true, webhook server will be enabled for masterSlaveAntiAffinity feature
+  # When enabled, you need to either:
+  # 1. Enable cert-manager (certmanager.enabled=true) for automatic certificate management, or
+  # 2. Manually create a certificate secret (see "How to generate private key" section in README)
   webhook: false
   automountServiceAccountToken: true
 
@@ -58,7 +61,12 @@ issuer:
     ingressClass: nginx
 
 certmanager:
+  # Whether to use cert-manager for certificate management
+  # Only effective when webhook=true
+  # If webhook=true and certmanager.enabled=false, you need to manually create certificate secret
   enabled: false
+  # API version of the cert-manager CRDs
+  apiVersion: "cert-manager.io/v1"
 
 priorityClassName: ""
 nodeSelector: {}


### PR DESCRIPTION
- Removed Chart.lock file for cert-manager dependency
- Updated Chart.yaml to remove explicit cert-manager dependency
- Bumped chart version to 0.19.2
- Updated README.md to clarify cert-manager installation instructions
- Modified values.yaml to improve cert-manager and webhook configuration documentation
- Added configuration validation helper in _helpers.tpl
- Introduced NOTES.txt template for helm chart installation guidance

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1206

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
