### PR TITLE
feat: support redis configuration generation in init container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG IMG
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,10 +22,11 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY api/ api/
 COPY pkg/ pkg/
+COPY internal/ internal/
 COPY mocks/ mocks/
 
 # Build
-ARG LDFLAGS="-s -w"
+ARG LDFLAGS="-s -w -X github.com/OT-CONTAINER-KIT/redis-operator/internal/image.operatorImage=${IMG}"
 ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
 ENV CGO_ENABLED=0

--- a/internal/image/operator_image.go
+++ b/internal/image/operator_image.go
@@ -1,0 +1,11 @@
+package image
+
+// operatorImage is the image of the operator, it be set by the linker when building the operator
+var operatorImage string
+
+func GetOperatorImage() string {
+	if operatorImage == "" {
+		return "quay.io/opstree/redis-operator:latest"
+	}
+	return operatorImage
+}

--- a/pkg/agent/bootstrap/generate_redis_config.go
+++ b/pkg/agent/bootstrap/generate_redis_config.go
@@ -34,16 +34,6 @@ func generateRedisConfig() error {
 		redisMajorVersion, _  = util.CoalesceEnv("REDIS_MAJOR_VERSION", "v7")
 	)
 
-	// common_operation - create necessary directories
-	{
-		if err := os.MkdirAll(dataDir, 0o755); err != nil {
-			log.Fatalf("Failed to create data directory: %v", err)
-		}
-		if err := os.MkdirAll(nodeConfDir, 0o755); err != nil {
-			log.Fatalf("Failed to create node configuration directory: %v", err)
-		}
-	}
-
 	// set_redis_password - configure Redis password
 	{
 		if val, ok := util.CoalesceEnv("REDIS_PASSWORD", ""); ok && val != "" {

--- a/pkg/k8sutils/const.go
+++ b/pkg/k8sutils/const.go
@@ -1,10 +1,6 @@
 package k8sutils
 
 const (
-	OperatorImage = "quay.io/opstree/redis-operator:v0.19.1"
-)
-
-const (
 	AnnotationKeyRecreateStatefulset         = "redis.opstreelabs.in/recreate-statefulset"
 	AnnotationKeyRecreateStatefulsetStrategy = "redis.opstreelabs.in/recreate-statefulset-strategy"
 )


### PR DESCRIPTION
- Added IMG argument to Dockerfile for dynamic image handling.
- Updated LDFLAGS in Dockerfile to set operator image during build.
- Modified Makefile to pass IMG as a build argument in Docker commands.
- Introduced internal package for operator image retrieval.
- Removed hardcoded operator image reference from const.go.

These changes improve the flexibility and maintainability of the operator image configuration.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
#766 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
