### PR TITLE
docs: update weight for Feature Gates documentation (#1370)

### DIFF
--- a/docs/content/en/docs/Advance Configuration/Feature Gates/_index.md
+++ b/docs/content/en/docs/Advance Configuration/Feature Gates/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Feature Gates"
 linkTitle: "Feature Gates"
-weight: 30
+weight: 40
 date: 2024-03-20T00:19:19Z
 description: >
   Configuration guide for Redis Operator feature gates


### PR DESCRIPTION
- Increased the weight of the Feature Gates section from 30 to 40 to adjust its prominence in the documentation hierarchy.