### PR TITLE
feat: Add support for anti affinity configuration in helm charts

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -70,6 +70,7 @@ helm delete <my-release> --namespace <namespace>
 | priorityClassName | string | `""` |  |
 | redisCluster.clusterSize | int | `3` |  |
 | redisCluster.clusterVersion | string | `"v7"` |  |
+| redisCluster.enableMasterSlaveAntiAffinity | bool | `false` | Enable pod anti-affinity between leader and follower pods by adding the appropriate label. Notice that this requires the operator to have its mutating webhook enabled, otherwise it will only add an annotation to the RedisCluster CR. Default is false. |
 | redisCluster.follower.affinity | string | `nil` |  |
 | redisCluster.follower.nodeSelector | string | `nil` |  |
 | redisCluster.follower.pdb.enabled | bool | `false` |  |
@@ -95,7 +96,6 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.name | string | `""` |  |
 | redisCluster.persistenceEnabled | bool | `true` |  |
 | redisCluster.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
-| redisCluster.enableMasterSlaveAntiAffinity | bool | `false` | Add the appropriate annotation to RedisCluster, so that the operator can enforce anti affinity between leaders and followers. Notice that this requires webhooks to be enabled on the operator. Default is false. |
 | redisCluster.redisSecret.secretKey | string | `""` |  |
 | redisCluster.redisSecret.secretName | string | `""` |  |
 | redisCluster.resources | object | `{}` |  |

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -95,6 +95,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.name | string | `""` |  |
 | redisCluster.persistenceEnabled | bool | `true` |  |
 | redisCluster.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
+| redisCluster.enableMasterSlaveAntiAffinity | bool | `false` | Add the appropriate annotation to RedisCluster, so that the operator can enforce anti affinity between leaders and followers. Notice that this requires webhooks to be enabled on the operator. Default is false. |
 | redisCluster.redisSecret.secretKey | string | `""` |  |
 | redisCluster.redisSecret.secretName | string | `""` |  |
 | redisCluster.resources | object | `{}` |  |

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -8,6 +8,9 @@ metadata:
     {{ if .Values.redisCluster.recreateStatefulSetOnUpdateInvalid }}
     redis.opstreelabs.in/recreate-statefulset: "true"
     {{ end }}
