### PR TITLE
fix(cluster): sync ready replica counts when StatefulSets degrade

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -219,8 +219,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if !r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-leader") || !r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-follower") {
-		return intctrlutil.Reconciled()
+	leaderSTSReady := r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-leader")
+	followerSTSReady := r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-follower")
+	if !leaderSTSReady || !followerSTSReady {
+		// Sync the actual ready replica counts from the StatefulSets so the status
+		// leaves Ready (and the reported counts drop) when pods go down after the
+		// cluster became Ready.
+		notReadyStatus := rcvb2.RedisClusterStatus{
+			State:                 rcvb2.RedisClusterInitializing,
+			Reason:                rcvb2.InitializingClusterFollowerReason,
+			ReadyLeaderReplicas:   r.getStatefulSetReadyReplicas(ctx, instance.Namespace, instance.Name+"-leader"),
+			ReadyFollowerReplicas: r.getStatefulSetReadyReplicas(ctx, instance.Namespace, instance.Name+"-follower"),
+		}
+		if !leaderSTSReady {
+			notReadyStatus.Reason = rcvb2.InitializingClusterLeaderReason
+		}
+		requeue, err := r.updateStatus(ctx, instance, notReadyStatus)
+		if err != nil {
+			return intctrlutil.RequeueE(ctx, err, "")
+		}
+		if requeue {
+			return intctrlutil.Requeue()
+		}
+		return intctrlutil.RequeueAfter(ctx, time.Second*10, "StatefulSet is not ready yet")
 	}
 
 	// Mark the cluster status as bootstrapping if all the leader and follower nodes are ready
@@ -439,6 +460,19 @@ func (r *Reconciler) updateStatus(ctx context.Context, rc *rcvb2.RedisCluster, s
 		return true, common.UpdateStatus(ctx, r.Client, copy)
 	}
 	return false, nil
+}
+
+// getStatefulSetReadyReplicas returns the number of ready replicas reported by
+// the StatefulSet status, or 0 if the StatefulSet does not exist yet.
+func (r *Reconciler) getStatefulSetReadyReplicas(ctx context.Context, namespace, name string) int32 {
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, sts); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "failed to get statefulset", "statefulset", name)
+		}
+		return 0
+	}
+	return sts.Status.ReadyReplicas
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/rediscluster/rediscluster_controller_test.go
+++ b/internal/controller/rediscluster/rediscluster_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
@@ -147,6 +148,117 @@ var _ = Describe("Redis Cluster Controller", func() {
 				Timeout:           timeout,
 				Interval:          interval,
 			})
