### PR TITLE
feat: add recreate-stateful-strategy, orphan, background, foreground(default)

### DIFF
--- a/docs/content/en/docs/CRD Reference/Redis API/_index.md
+++ b/docs/content/en/docs/CRD Reference/Redis API/_index.md
@@ -19,6 +19,23 @@ This page documents the Redis API Schema definitions for the redis API group.
 
 Package v1beta2 contains API Schema definitions for the redis v1beta2 API group
 
+### Annotations
+
+Redis Operator supports the following annotations that can be added to Redis, RedisCluster, RedisReplication, and RedisSentinel resources:
+
+| Annotation | Description | Default | Values |
+| --- | --- | --- | --- |
+| `redis.opstreelabs.in/recreate-statefulset` | Controls whether the StatefulSet should be recreated when changed | `false` | `"true"`, `"false"` |
+| `redis.opstreelabs.in/recreate-statefulset-strategy` | Controls how dependent resources are handled when the StatefulSet is recreated | `foreground` | `"foreground"`, `"background"`, `"orphan"` |
+
+#### Deletion Propagation Strategies
+
+When `redis.opstreelabs.in/recreate-statefulset` is set to `"true"`, you can control the deletion behavior using the `redis.opstreelabs.in/recreate-statefulset-strategy` annotation:
+
+- **foreground**: The StatefulSet and its dependent objects (like Pods) are deleted synchronously
+- **background**: The StatefulSet is deleted immediately, and dependent objects are deleted asynchronously
+- **orphan**: The StatefulSet is deleted but its dependent objects (Pods) are kept running
+
 ### Resource Types
 
 - [Redis](#redis)

--- a/pkg/k8sutils/const.go
+++ b/pkg/k8sutils/const.go
@@ -1,7 +1,8 @@
 package k8sutils
 
 const (
-	AnnotationKeyRecreateStatefulset = "redis.opstreelabs.in/recreate-statefulset"
+	AnnotationKeyRecreateStatefulset         = "redis.opstreelabs.in/recreate-statefulset"
+	AnnotationKeyRecreateStatefulsetStrategy = "redis.opstreelabs.in/recreate-statefulset-strategy"
 )
 
 const (

--- a/pkg/k8sutils/redis-cluster.go
+++ b/pkg/k8sutils/redis-cluster.go
@@ -83,7 +83,7 @@ func generateRedisClusterParams(ctx context.Context, cr *redisv1beta2.RedisClust
 			propagation = metav1.DeletePropagationBackground
 		}
 
-		res.RecreateStateteulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = &propagation
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-cluster.go
+++ b/pkg/k8sutils/redis-cluster.go
@@ -79,7 +79,7 @@ func generateRedisClusterParams(ctx context.Context, cr *redisv1beta2.RedisClust
 		propagation = metav1.DeletePropagationForeground
 		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
 			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "backgroud" {
+		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
 			propagation = metav1.DeletePropagationBackground
 		}
 

--- a/pkg/k8sutils/redis-cluster.go
+++ b/pkg/k8sutils/redis-cluster.go
@@ -8,7 +8,6 @@ import (
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -73,17 +72,8 @@ func generateRedisClusterParams(ctx context.Context, cr *redisv1beta2.RedisClust
 		res.ExternalConfig = externalConfig
 	}
 	if value, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found && value == "true" {
-		var propagation metav1.DeletionPropagation
 		res.RecreateStatefulSet = true
-
-		propagation = metav1.DeletePropagationForeground
-		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
-			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
-			propagation = metav1.DeletePropagationBackground
-		}
-
-		res.RecreateStatefulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = getDeletionPropagationStrategy(cr.ObjectMeta.GetAnnotations())
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-replication.go
+++ b/pkg/k8sutils/redis-replication.go
@@ -5,6 +5,7 @@ import (
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -122,7 +123,17 @@ func generateRedisReplicationParams(cr *redisv1beta2.RedisReplication) statefulS
 		res.ServiceAccountName = cr.Spec.ServiceAccountName
 	}
 	if value, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found && value == "true" {
+		var propagation metav1.DeletionPropagation
 		res.RecreateStatefulSet = true
+
+		propagation = metav1.DeletePropagationForeground
+		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
+			propagation = metav1.DeletePropagationOrphan
+		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "backgroud" {
+			propagation = metav1.DeletePropagationBackground
+		}
+
+		res.RecreateStateteulsetStrategy = &propagation
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-replication.go
+++ b/pkg/k8sutils/redis-replication.go
@@ -5,7 +5,6 @@ import (
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -123,17 +122,8 @@ func generateRedisReplicationParams(cr *redisv1beta2.RedisReplication) statefulS
 		res.ServiceAccountName = cr.Spec.ServiceAccountName
 	}
 	if value, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found && value == "true" {
-		var propagation metav1.DeletionPropagation
 		res.RecreateStatefulSet = true
-
-		propagation = metav1.DeletePropagationForeground
-		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
-			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
-			propagation = metav1.DeletePropagationBackground
-		}
-
-		res.RecreateStatefulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = getDeletionPropagationStrategy(cr.ObjectMeta.GetAnnotations())
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-replication.go
+++ b/pkg/k8sutils/redis-replication.go
@@ -133,7 +133,7 @@ func generateRedisReplicationParams(cr *redisv1beta2.RedisReplication) statefulS
 			propagation = metav1.DeletePropagationBackground
 		}
 
-		res.RecreateStateteulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = &propagation
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-replication.go
+++ b/pkg/k8sutils/redis-replication.go
@@ -129,7 +129,7 @@ func generateRedisReplicationParams(cr *redisv1beta2.RedisReplication) statefulS
 		propagation = metav1.DeletePropagationForeground
 		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
 			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "backgroud" {
+		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
 			propagation = metav1.DeletePropagationBackground
 		}
 

--- a/pkg/k8sutils/redis-sentinel.go
+++ b/pkg/k8sutils/redis-sentinel.go
@@ -125,7 +125,7 @@ func generateRedisSentinelParams(ctx context.Context, cr *redisv1beta2.RedisSent
 		propagation = metav1.DeletePropagationForeground
 		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
 			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "backgroud" {
+		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
 			propagation = metav1.DeletePropagationBackground
 		}
 

--- a/pkg/k8sutils/redis-sentinel.go
+++ b/pkg/k8sutils/redis-sentinel.go
@@ -9,7 +9,6 @@ import (
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -119,17 +118,8 @@ func generateRedisSentinelParams(ctx context.Context, cr *redisv1beta2.RedisSent
 		res.EnableMetrics = cr.Spec.RedisExporter.Enabled
 	}
 	if value, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found && value == "true" {
-		var propagation metav1.DeletionPropagation
 		res.RecreateStatefulSet = true
-
-		propagation = metav1.DeletePropagationForeground
-		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
-			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
-			propagation = metav1.DeletePropagationBackground
-		}
-
-		res.RecreateStatefulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = getDeletionPropagationStrategy(cr.ObjectMeta.GetAnnotations())
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-sentinel.go
+++ b/pkg/k8sutils/redis-sentinel.go
@@ -129,7 +129,7 @@ func generateRedisSentinelParams(ctx context.Context, cr *redisv1beta2.RedisSent
 			propagation = metav1.DeletePropagationBackground
 		}
 
-		res.RecreateStateteulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = &propagation
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-standalone.go
+++ b/pkg/k8sutils/redis-standalone.go
@@ -141,7 +141,7 @@ func generateRedisStandaloneParams(cr *redisv1beta2.Redis) statefulSetParameters
 			propagation = metav1.DeletePropagationBackground
 		}
 
-		res.RecreateStateteulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = &propagation
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-standalone.go
+++ b/pkg/k8sutils/redis-standalone.go
@@ -5,7 +5,6 @@ import (
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -131,17 +130,8 @@ func generateRedisStandaloneParams(cr *redisv1beta2.Redis) statefulSetParameters
 		res.ServiceAccountName = cr.Spec.ServiceAccountName
 	}
 	if value, found := cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulset]; found && value == "true" {
-		var propagation metav1.DeletionPropagation
 		res.RecreateStatefulSet = true
-
-		propagation = metav1.DeletePropagationForeground
-		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
-			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
-			propagation = metav1.DeletePropagationBackground
-		}
-
-		res.RecreateStatefulsetStrategy = &propagation
+		res.RecreateStatefulsetStrategy = getDeletionPropagationStrategy(cr.ObjectMeta.GetAnnotations())
 	}
 	return res
 }

--- a/pkg/k8sutils/redis-standalone.go
+++ b/pkg/k8sutils/redis-standalone.go
@@ -137,7 +137,7 @@ func generateRedisStandaloneParams(cr *redisv1beta2.Redis) statefulSetParameters
 		propagation = metav1.DeletePropagationForeground
 		if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "orphan" {
 			propagation = metav1.DeletePropagationOrphan
-		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "backgroud" {
+		} else if cr.ObjectMeta.GetAnnotations()[AnnotationKeyRecreateStatefulsetStrategy] == "background" {
 			propagation = metav1.DeletePropagationBackground
 		}
 

--- a/pkg/k8sutils/statefulset.go
+++ b/pkg/k8sutils/statefulset.go
@@ -110,7 +110,7 @@ type statefulSetParameters struct {
 	ServiceAccountName            *string
 	UpdateStrategy                appsv1.StatefulSetUpdateStrategy
 	RecreateStatefulSet           bool
-	RecreateStateteulsetStrategy  *metav1.DeletionPropagation
+	RecreateStatefulsetStrategy   *metav1.DeletionPropagation
 	TerminationGracePeriodSeconds *int64
 	IgnoreAnnotations             []string
 	HostNetwork                   bool
@@ -175,7 +175,7 @@ func CreateOrUpdateStateFul(ctx context.Context, cl kubernetes.Interface, namesp
 		}
 		return err
 	}
-	return patchStatefulSet(ctx, storedStateful, statefulSetDef, namespace, params.RecreateStatefulSet, params.RecreateStateteulsetStrategy, cl)
+	return patchStatefulSet(ctx, storedStateful, statefulSetDef, namespace, params.RecreateStatefulSet, params.RecreateStatefulsetStrategy, cl)
 }
 
 // patchStatefulSet patches the Redis StatefulSet by applying changes while maintaining atomicity.

--- a/pkg/k8sutils/statefulset.go
+++ b/pkg/k8sutils/statefulset.go
@@ -874,3 +874,27 @@ func getSidecars(sidecars *[]redisv1beta2.Sidecar) []redisv1beta2.Sidecar {
 	}
 	return *sidecars
 }
+
+// getDeletionPropagationStrategy returns the deletion propagation strategy based on the annotation
+func getDeletionPropagationStrategy(annotations map[string]string) *metav1.DeletionPropagation {
+	if annotations == nil {
+		return nil
+	}
+
+	if strategy, exists := annotations[AnnotationKeyRecreateStatefulsetStrategy]; exists {
+		var propagation metav1.DeletionPropagation
+
+		switch strings.ToLower(strategy) {
+		case "orphan":
+			propagation = metav1.DeletePropagationOrphan
+		case "background":
+			propagation = metav1.DeletePropagationBackground
+		default:
+			propagation = metav1.DeletePropagationForeground
+		}
+
+		return &propagation
+	}
+
+	return nil
+}

--- a/pkg/k8sutils/statefulset_test.go
+++ b/pkg/k8sutils/statefulset_test.go
@@ -336,12 +336,13 @@ func Test_createStatefulSet(t *testing.T) {
 
 func TestUpdateStatefulSet(t *testing.T) {
 	tests := []struct {
-		name            string
-		existingStsSpec appsv1.StatefulSetSpec
-		updatedStsSpec  appsv1.StatefulSetSpec
-		recreateSts     bool
-		stsPresent      bool
-		expectErr       error
+		name              string
+		existingStsSpec   appsv1.StatefulSetSpec
+		updatedStsSpec    appsv1.StatefulSetSpec
+		recreateSts       bool
+		deletePropagation metav1.DeletionPropagation
+		stsPresent        bool
+		expectErr         error
 	}{
 		{
 			name: "Update StatefulSet without recreate in existing Statefulset",
@@ -439,7 +440,7 @@ func TestUpdateStatefulSet(t *testing.T) {
 			} else {
 				client = k8sClientFake.NewSimpleClientset()
 			}
-			err := updateStatefulSet(context.TODO(), client, updatedSts.GetNamespace(), &updatedSts, test.recreateSts)
+			err := updateStatefulSet(context.TODO(), client, updatedSts.GetNamespace(), &updatedSts, test.recreateSts, &test.deletePropagation)
 			if test.expectErr != nil {
 				assert.Error(err, "Expected Error while updating Statefulset")
 				assert.Equal(test.expectErr, err)


### PR DESCRIPTION
This PR will expand the capability of current `"redis.opstreelabs.in/recreate-statefulset"`, to make the users have more control to deal with recreating process of the StatefulSet,

For example: Recreating the Statefulset (with foreground delete) on, will make the Pod of Sentinel entirely terminated, 
with the setting of [orphan](https://kubernetes.io/docs/tasks/run-application/delete-stateful-set/#deleting-a-statefulset) --> `"redis.opstreelabs.in/recreate-statefulset-strategy: orphan"` will keep the Pod up and running and will make the administrator have more control on it (for example: to avoid downtime).

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/master/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!-- 
    Is there anything else you'd like reviewers to know? 
    For example, any other related issues or testing carried out.
-->
