### PR TITLE
fix: handle panic when retrieving StatefulSet in GetRedisNodesByRole

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ verify-codegen: codegen
 # ===========================
 
 .PHONY: tests
-tests: integration-test-setup unit-tests
+tests: integration-test-setup unit-tests integration-tests
 
 .PHONY: unit-tests
 unit-tests:
@@ -195,6 +195,10 @@ e2e-test: e2e-kind-setup kuttl
 .PHONY: integration-test-setup
 integration-test-setup:
 	./hack/integrationSetup.sh
+
+.PHONY: integration-tests
+integration-tests:
+	ginkgo -r -race --repeat=5
 
 .PHONY: e2e-kind-setup
 e2e-kind-setup:

--- a/pkg/k8sutils/redis.go
+++ b/pkg/k8sutils/redis.go
@@ -577,6 +577,7 @@ func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *redis
 	statefulset, err := GetStatefulSet(ctx, cl, cr.GetNamespace(), cr.GetName())
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to Get the Statefulset of the", "custom resource", cr.Name, "in namespace", cr.Namespace)
+		return nil
 	}
 
 	var pods []string


### PR DESCRIPTION
Signed-off-by: Shubham Gupta <iamshubhamgupta2001@gmail.com>

**Description**

Test were panic due to continuation on the error.
We need to return if we have found the error

```
Will run 1 of 1 specs
•panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x188ba15]

goroutine 251 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:116 +0x1da
```
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Tried Running Test More that 1 one to make sure to catch the flaky condition