+		})
+	})
+
+	Context("When pods become not ready after the cluster has been Ready", func() {
+		const degradedName = "redis-cluster-degraded-test"
+
+		// setStatefulSetReadyReplicas simulates pod readiness changes by updating the
+		// StatefulSet status, since no StatefulSet controller runs in envtest.
+		setStatefulSetReadyReplicas := func(name string, readyReplicas int32) {
+			Eventually(func() error {
+				sts := &appsv1.StatefulSet{}
+				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, sts); err != nil {
+					return err
+				}
+				sts.Status.Replicas = *sts.Spec.Replicas
+				sts.Status.ReadyReplicas = readyReplicas
+				sts.Status.AvailableReplicas = readyReplicas
+				sts.Status.CurrentReplicas = *sts.Spec.Replicas
+				sts.Status.UpdatedReplicas = *sts.Spec.Replicas
+				sts.Status.ObservedGeneration = sts.Generation
+				return k8sClient.Status().Update(context.Background(), sts)
+			}, timeout, interval).Should(Succeed())
+		}
+
+		getClusterStatus := func() (rcvb2.RedisClusterStatus, error) {
+			rc := &rcvb2.RedisCluster{}
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: degradedName, Namespace: ns}, rc)
+			return rc.Status, err
+		}
+
+		It("should leave the Ready state and decrease the ready replica counts", func() {
+			redisCluster := &rcvb2.RedisCluster{
+				ObjectMeta: testutil.CreateTestObject(degradedName, ns, nil),
+				Spec: rcvb2.RedisClusterSpec{
+					ClusterSize: ptr.To(int32(3)),
+					KubernetesConfig: common.KubernetesConfig{
+						Image: testutil.DefaultRedisImage,
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), redisCluster)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(context.Background(), redisCluster)).Should(Succeed())
+			})
+
+			By("marking the leader and follower StatefulSets as ready")
+			setStatefulSetReadyReplicas(degradedName+"-leader", 3)
+			setStatefulSetReadyReplicas(degradedName+"-follower", 3)
+
+			By("waiting for the operator to report all replicas as ready")
+			Eventually(getClusterStatus, timeout, interval).Should(Equal(rcvb2.RedisClusterStatus{
+				State:                 rcvb2.RedisClusterBootstrap,
+				Reason:                rcvb2.BootstrapClusterReason,
+				ReadyLeaderReplicas:   3,
+				ReadyFollowerReplicas: 3,
+			}))
+
+			By("simulating a cluster that has reached the Ready state")
+			Eventually(func() error {
+				rc := &rcvb2.RedisCluster{}
+				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: degradedName, Namespace: ns}, rc); err != nil {
+					return err
+				}
+				rc.Status = rcvb2.RedisClusterStatus{
+					State:                 rcvb2.RedisClusterReady,
+					Reason:                rcvb2.ReadyClusterReason,
+					ReadyLeaderReplicas:   3,
+					ReadyFollowerReplicas: 3,
+				}
+				return k8sClient.Status().Update(context.Background(), rc)
+			}, timeout, interval).Should(Succeed())
+
+			By("verifying the status stays Ready while all pods are ready")
+			Consistently(func() (rcvb2.RedisClusterState, error) {
+				status, err := getClusterStatus()
+				return status.State, err
+			}, time.Second*2, interval).Should(Equal(rcvb2.RedisClusterReady))
+
+			By("dropping one follower pod from ready")
+			setStatefulSetReadyReplicas(degradedName+"-follower", 2)
+
+			By("verifying the status leaves Ready and the follower count drops")
+			Eventually(getClusterStatus, timeout, interval).Should(Equal(rcvb2.RedisClusterStatus{
+				State:                 rcvb2.RedisClusterInitializing,
+				Reason:                rcvb2.InitializingClusterFollowerReason,
+				ReadyLeaderReplicas:   3,
+				ReadyFollowerReplicas: 2,
+			}))
+
+			By("dropping one leader pod from ready")
+			setStatefulSetReadyReplicas(degradedName+"-leader", 2)
+
+			By("verifying the leader count drops as well")
+			Eventually(getClusterStatus, timeout, interval).Should(Equal(rcvb2.RedisClusterStatus{
+				State:                 rcvb2.RedisClusterInitializing,
+				Reason:                rcvb2.InitializingClusterLeaderReason,
+				ReadyLeaderReplicas:   2,
+				ReadyFollowerReplicas: 2,
+			}))
+
+			By("recovering all pods")
+			setStatefulSetReadyReplicas(degradedName+"-leader", 3)
+			setStatefulSetReadyReplicas(degradedName+"-follower", 3)
+
+			By("verifying the status reports all replicas as ready again")
+			Eventually(getClusterStatus, timeout, interval).Should(Equal(rcvb2.RedisClusterStatus{
+				State:                 rcvb2.RedisClusterBootstrap,
+				Reason:                rcvb2.BootstrapClusterReason,
+				ReadyLeaderReplicas:   3,
+				ReadyFollowerReplicas: 3,
+			}))
 		})
 	})
 })


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Key Changes
Status Management
- Added status updates for StatefulSet readiness checks
- Implemented faster requeue (5s) during degraded state
- New status flow: Initializing → Degraded → Bootstrap → Ready

Code Optimization
- Replaced early return with proper status updates
- Added explicit status checks for replica counts
- Better error handling during StatefulSet transitions

<!-- Please provide a summary of the change here. -->
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1359 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
