### PR TITLE
docs: fix Redis Cluster YAML Manifest Example (#1345)

### DIFF
--- a/docs/content/en/docs/Getting Started/Cluster/_index.md
+++ b/docs/content/en/docs/Getting Started/Cluster/_index.md
@@ -91,7 +91,7 @@ metadata:
 spec:
   clusterSize: 3
   clusterVersion: v7
-  securityContext:
+  podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   persistenceEnabled: true


### PR DESCRIPTION
**Description**

This pull request corrects an error in the YAML installation example for Redis Cluster found in the documentation under `Installation > Getting Started > Cluster`.
The sample manifest incorrectly used `spec.securityContext` for the `RedisCluster` Custom Resource (apiVersion `redis.redis.opstreelabs.in/v1beta2`). This has been updated to the correct field `spec.podSecurityContext`.

This change ensures that users following the YAML installation guide can successfully deploy a Redis cluster without encountering a `BadRequest` error due to an unknown field.

Fixes : https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1345
**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

The error message encountered when applying the incorrect manifest as per the old documentation was:

```
Error from server (BadRequest): error when creating "redis-cluster/clusterd.yaml": RedisCluster in version "v1beta2" cannot be handled as a RedisCluster: strict decoding error: unknown field "spec.securityContext"
```

This PR directly addresses this documentation flaw to improve the user experience.