### PR TITLE
feat: Extract PVC resizing logic to a separate module and improve error handling

### DIFF
--- a/pkg/k8sutils/pvc.go
+++ b/pkg/k8sutils/pvc.go
@@ -1,0 +1,86 @@
+package k8sutils
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// HandlePVCResizing checks and updates the PVC storage capacity.
+// If the storage capacity defined in the new StatefulSet's VolumeClaimTemplate differs from the actual PVC capacity,
+// it attempts to update the PVC and adjusts the annotation accordingly.
+// Returns an error if any update fails.
+func HandlePVCResizing(ctx context.Context, storedStateful, newStateful *appsv1.StatefulSet, cl kubernetes.Interface) error {
+	// If the VolumeClaimTemplate Spec hasn't changed, no update is required.
+	if equality.Semantic.DeepEqual(newStateful.Spec.VolumeClaimTemplates[0].Spec, storedStateful.Spec.VolumeClaimTemplates[0].Spec) {
+		return nil
+	}
+
+	// Retrieve or initialize the storage capacity recorded in annotations.
+	annotations := storedStateful.Annotations
+	if annotations == nil {
+		annotations = map[string]string{"storageCapacity": "0"}
+	}
+
+	storedCapacity, _ := strconv.ParseInt(annotations["storageCapacity"], 0, 64)
+	desiredCapacity := newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().Value()
+
+	// If the stored capacity matches the desired capacity, no update is needed.
+	if storedCapacity == desiredCapacity {
+		return nil
+	}
+
+	// Create a label selector to list all related PVCs.
+	labelSelector := labels.FormatLabels(map[string]string{
+		"app":                         storedStateful.Name,
+		"app.kubernetes.io/component": "redis",
+	})
+	listOpt := metav1.ListOptions{LabelSelector: labelSelector}
+
+	pvcs, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).List(context.Background(), listOpt)
+	if err != nil {
+		return err
+	}
+
+	updateFailed := false
+	realUpdate := false
+
+	// Iterate over PVCs and update the resource requests if their capacity does not match the desired capacity.
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		currentCapacity := pvc.Spec.Resources.Requests.Storage().Value()
+		if currentCapacity != desiredCapacity {
+			realUpdate = true
+			pvc.Spec.Resources.Requests = newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests
+			if _, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
+				updateFailed = true
+				log.FromContext(ctx).Error(fmt.Errorf("redis:%s resize pvc failed: %s", storedStateful.Name, err.Error()), "")
+			}
+		}
+	}
+
+	// If any update failed, return an error.
+	if updateFailed {
+		return fmt.Errorf("one or more PVC updates failed")
+	}
+
+	// If updates were successful, update the annotation with the new storage capacity.
+	if len(pvcs.Items) != 0 {
+		annotations["storageCapacity"] = fmt.Sprintf("%d", desiredCapacity)
+		storedStateful.Annotations = annotations
+		if realUpdate {
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("redis:%s resized pvc from %d to %d", storedStateful.Name, storedCapacity, desiredCapacity))
+		} else {
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("redis:%s updated annotations for storage capacity", storedStateful.Name))
+		}
+	}
+
+	return nil
+}

