### PR TITLE
fix: race condition resulting in permanently broken Redis cluster

### DIFF
--- a/pkg/k8sutils/redis.go
+++ b/pkg/k8sutils/redis.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -647,6 +648,10 @@ func CreateMasterSlaveReplication(ctx context.Context, client kubernetes.Interfa
 	}
 
 	realMasterPodIP := getRedisServerIP(ctx, client, realMasterInfo)
+
+	if realMasterPodIP == "" {
+		return errors.New("CreateMasterSlaveReplication got empty master IP, refusing")
+	}
 
 	for i := 0; i < len(masterPods); i++ {
 		if masterPods[i] != realMasterPod {


### PR DESCRIPTION
**Description**

The operator contains a race condition that results in a broken cluster where all `redis` instances (including the previous master) are set to be replicas with an empty master IP. It doesn't seem to ever recover from that state, and requires a manual intervention to bring the cluster back to life.

This is because [`CreateMasterSlaveReplication`](https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/pkg/k8sutils/redis.go#L649) doesn't check whether the IP of the master node is empty, and happily iterates through all instances and sets them to replicas. It attempts to exclude the master by comparing the IPs, that can be empty:

```go
realMasterPodIP := getRedisServerIP(ctx, client, realMasterInfo)

for i := 0; i < len(masterPods); i++ {
	if masterPods[i] != realMasterPod {
		redisClient := configureRedisReplicationClient(ctx, client, cr, masterPods[i])
		defer redisClient.Close()
		log.FromContext(ctx).V(1).Info("Setting the", "pod", masterPods[i], "to slave of", realMasterPod)
		err := redisClient.SlaveOf(ctx, realMasterPodIP, "6379").Err()
		if err != nil {
			log.FromContext(ctx).Error(err, "Failed to set", "pod", masterPods[i], "to slave of", realMasterPod)
			return err
		}
	}
}
```

The master IP can be empty for a few reasons (see [getRedisServerIP](https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/pkg/k8sutils/redis.go#L649)). The func signature returns a string, so error handling is effectively missing atm.

Here's one such condition:

```go
// getRedisServerIP will return the IP of redis service
func getRedisServerIP(ctx context.Context, client kubernetes.Interface, redisInfo RedisDetails) string {
	log.FromContext(ctx).V(1).Info("Fetching Redis pod", "namespace", redisInfo.Namespace, "podName", redisInfo.PodName)

	redisPod, err := client.CoreV1().Pods(redisInfo.Namespace).Get(context.TODO(), redisInfo.PodName, metav1.GetOptions{})
	if err != nil {
		log.FromContext(ctx).Error(err, "Error in getting Redis pod IP", "namespace", redisInfo.Namespace, "podName", redisInfo.PodName)
		return ""
	}
```

Independently, it might be a good idea to assert that the `realMasterPod` is actually in `masterPods`.

**Reproducing**

Deleting the statefulset pods a few times in a row seems to be enough to trigger this reliably.
I'm not including more detailed instructions, because it's easy to point out the issue in the code as per above.


**Change**

This change fails the `CreateMasterSlaveReplication` function if the master IP is empty.

This will then be retried 60 seconds later through the existing error handling in [`reconcileRedis`](https://github.com/OT-CONTAINER-KIT/redis-operator/blob/317fc37b051db2199193191c30bd928882a89a17/pkg/controllers/redisreplication/redisreplication_controller.go#L178-L180):

```go
if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, masterNodes, realMaster); err != nil {
	return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
}
```


**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

