### PR TITLE
feat: add feature gates for sentinel configuration generation in init container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ coverage.html
 *.swo
 *~
 .vscode
+.go-version
 
 .DS_Store
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 require (
 	emperror.dev/errors v0.8.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/pkg/agent/bootstrap/generate_config.go
+++ b/pkg/agent/bootstrap/generate_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,5 +67,9 @@ func (c *config) append(config ...string) *config {
 }
 
 func (c *config) commit() error {
+	dir := filepath.Dir(c.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %v", dir, err)
+	}
 	return os.WriteFile(c.path, []byte(c.content), 0o644)
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,30 @@
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// GenerateConfigInInitContainer enables generating Redis configuration using an init container
+	// instead of a regular container
+	GenerateConfigInInitContainer featuregate.Feature = "GenerateConfigInInitContainer"
+)
+
+// DefaultRedisOperatorFeatureGates consists of all known Redis operator feature gates.
+// To add a new feature, define a key for it above and add it here.
+var DefaultRedisOperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	GenerateConfigInInitContainer: {Default: false, PreRelease: featuregate.Alpha},
+}
+
+// MutableFeatureGate is a feature gate that can be dynamically set
+var MutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+func init() {
+	runtime.Must(MutableFeatureGate.Add(DefaultRedisOperatorFeatureGates))
+}
+
+// Enabled checks if a feature is enabled
+func Enabled(feature featuregate.Feature) bool {
+	return MutableFeatureGate.Enabled(feature)
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -20,6 +20,7 @@ var DefaultRedisOperatorFeatureGates = map[featuregate.Feature]featuregate.Featu
 // MutableFeatureGate is a feature gate that can be dynamically set
 var MutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
 
+//nolint:gochecknoinits
 func init() {
 	runtime.Must(MutableFeatureGate.Add(DefaultRedisOperatorFeatureGates))
 }

--- a/pkg/k8sutils/const.go
+++ b/pkg/k8sutils/const.go
@@ -1,6 +1,10 @@
 package k8sutils
 
 const (
+	OperatorImage = "quay.io/opstree/redis-operator:v0.19.1"
+)
+
+const (
 	AnnotationKeyRecreateStatefulset         = "redis.opstreelabs.in/recreate-statefulset"
 	AnnotationKeyRecreateStatefulsetStrategy = "redis.opstreelabs.in/recreate-statefulset-strategy"
 )
@@ -13,4 +17,8 @@ const (
 	RedisRoleLabelKey    = "redis-role"
 	RedisRoleLabelMaster = "master"
 	RedisRoleLabelSlave  = "slave"
+)
+
+const (
+	VolumeNameConfig = "config"
 )

--- a/pkg/k8sutils/statefulset.go
+++ b/pkg/k8sutils/statefulset.go
@@ -748,7 +748,9 @@ func getVolumeMount(name string, persistenceEnabled *bool, clusterMode bool, nod
 		})
 	}
 
-	VolumeMounts = append(VolumeMounts, generateConfigVolumeMount(VolumeNameConfig))
+	if features.Enabled(features.GenerateConfigInInitContainer) {
+		VolumeMounts = append(VolumeMounts, generateConfigVolumeMount(VolumeNameConfig))
+	}
 
 	VolumeMounts = append(VolumeMounts, mountpath...)
 

--- a/pkg/k8sutils/statefulset.go
+++ b/pkg/k8sutils/statefulset.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/features"
 	"github.com/OT-CONTAINER-KIT/redis-operator/pkg/util"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
@@ -286,14 +287,14 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 					Affinity:                      params.Affinity,
 					TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
 					HostNetwork:                   params.HostNetwork,
+					Volumes:                       []corev1.Volume{generateConfigVolume(VolumeNameConfig)},
 				},
 			},
 		},
 	}
 