+    {{- if .Values.redisCluster.enableMasterSlaveAntiAffinity }}
+    redisclusters.redis.redis.opstreelabs.in/role-anti-affinity: "true"
+    {{- end }}
 spec:
   clusterSize: {{ .Values.redisCluster.clusterSize }}
   persistenceEnabled: {{ .Values.redisCluster.persistenceEnabled }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -23,11 +23,9 @@ redisCluster:
   # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
   # When set to true, the operator will delete the statefulset and recreate it. Default is false.
   recreateStatefulSetOnUpdateInvalid: false
-  # Enable pod anti-affinity between leader and follower pods
-  # This ensures same leader and follower pods are scheduled on different nodes
-  # for better high availability
-  # NOTICE THAT this requires the operator to have its mutating webhook enabled
-  # otherwise it will only add an annotation to the RedisCluster CR.
+  # -- Enable pod anti-affinity between leader and follower pods by adding the appropriate label.
+  # Notice that this requires the operator to have its mutating webhook enabled,
+  # otherwise it will only add an annotation to the RedisCluster CR. Default is false.
   enableMasterSlaveAntiAffinity: false
   leader:
     replicas: 3

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -23,6 +23,12 @@ redisCluster:
   # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
   # When set to true, the operator will delete the statefulset and recreate it. Default is false.
   recreateStatefulSetOnUpdateInvalid: false
+  # Enable pod anti-affinity between leader and follower pods
+  # This ensures same leader and follower pods are scheduled on different nodes
+  # for better high availability
+  # NOTICE THAT this requires the operator to have its mutating webhook enabled
+  # otherwise it will only add an annotation to the RedisCluster CR.
+  enableMasterSlaveAntiAffinity: false
   leader:
     replicas: 3
     serviceType: ClusterIP

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -46,6 +46,8 @@ helm install <redis-operator> ot-helm/redis-operator --version=0.15.5 --appVersi
 > Note: If `certificate.secretName` is not provided, the operator will generate a self-signed certificate and use it for webhook server.
 ---
 > Note : If you want to disable the webhook you have to pass the `--set webhook=false` and `--set certmanager.enabled=false`  while installing the redis-operator.
+---
+> Note: If you want to use an existing `ClusterIssuer` to sign the webhook certificate, you can pass `--set issuer.create=false`, `--set issuer.kind=ClusterIssuer` and `--set issuer.name=cluster-issuer-name-here` while installing the operator.
 
 ### 4. Patch the CA Bundle (if using cert-manager)
 
@@ -90,6 +92,8 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | certificate.secretName | string | `"webhook-server-cert"` |  |
 | certmanager.apiVersion | string | `"cert-manager.io/v1"` |  |
 | certmanager.enabled | bool | `false` |  |
+| issuer.create | bool | `true` |  |
+| issuer.kind | string | `Issuer` |  |
 | issuer.email | string | `"shubham.gupta@opstree.com"` |  |
 | issuer.name | string | `"redis-operator-issuer"` |  |
 | issuer.privateKeySecretName | string | `"letsencrypt-prod"` |  |

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -93,8 +93,8 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | certmanager.apiVersion | string | `"cert-manager.io/v1"` |  |
 | certmanager.enabled | bool | `false` |  |
 | issuer.create | bool | `true` |  |
-| issuer.kind | string | `Issuer` |  |
 | issuer.email | string | `"shubham.gupta@opstree.com"` |  |
+| issuer.kind | string | `"Issuer"` |  |
 | issuer.name | string | `"redis-operator-issuer"` |  |
 | issuer.privateKeySecretName | string | `"letsencrypt-prod"` |  |
 | issuer.server | string | `"https://acme-v02.api.letsencrypt.org/directory"` |  |

--- a/charts/redis-operator/README.md.gotmpl
+++ b/charts/redis-operator/README.md.gotmpl
@@ -46,6 +46,8 @@ helm install <redis-operator> ot-helm/redis-operator --version=0.15.5 --appVersi
 > Note: If `certificate.secretName` is not provided, the operator will generate a self-signed certificate and use it for webhook server.
 ---
 > Note : If you want to disable the webhook you have to pass the `--set webhook=false` and `--set certmanager.enabled=false`  while installing the redis-operator.
+---
+> Note: If you want to use an existing `ClusterIssuer` to sign the webhook certificate, you can pass `--set issuer.create=false`, `--set issuer.kind=ClusterIssuer` and `--set issuer.name=cluster-issuer-name-here` while installing the operator.
 
 ### 4. Patch the CA Bundle (if using cert-manager)
 

--- a/charts/redis-operator/templates/cert-manager.yaml
+++ b/charts/redis-operator/templates/cert-manager.yaml
@@ -1,10 +1,9 @@
 {{ if .Values.certmanager.enabled }}
-
+{{- if .Values.issuer.create }}
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: {{ .Values.issuer.kind }}
 metadata:
   name: {{ .Values.issuer.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.redisOperator.name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -15,9 +14,8 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
 spec:
   {{- include "redis-operator.issuerSpec" . | nindent 2 }}
-
 ---
-
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -36,8 +34,7 @@ spec:
     - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc
     - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.cluster.local
   issuerRef:
-    kind: Issuer
+    kind: {{ .Values.issuer.kind }}
     name: {{ .Values.issuer.name }}
   secretName: {{ .Values.certificate.secretName }}
-
 {{ end }}

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -51,6 +51,12 @@ certificate:
   secretName: webhook-server-cert
 
 issuer:
+  # Whether to create the issuer or not. You might want to disable this if instead you
+  # want to use a ClusterIssuer that you simply want to provide.
+  create: true
+  # You can choose Issuer or ClusterIssuer here. The first one is namespaced, the second one
+  # is available for global usage.
+  kind: Issuer
   type: selfSigned
   name: redis-operator-issuer
   email: shubham.gupta@opstree.com


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Following what was done in [pull/1180](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1180), there is an annotation that can be used to enforce leader-follower anti affinity using a mutating webhook. But it's not possible to use it from the provided Helm Charts.

I added the following:

- Possibility to add the annotation on the `RedisCluster` resource by using `redisCluster.enableMasterSlaveAntiAffinity`
- Possibility to disable the creation of cert-manager `Issuer` (which might be not required) in case someone wants to use an existing one for the `Certificate`
- Possibility to create it as a `ClusterIssuer`, if desired. And also to use this kind of issuer in the certificate.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
    - There are no tests for the Helm Charts (it seems)
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->

I left the default parameters in the values to configure the chart as before, so there should be no changes, unless parameters are personalized.