### PR TITLE
Changed certificate serverName to pod+namespace

### DIFF
--- a/pkg/k8sutils/secrets.go
+++ b/pkg/k8sutils/secrets.go
@@ -60,7 +60,7 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ServerName:   podName,
+		ServerName:   podName + "." + namespace,
 		RootCAs:      tlsCaCertificates,
 		MinVersion:   tls.VersionTLS12,
 		ClientAuth:   tls.NoClientCert,


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Changed podName to podName.namespace in the tls.config in secrets.go so that is it possible to issue *.namespace wildcard TLS certificate with cert-manager.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #763 
**Type of change**
<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)
**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [*] Functionality/bugs have been confirmed to be unchanged or fixed.
- [*] I have performed a self-review of my own code.
- [*] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
