### PR TITLE
docs: fix redis sentinel example

### DIFF
--- a/docs/content/en/docs/Getting Started/Sentinel/_index.md
+++ b/docs/content/en/docs/Getting Started/Sentinel/_index.md
@@ -71,7 +71,7 @@ metadata:
   name: redis-sentinel
 spec:
   clusterSize: 3
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig:


### PR DESCRIPTION
**Description**

`fsGroup` is only available under `PodSecurityContext` in the CRD unless I'm not seeing it right.

**Type of change**
* Documentation

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

