### PR TITLE
fix: svc finalizer removed.

### DIFF
--- a/pkg/util/map.go
+++ b/pkg/util/map.go
@@ -11,3 +11,29 @@ func MergeMap[K comparable, V any](all ...map[K]V) map[K]V {
 	}
 	return res
 }
+
+// CopyMap creates a shallow copy of the given map.
+// It returns a new map containing all key-value pairs from the source map.
+// Note: This is a shallow copy; if the values are reference types,
+// the copied map will reference the same underlying objects as the source.
+func CopyMap[K comparable, V any](src map[K]V) map[K]V {
+	return MergeMap(src)
+}
+
+// MergePreservingExistingKeys merges source into destination while skipping any keys that exist in the destination.
+func MergePreservingExistingKeys[K comparable, V any](dest, src map[K]V) map[K]V {
+	if dest == nil {
+		if src == nil {
+			return nil
+		}
+		dest = make(map[K]V, len(src))
+	}
+
+	for k, v := range src {
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+		}
+	}
+
+	return dest
+}


### PR DESCRIPTION
## Description

This PR addresses two issues:

1. **Fix Svc Finalizer Issue:**  
   The service (svc) finalizer was mistakenly being removed. This PR includes changes that ensure the finalizer is preserved during updates, preventing unintended deletions.

2. **Introduce Utility Functions:**  
   Two new generic utility functions have been added:
   - **MergePreservingExistingKeys:** Merges key-value pairs from a source map into a destination map, preserving existing keys in the destination.
   - **CopyMap:** Creates a shallow copy of a given map by leveraging the `MergeMap` function.
