### PR TITLE
fix: improve pod label patching with error handling and retry mechanism

### DIFF
--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,0 +1,7 @@
+package util
+
+import "strings"
+
+func EscapeJSONPointer(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "~", "~0"), "/", "~1")
+}


### PR DESCRIPTION
- Added JSON pointer escaping for label keys
- Implemented retry mechanism for label patching
- Enhanced error handling and logging
- Added validation for empty labels
- Created utility function for JSON pointer escaping in util package

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
#1217
**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
