### PR TITLE
fix: VCT resize detection logic; add support for scaling out with new VCT size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,13 @@ jobs:
           config: tests/_config/kind-config.yaml
           cluster_name: kind
 
+      # NOTE: This is a workaround for the issue where the default storage class does not support volume expansion.
+      # Since we don't require PVC resizing (unlike physical disks), we can simply ensure that the requested PVC size is met.
+      - name: Set allowVolumeExpansion to true
+        run: |
+          DEFAULT_SC=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+          kubectl patch storageclass $DEFAULT_SC -p '{"allowVolumeExpansion": true}'          
+
       - name: Load Docker image into Kind
         run: |
           kubectl cluster-info --context kind-kind

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -735,7 +735,7 @@ func TestCreateOrUpdateResizingPVC(t *testing.T) {
 				},
 			}
 			client := k8sClientFake.NewSimpleClientset()
-			// create the STS with the inital params and PVC so that we know there shouldn't be any other differences
+			// create the STS with the initial params and PVC so that we know there shouldn't be any other differences
 			err := CreateOrUpdateStateFul(context.Background(), client, objMeta.Namespace, objMeta,
 				stsParams, stsOwnerDef, initContainerParams, containerParams, sidecar)
 			require.NoError(t, err, "Error while creating Statefulset")

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -678,7 +678,8 @@ func TestCreateOrUpdateResizingPVC(t *testing.T) {
 		},
 	}
 
-	stsOwnerDef := metav1.OwnerReference{Name: "test-sts",
+	stsOwnerDef := metav1.OwnerReference{
+		Name:       "test-sts",
 		Kind:       "StatefulSet",
 		APIVersion: "apps/v1",
 		UID:        "12345",

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -3,11 +3,13 @@ package k8sutils
 import (
 	"context"
 	"path"
+	"strconv"
 	"testing"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api"
 	redisv1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -623,6 +625,148 @@ func TestCreateOrUpdateStateFul(t *testing.T) {
 
 				err := CreateOrUpdateStateFul(context.TODO(), client, updatedSts.GetNamespace(), updatedSts.ObjectMeta, test.stsParams, test.stsOwnerDef, test.initContainerParams, test.containerParams, test.sidecar)
 				assert.Nil(err)
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateResizingPVC(t *testing.T) {
+	tests := []struct {
+		name                     string
+		startingPVCSize          string
+		newPVCSize               string
+		recreateStatefulSet      bool
+		expectedVCTUpdate        bool
+		expectedAnnotationUpdate bool
+		expectErr                error
+	}{
+		{
+			name:                     "NoPVCSizeChangeResultsInNoSTSUpdate",
+			startingPVCSize:          "2Gi",
+			newPVCSize:               "2Gi",
+			recreateStatefulSet:      true,
+			expectedVCTUpdate:        false,
+			expectedAnnotationUpdate: false,
+			expectErr:                nil,
+		},
+		{
+			name:                     "NoPVCSizeChangeResultsInNoSTSUpdate_2",
+			startingPVCSize:          "2Gi",
+			newPVCSize:               "2Gi",
+			recreateStatefulSet:      false,
+			expectedVCTUpdate:        false,
+			expectedAnnotationUpdate: false,
+			expectErr:                nil,
+		},
+		{
+			name:                     "PVCSizeChangeResultsInSTSUpdate",
+			startingPVCSize:          "2Gi",
+			newPVCSize:               "3Gi",
+			recreateStatefulSet:      true,
+			expectedVCTUpdate:        true,
+			expectedAnnotationUpdate: true,
+			expectErr:                nil,
+		},
+		{
+			name:                     "PVCResizeChangesAnnotationOnlyIfRecreateNotEnabled",
+			startingPVCSize:          "2Gi",
+			newPVCSize:               "3Gi",
+			recreateStatefulSet:      false,
+			expectedVCTUpdate:        false,
+			expectedAnnotationUpdate: true,
+			expectErr:                nil,
+		},
+	}
+
+	stsOwnerDef := metav1.OwnerReference{Name: "test-sts",
+		Kind:       "StatefulSet",
+		APIVersion: "apps/v1",
+		UID:        "12345",
+	}
+	initContainerParams := initContainerParameters{Image: "redis-init:latest"}
+	containerParams := containerParameters{
+		PersistenceEnabled: ptr.To(true),
+	}
+	sidecar := &[]redisv1beta2.Sidecar{}
+	objMeta := metav1.ObjectMeta{
+		Name:      "test-sts",
+		Namespace: "test-ns",
+		UID:       "12345",
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			stsParams := statefulSetParameters{
+				Replicas:            ptr.To(int32(4)),
+				RecreateStatefulSet: test.recreateStatefulSet,
+				NodeConfVolume:      true,
+				NodeConfPersistentVolumeClaim: corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-conf",
+						Annotations: map[string]string{
+							"redis.opstreelabs.in":       "true",
+							"redis.opstreelabs.instance": "test-sts",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				PersistentVolumeClaim: corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: objMeta.Name,
+						Annotations: map[string]string{
+							"redis.opstreelabs.in":       "true",
+							"redis.opstreelabs.instance": "test-sts",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse(test.startingPVCSize),
+							},
+						},
+					},
+				},
+			}
+			client := k8sClientFake.NewSimpleClientset()
+			// create the STS with the inital params and PVC so that we know there shouldn't be any other differences
+			err := CreateOrUpdateStateFul(context.Background(), client, objMeta.Namespace, objMeta,
+				stsParams, stsOwnerDef, initContainerParams, containerParams, sidecar)
+			require.NoError(t, err, "Error while creating Statefulset")
+			getCreatedSts, err := client.AppsV1().StatefulSets(objMeta.Namespace).Get(context.Background(), objMeta.Name, metav1.GetOptions{})
+			require.NoError(t, err, "Error getting StatefulSet")
+
+			// only change the PVC sizes from the original request to create the STS
+			stsParams.PersistentVolumeClaim.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(test.newPVCSize)
+
+			err = CreateOrUpdateStateFul(context.Background(), client, objMeta.Namespace, objMeta,
+				stsParams, stsOwnerDef, initContainerParams, containerParams, sidecar)
+
+			if test.expectErr != nil {
+				require.Error(t, err, "Expected Error while updating Statefulset")
+				require.Equal(t, test.expectErr, err)
+				getUpdatedSts, err := client.AppsV1().StatefulSets(objMeta.Namespace).Get(context.Background(), objMeta.Name, metav1.GetOptions{})
+				require.NoError(t, err, "Error getting StatefulSet")
+				require.Equal(t, getCreatedSts, getUpdatedSts)
+			} else {
+				require.NoError(t, err, "Error while updating Statefulset")
+				getUpdatedSts, err := client.AppsV1().StatefulSets(objMeta.Namespace).Get(context.Background(), objMeta.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+				if test.expectedAnnotationUpdate {
+					expected := resource.MustParse(test.newPVCSize)
+					require.Equal(t, strconv.FormatInt(expected.Value(), 10), getUpdatedSts.Annotations["storageCapacity"])
+				}
+				if test.expectedVCTUpdate {
+					require.Equal(t, resource.MustParse(test.newPVCSize), getUpdatedSts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage])
+				} else {
+					require.Equal(t, resource.MustParse(test.startingPVCSize), getUpdatedSts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage])
+				}
 			}
 		})
 	}

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
@@ -40,6 +40,17 @@ spec:
             check:
               (contains($stdout, 'OK')): true
 
