### PR TITLE
feat: add securityContext config in chart for redis-exporter

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -104,6 +104,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.image | string | `"quay.io/opstree/redis-exporter"` |  |
 | redisExporter.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisExporter.resources | object | `{}` |  |
+| redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | serviceAccountName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -36,6 +36,9 @@ spec:
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
+    {{- if .Values.redisExporter.securityContext}}
+    securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
+    {{- end }}
     
   kubernetesConfig:
     image: "{{ .Values.redisCluster.image }}:{{ .Values.redisCluster.tag }}"

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -117,6 +117,7 @@ redisExporter:
   env: []
     # - name: VAR_NAME
     #   value: "value1"
+  securityContext: {}
 
 sidecars:
   name: ""

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -73,6 +73,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.image | string | `"quay.io/opstree/redis-exporter"` |  |
 | redisExporter.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisExporter.resources | object | `{}` |  |
+| redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | redisReplication.clusterSize | int | `3` |  |
 | redisReplication.ignoreAnnotations | list | `[]` |  |

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -41,6 +41,9 @@ spec:
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
+    {{- if .Values.redisExporter.securityContext}}
+    securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
+    {{- end }}
   
   {{- if .Values.externalConfig.enabled }}
   redisConfig:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -71,6 +71,7 @@ redisExporter:
   env: []
     # - name: VAR_NAME
     #   value: "value1"
+  securityContext: {}
 
 initContainer:
   enabled: false

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -85,6 +85,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.image | string | `"quay.io/opstree/redis-exporter"` |  |
 | redisExporter.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisExporter.resources | object | `{}` |  |
+| redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | redisSentinel.clusterSize | int | `3` |  |
 | redisSentinel.ignoreAnnotations | list | `[]` |  |

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -60,6 +60,9 @@ spec:
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
+    {{- if .Values.redisExporter.securityContext}}
+    securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
+    {{- end }}
 
   {{- if .Values.nodeSelector }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -83,6 +83,7 @@ redisExporter:
   env: []
     # - name: VAR_NAME
     #   value: "value1"
+  securityContext: {}
 
 initContainer:
   enabled: false

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -72,6 +72,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.image | string | `"quay.io/opstree/redis-exporter"` |  |
 | redisExporter.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisExporter.resources | object | `{}` |  |
+| redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | redisStandalone.ignoreAnnotations | list | `[]` |  |
 | redisStandalone.image | string | `"quay.io/opstree/redis"` |  |

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -40,6 +40,9 @@ spec:
     {{- if .Values.redisExporter.env }}
     env: {{ toYaml .Values.redisExporter.env | nindent 6 }}
     {{- end }}
+    {{- if .Values.redisExporter.securityContext}}
+    securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
+    {{- end }}
 
   {{- if .Values.externalConfig.enabled }}
   redisConfig:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -67,6 +67,7 @@ redisExporter:
   env: []
     # - name: VAR_NAME
     #   value: "value1"
+  securityContext: {}
 
 initContainer:
   enabled: false


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Add ability to configure securityContext for redis-exporter in redis helm charts:
- redis
- redis-cluster
- redis-replication
- redis-sentinel

Supported in:
- v1beta1 & v1beta2: Redis, RedisCluster, RedisReplication Operator CRDs
- v1beta2 only: RedisSentinel Operator CRD

This aligns with existing redis operator CRD functionality.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

This change is required to support restricted pod security admission standards for the redis-exporter containers.