### PR TITLE
fix: Service updated before Statefulset during Reconcilation #1347

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -122,16 +122,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	err = k8sutils.CreateRedisLeader(ctx, instance, r.K8sClient)
+	if err != nil {
+		return intctrlutil.RequeueWithError(ctx, err, "")
+	}
 	if leaderReplicas != 0 {
 		err = k8sutils.CreateRedisLeaderService(ctx, instance, r.K8sClient)
 		if err != nil {
 			return intctrlutil.RequeueWithError(ctx, err, "")
 		}
 	}
-	err = k8sutils.CreateRedisLeader(ctx, instance, r.K8sClient)
-	if err != nil {
-		return intctrlutil.RequeueWithError(ctx, err, "")
-	}
+
 	err = k8sutils.ReconcileRedisPodDisruptionBudget(ctx, instance, "leader", instance.Spec.RedisLeader.PodDisruptionBudget, r.K8sClient)
 	if err != nil {
 		return intctrlutil.RequeueWithError(ctx, err, "")


### PR DESCRIPTION
fix: Service updated before Statefulset during Reconcilation(#1347)

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1347

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

I have only fixed the cluster creation and label updates with this pull request. Any other test cases needs to be tested.
<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