-	if initcontainerParams.Enabled != nil && *initcontainerParams.Enabled {
-		statefulset.Spec.Template.Spec.InitContainers = generateInitContainerDef(stsMeta.GetName(), initcontainerParams, initcontainerParams.AdditionalMountPath)
-	}
+	statefulset.Spec.Template.Spec.InitContainers = generateInitContainerDef(containerParams.Role, stsMeta.GetName(), initcontainerParams, initcontainerParams.AdditionalMountPath, containerParams, params.ClusterVersion)
+
 	if params.Tolerations != nil {
 		statefulset.Spec.Template.Spec.Tolerations = *params.Tolerations
 	}
@@ -340,6 +341,22 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 
 	AddOwnerRefToObject(statefulset, ownerDef)
 	return statefulset
+}
+
+func generateConfigVolume(volumeName string) corev1.Volume {
+	return corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func generateConfigVolumeMount(volumeName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: "/etc/redis",
+	}
 }
 
 // getExternalConfig will return the redis external configuration
@@ -408,6 +425,11 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 			LivenessProbe:  getProbeInfo(containerParams.LivenessProbe, sentinelCntr, enableTLS, enableAuth),
 			VolumeMounts:   getVolumeMount(name, containerParams.PersistenceEnabled, clusterMode, nodeConfVolume, externalConfig, mountpath, containerParams.TLSConfig, containerParams.ACLConfig),
 		},