+    - name: Resize pvc
+      try:
+        - script:
+            timeout: 10s
+            content: |
+              PATCH_DATA='[{"op": "replace", "path": "/spec/storage/volumeClaimTemplate/spec/resources/requests/storage", "value": "2Gi"}]'
+              kubectl patch redisreplication redis-replication --namespace ${NAMESPACE} --type='json' -p="${PATCH_DATA}"
+        - assert:
+            timeout: 300s
+            file: ready-pvc-resized.yaml
+
     - name: redis-replication-uninstall
       description: Uninstall Redis Replication
       try:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/ready-pvc-resized.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/ready-pvc-resized.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-replication-redis-replication-0
+  labels:
+    app: redis-replication
+    redis_setup_type: replication
+    role: replication
+spec:
+  resources:
+    requests:
+      # NOTE: This is a workaround for the issue where the default storage class does not support volume expansion.
+      # Since we don't require PVC resizing (unlike physical disks), we can simply ensure that the requested PVC size is met.
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-replication-redis-replication-1
+  labels:
+    app: redis-replication
+    redis_setup_type: replication
+    role: replication
+spec:
+  resources:
+    requests:
+      # NOTE: This is a workaround for the issue where the default storage class does not support volume expansion.
+      # Since we don't require PVC resizing (unlike physical disks), we can simply ensure that the requested PVC size is met.
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-replication-redis-replication-2
+  labels:
+    app: redis-replication
+    redis_setup_type: replication
+    role: replication
+spec:
+  resources:
+    requests:
+      # NOTE: This is a workaround for the issue where the default storage class does not support volume expansion.
+      # Since we don't require PVC resizing (unlike physical disks), we can simply ensure that the requested PVC size is met.
+      storage: 2Gi


### PR DESCRIPTION
**Description**

Resizing STS VolumeClaimTemplates is currently broken because the change does not get detected and acted on. This is an unintended side effect of #1322 where the `newStateful` has its VCT changes reset and then a patch is calculated. If you've only changed the VCT, then because of the reset no changes are detected and the function returns early, leading to not resizing the PVCs, not replacing the StatefulSet (if recreation is enabled), and not setting the storageCapacity annotation. 

The change now takes into account whether STS recreation is enabled or not. If it is, it makes sense to not reset the VCT and recreate the STS. This then solves the TODO of handling the case when the STS is scaled out -- the new PVCs will have the intended new size.

The change is slightly messy -- it resizes the PVCs first and only then checks if the StatefulSet should be patched; this logically seems backwards. However, I opted for this because the alternative would have required a larger refactor (e.g. extracting some of the logic from HandlePVCResizing which detects there is a change). 
Another way to go about this is to remove the logic resetting the VCT changes altogether; then the code becomes a lot simpler. Given that the operator supports re-creating the STS (including orphaning the resources which will be adopted by the new STS), I am struggling to see why re-create isn't always turned on. Nevertheless, I have opted to keep the behaviour as I could be missing something. 

Lastly, I have reviewed #1321 and I think my PR still addresses it. I have tested locally by mutating a RedisCluster's annotation, observing the operator updating the STS, the pods being rolled, and then the stream of changes from `kubectl get sts -w` stopping. 

Fixes #1321

**Type of change**

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

