### PR TITLE
feat: configurable operator maxConcurrentReconciles

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strconv"
 	"strings"
 
@@ -38,6 +37,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"

--- a/pkg/controllers/redis/redis_controller.go
+++ b/pkg/controllers/redis/redis_controller.go
@@ -18,7 +18,6 @@ package redis
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // Reconciler reconciles a Redis object

--- a/pkg/controllers/redis/redis_controller.go
+++ b/pkg/controllers/redis/redis_controller.go
@@ -18,6 +18,7 @@ package redis
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -65,8 +66,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta2.Redis{}).
+		WithOptions(opts).
 		Complete(r)
 }

--- a/pkg/controllers/redis/redis_controller_suite_test.go
+++ b/pkg/controllers/redis/redis_controller_suite_test.go
@@ -19,6 +19,7 @@ package redis
 import (
 	"context"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -98,7 +99,7 @@ var _ = BeforeSuite(func() {
 	err = (&Reconciler{
 		Client:    k8sManager.GetClient(),
 		K8sClient: k8sClient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/pkg/controllers/redis/redis_controller_suite_test.go
+++ b/pkg/controllers/redis/redis_controller_suite_test.go
@@ -19,7 +19,6 @@ package redis
 import (
 	"context"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/pkg/controllers/rediscluster/rediscluster_controller.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller.go
@@ -113,8 +113,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// check if cluster is upscaled
-
 	// Mark the cluster status as initializing if there are no leader or follower nodes
 	if (instance.Status.ReadyLeaderReplicas == 0 && instance.Status.ReadyFollowerReplicas == 0) ||
 		instance.Status.ReadyLeaderReplicas != leaderReplicas {

--- a/pkg/controllers/rediscluster/rediscluster_controller.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller.go
@@ -19,6 +19,7 @@ package rediscluster
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/api/status"
@@ -111,6 +112,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			logger.Info("masterCount is not equal to leader statefulset replicas,skip downscale", "masterCount", masterCount, "leaderReplicas", leaderReplicas)
 		}
 	}
+
+	// check if cluster is upscaled
 
 	// Mark the cluster status as initializing if there are no leader or follower nodes
 	if (instance.Status.ReadyLeaderReplicas == 0 && instance.Status.ReadyFollowerReplicas == 0) ||
@@ -262,9 +265,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta2.RedisCluster{}).
+		WithOptions(opts).
 		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }

--- a/pkg/controllers/rediscluster/rediscluster_controller.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller.go
@@ -19,7 +19,6 @@ package rediscluster
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/api/status"
@@ -35,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 

--- a/pkg/controllers/rediscluster/rediscluster_controller_suite_test.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller_suite_test.go
@@ -19,6 +19,7 @@ package rediscluster
 import (
 	"context"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -106,7 +107,7 @@ var _ = BeforeSuite(func() {
 		Dk8sClient:  dk8sClient,
 		Recorder:    k8sManager.GetEventRecorderFor("rediscluster-controller"),
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/pkg/controllers/rediscluster/rediscluster_controller_suite_test.go
+++ b/pkg/controllers/rediscluster/rediscluster_controller_suite_test.go
@@ -19,7 +19,6 @@ package rediscluster
 import (
 	"context"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/pkg/controllers/redisreplication/redisreplication_controller.go
+++ b/pkg/controllers/redisreplication/redisreplication_controller.go
@@ -2,6 +2,7 @@ package redisreplication
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -189,9 +190,10 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *redisv1beta2
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta2.RedisReplication{}).
+		WithOptions(opts).
 		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }

--- a/pkg/controllers/redisreplication/redisreplication_controller.go
+++ b/pkg/controllers/redisreplication/redisreplication_controller.go
@@ -2,7 +2,6 @@ package redisreplication
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 

--- a/pkg/controllers/redisreplication/redisreplication_controller_suite_test.go
+++ b/pkg/controllers/redisreplication/redisreplication_controller_suite_test.go
@@ -19,6 +19,7 @@ package redisreplication
 import (
 	"context"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -106,7 +107,7 @@ var _ = BeforeSuite(func() {
 		Dk8sClient:  dk8sClient,
 		Pod:         k8sutils.NewPodService(k8sClient),
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/pkg/controllers/redisreplication/redisreplication_controller_suite_test.go
+++ b/pkg/controllers/redisreplication/redisreplication_controller_suite_test.go
@@ -19,7 +19,6 @@ package redisreplication
 import (
 	"context"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/pkg/controllers/redissentinel/redissentinel_controller.go
+++ b/pkg/controllers/redissentinel/redissentinel_controller.go
@@ -2,7 +2,6 @@ package redissentinel
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -13,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 

--- a/pkg/controllers/redissentinel/redissentinel_controller.go
+++ b/pkg/controllers/redissentinel/redissentinel_controller.go
@@ -2,6 +2,7 @@ package redissentinel
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
@@ -131,9 +132,10 @@ func (r *RedisSentinelReconciler) reconcileService(ctx context.Context, instance
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *RedisSentinelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *RedisSentinelReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta2.RedisSentinel{}).
+		WithOptions(opts).
 		Watches(&redisv1beta2.RedisReplication{}, r.ReplicationWatcher).
 		Complete(r)
 }

--- a/pkg/controllers/redissentinel/redissentinel_controller_suite_test.go
+++ b/pkg/controllers/redissentinel/redissentinel_controller_suite_test.go
@@ -19,6 +19,7 @@ package redissentinel
 import (
 	"context"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -105,7 +106,7 @@ var _ = BeforeSuite(func() {
 		K8sClient:          k8sClient,
 		Dk8sClient:         dk8sClient,
 		ReplicationWatcher: intctrlutil.NewResourceWatcher(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/pkg/controllers/redissentinel/redissentinel_controller_suite_test.go
+++ b/pkg/controllers/redissentinel/redissentinel_controller_suite_test.go
@@ -19,7 +19,6 @@ package redissentinel
 import (
 	"context"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
configurable operator maxConcurrentReconciles: running multiple instances of (Replication, Sentinel, Cluster) will make the reconcile faster without the need to wait one by one processing.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