+	}
+
+	if sentinelCntr && features.Enabled(features.GenerateConfigInInitContainer) {
+		containerDefinition[0].Command = []string{"redis-sentinel"}
+		containerDefinition[0].Args = []string{"/etc/redis/sentinel.conf"}
 	}
 
 	if preStopCmd := GeneratePreStopCommand(containerParams.Role, enableAuth, enableTLS); preStopCmd != "" {
@@ -523,9 +545,36 @@ if [ "$ROLE" = "master" ]; then
 fi`, authArgs, tlsArgs, authArgs, tlsArgs, authArgs, tlsArgs)
 }
 
-func generateInitContainerDef(name string, initcontainerParams initContainerParameters, mountpath []corev1.VolumeMount) []corev1.Container {
-	initcontainerDefinition := []corev1.Container{
-		{
+func generateInitContainerDef(role, name string, initcontainerParams initContainerParameters, mountpath []corev1.VolumeMount, containerParams containerParameters, clusterVersion *string) []corev1.Container {
+	containers := []corev1.Container{}
+
+	if role == "sentinel" && features.Enabled(features.GenerateConfigInInitContainer) {
+		containers = append(containers, corev1.Container{
+			Name:            "init-config",
+			Image:           OperatorImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/operator", "agent"},
+			Args:            []string{"bootstrap", "--sentinel"},
+			Env: getEnvironmentVariables(
+				containerParams.Role,
+				containerParams.EnabledPassword,
+				containerParams.SecretName,
+				containerParams.SecretKey,
+				containerParams.PersistenceEnabled,
+				containerParams.TLSConfig,
+				containerParams.ACLConfig,
+				containerParams.EnvVars,
+				containerParams.Port,
+				clusterVersion,
+			),
+			VolumeMounts: []corev1.VolumeMount{
+				generateConfigVolumeMount(VolumeNameConfig),
+			},
+		})
+	}
+
+	if initcontainerParams.Enabled != nil && *initcontainerParams.Enabled {
+		containers = append(containers, corev1.Container{
 			Name:            "init" + name,
 			Image:           initcontainerParams.Image,
 			ImagePullPolicy: initcontainerParams.ImagePullPolicy,
@@ -533,18 +582,11 @@ func generateInitContainerDef(name string, initcontainerParams initContainerPara
 			Args:            initcontainerParams.Arguments,
 			VolumeMounts:    getVolumeMount(name, initcontainerParams.PersistenceEnabled, false, false, nil, mountpath, nil, nil),
 			SecurityContext: initcontainerParams.SecurityContext,
-		},
+			Resources:       ptr.Deref(initcontainerParams.Resources, corev1.ResourceRequirements{}),
+			Env:             ptr.Deref(initcontainerParams.AdditionalEnvVariable, []corev1.EnvVar{}),
+		})
 	}
-
-	if initcontainerParams.Resources != nil {
-		initcontainerDefinition[0].Resources = *initcontainerParams.Resources
-	}
-
-	if initcontainerParams.AdditionalEnvVariable != nil {
-		initcontainerDefinition[0].Env = append(initcontainerDefinition[0].Env, *initcontainerParams.AdditionalEnvVariable...)
-	}
-
-	return initcontainerDefinition
+	return containers
 }
 
 func GenerateTLSEnvironmentVariables(tlsconfig *redisv1beta2.TLSConfig) []corev1.EnvVar {
@@ -705,6 +747,8 @@ func getVolumeMount(name string, persistenceEnabled *bool, clusterMode bool, nod
 			MountPath: "/etc/redis/external.conf.d",
 		})
 	}
+
+	VolumeMounts = append(VolumeMounts, generateConfigVolumeMount(VolumeNameConfig))
 
 	VolumeMounts = append(VolumeMounts, mountpath...)
 

--- a/pkg/k8sutils/statefulset_test.go
+++ b/pkg/k8sutils/statefulset_test.go
@@ -1318,6 +1318,7 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 								},
 							},
 							ServiceAccountName: "redis",
+							InitContainers:     []corev1.Container{},
 							Containers: []corev1.Container{
 								{
 									Name:  "test-sts",
@@ -1504,6 +1505,7 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 						Spec: v1.PodSpec{
 							InitContainers: []corev1.Container{
 								{
+									Env:   []v1.EnvVar{},
 									Name:  "inittest-sts",
 									Image: "redis-init:latest",
 								},
@@ -1574,6 +1576,12 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 								},
 							},
 							Volumes: []v1.Volume{
+								{
+									Name: "config",
+									VolumeSource: v1.VolumeSource{
+										EmptyDir: &v1.EmptyDirVolumeSource{},
+									},
+								},
 								{
 									Name: "additional-vol",
 								},

--- a/pkg/k8sutils/statefulset_test.go
+++ b/pkg/k8sutils/statefulset_test.go
@@ -915,6 +915,7 @@ func TestGenerateInitContainerDef(t *testing.T) {
 			name:              "Test1_With_Resources_AdditionalENV",
 			initContainerName: "redis",
 			initContainerDef: initContainerParameters{
+				Enabled:            ptr.To(true),
 				Image:              "redis-init-container:latest",
 				ImagePullPolicy:    corev1.PullAlways,
 				Command:            []string{"/bin/bash", "-c", "/app/restore.bash"},
@@ -967,6 +968,7 @@ func TestGenerateInitContainerDef(t *testing.T) {
 			name:              "Test2_With_Volume",
 			initContainerName: "redis",
 			initContainerDef: initContainerParameters{
+				Enabled:            ptr.To(true),
 				Image:              "redis-init-container:latest",
 				ImagePullPolicy:    corev1.PullAlways,
 				Command:            []string{"/bin/bash", "-c", "/app/restore.bash"},
@@ -984,6 +986,7 @@ func TestGenerateInitContainerDef(t *testing.T) {
 							MountPath: "/data",
 						},
 					}, nil, nil),
+					Env: []v1.EnvVar{},
 				},
 			},
 			mountPaths: []corev1.VolumeMount{
@@ -998,7 +1001,7 @@ func TestGenerateInitContainerDef(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			initContainer := generateInitContainerDef(test.initContainerName, test.initContainerDef, test.mountPaths)
+			initContainer := generateInitContainerDef("", test.initContainerName, test.initContainerDef, test.mountPaths, containerParameters{}, ptr.To("v6"))
 			assert.Equal(t, initContainer, test.expectedInitContainerDef, "Init Container Configuration")
 		})
 	}


### PR DESCRIPTION
- Introduced a new feature gate to enable generating Redis configuration using an init container.
- Updated the main.go to parse feature gates from command-line flags.
- Enhanced statefulset definition to conditionally include init containers based on feature gate status.
- Added necessary volume and volume mount definitions for configuration management.

This change improves flexibility in Redis operator deployment configurations.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
https://github.com/OT-CONTAINER-KIT/redis-operator/issues/766

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