--- a/pkg/k8sutils/pvc_test.go
+++ b/pkg/k8sutils/pvc_test.go
@@ -1,0 +1,229 @@
+package k8sutils
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// TestHandlePVCResizing_NoUpdateNeeded verifies that if the VolumeClaimTemplate spec hasn't changed,
+// HandlePVCResizing returns nil without performing any update.
+func TestHandlePVCResizing_NoUpdateNeeded(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a dummy PVC spec (5Gi).
+	quantity := resource.MustParse("5Gi")
+	pvcSpec := corev1.PersistentVolumeClaimSpec{
+		// After
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: quantity,
+			},
+		},
+	}
+
+	// Both stored and new StatefulSets have identical VolumeClaimTemplate spec.
+	storedStateful := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"storageCapacity": strconv.FormatInt(quantity.Value(), 10),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{Spec: pvcSpec},
+			},
+		},
+	}
+
+	newStateful := storedStateful.DeepCopy()
+
+	cl := fake.NewSimpleClientset()
+
+	err := HandlePVCResizing(ctx, storedStateful, newStateful, cl)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+// TestHandlePVCResizing_UpdatePVC verifies that when the desired capacity differs from the stored capacity,
+// the PVC is updated and the annotation is revised.
+func TestHandlePVCResizing_UpdatePVC(t *testing.T) {
+	ctx := context.Background()
+
+	// Define stored PVC spec (5Gi) and new PVC spec (10Gi).
+	quantity := resource.MustParse("5Gi")
+	storedPVCSpec := corev1.PersistentVolumeClaimSpec{
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: quantity,
+			},
+		},
+	}
+	newPVCSpec := corev1.PersistentVolumeClaimSpec{
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+
+	storedStateful := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"storageCapacity": strconv.FormatInt(quantity.Value(), 10),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "redis-data"},
+					Spec:       storedPVCSpec,
+				},
+			},
+		},
+	}
+
+	newStateful := storedStateful.DeepCopy()
+	// Update the spec in newStateful to 10Gi.
+	newStateful.Spec.VolumeClaimTemplates[0].Spec = newPVCSpec
+
+	// Create a fake PVC representing an existing PVC with 5Gi capacity.
+	existingPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis-data-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                         "redis",
+				"app.kubernetes.io/component": "redis",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: quantity,
+				},
+			},
+		},
+	}
+
+	cl := fake.NewSimpleClientset(existingPVC)
+
+	err := HandlePVCResizing(ctx, storedStateful, newStateful, cl)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify the annotation was updated to the desired capacity.
+	desiredCapacity := newStateful.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().Value()
+	expectedAnnotation := fmt.Sprintf("%d", desiredCapacity)
+	if storedStateful.Annotations["storageCapacity"] != expectedAnnotation {
+		t.Errorf("Expected annotation storageCapacity to be %s, got %s", expectedAnnotation, storedStateful.Annotations["storageCapacity"])
+	}
+
+	// Verify the PVC was updated.
+	pvcList, err := cl.CoreV1().PersistentVolumeClaims("default").List(ctx, metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(map[string]string{
+			"app":                         "redis",
+			"app.kubernetes.io/component": "redis",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list PVCs: %v", err)
+	}
+	if len(pvcList.Items) != 1 {
+		t.Fatalf("Expected 1 PVC, got: %d", len(pvcList.Items))
+	}
+
+	updatedPVC := pvcList.Items[0]
+	updatedCapacity := updatedPVC.Spec.Resources.Requests.Storage().Value()
+	if updatedCapacity != desiredCapacity {
+		t.Errorf("Expected PVC capacity to be %d, got %d", desiredCapacity, updatedCapacity)
+	}
+}
+
+// TestHandlePVCResizing_UpdateFailure simulates a failure during PVC update and verifies that an error is returned.
+func TestHandlePVCResizing_UpdateFailure(t *testing.T) {
+	ctx := context.Background()
+
+	quantity := resource.MustParse("5Gi")
+	storedPVCSpec := corev1.PersistentVolumeClaimSpec{
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: quantity,
+			},
+		},
+	}
+	newPVCSpec := corev1.PersistentVolumeClaimSpec{
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+
+	storedStateful := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"storageCapacity": strconv.FormatInt(quantity.Value(), 10),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "redis-data"},
+					Spec:       storedPVCSpec,
+				},
+			},
+		},
+	}
+
+	newStateful := storedStateful.DeepCopy()
+	newStateful.Spec.VolumeClaimTemplates[0].Spec = newPVCSpec
+
+	// Create a fake PVC representing an existing PVC with 5Gi capacity.
+	existingPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis-data-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                         "redis",
+				"app.kubernetes.io/component": "redis",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: quantity,
+				},
+			},
+		},
+	}
+
+	cl := fake.NewSimpleClientset(existingPVC)
+	// Prepend a reactor to simulate an update failure.
+	cl.PrependReactor("update", "persistentvolumeclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated update error")
+	})
+
+	err := HandlePVCResizing(ctx, storedStateful, newStateful, cl)
+	if err == nil {
+		t.Fatalf("Expected error due to simulated update failure, got nil")
+	}
+}


### PR DESCRIPTION
### Description

This PR refactors the PVC resizing logic in the Redis controller to improve modularity, clarity, and error handling. The changes include:

- **Separation of Concerns:**  
  The PVC resizing logic is now moved into its own file (`pvc.go`). This separation helps isolate PVC-related functionality from the main StatefulSet handling logic, making the codebase easier to understand and maintain.

- **Function Renaming:**  
  The PVC update function is renamed to `HandlePVCResizing` to clearly indicate its purpose of handling PVC expansion.

- **Improved Error Handling:**  
  Previously, when a PVC update failed, the error was only logged and not returned. Now, if any PVC update fails, `HandlePVCResizing` returns an error. This change ensures that errors during PVC updates are properly propagated and can be handled by the caller.

- **Unit Tests:**  
  New unit tests have been added (in `pvc_test.go`) to validate the following scenarios:
  - No update is necessary when the desired storage capacity matches the current state.
  - PVCs are successfully updated when the desired capacity differs.
  - An error is returned when the PVC update fails (simulated using a reactor in the fake client).

### Motivation

In our previous implementation, PVC update failures were silently logged rather than being reported to the caller. This could lead to situations where storage capacity mismatches went unnoticed, causing issues in the deployment lifecycle. By improving error propagation and refactoring the PVC logic, we enhance the reliability and maintainability of the Redis controller.

### Testing

I have verified that all unit tests pass with:

```bash
go test ./...
```

Please review the changes and let me know if you have any questions or need further modifications.