### PR TITLE
fix: invalid usage of securityContext in docs for sentinel

### DIFF
--- a/docs/content/en/docs/Getting Started/Sentinel/_index.md
+++ b/docs/content/en/docs/Getting Started/Sentinel/_index.md
@@ -71,7 +71,7 @@ metadata:
   name: redis-sentinel
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig:


### PR DESCRIPTION
Now using the correct `podSecurityContext`

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The documentation example resource uses an invalid key and therefore doesn't work.


**Type of change**


* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**
As I just edited the docs I didn't actually check any tests / code.