### PR TITLE
docs: add important notes on redisReplicationName parameter in Sentinel documentation

### DIFF
--- a/docs/content/en/docs/Getting Started/Sentinel/_index.md
+++ b/docs/content/en/docs/Getting Started/Sentinel/_index.md
@@ -34,6 +34,8 @@ REVISION: 1
 TEST SUITE: None
 ```
 
+**Note**: The `redisReplicationName` parameter must reference an existing RedisReplication resource. Make sure to deploy a RedisReplication resource first before installing the sentinel.
+
 Verify the sentinel redis setup by kubectl command line.
 
 ```shell
@@ -75,7 +77,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig:
-    redisReplicationName : redis-replication
+    redisReplicationName : redis-replication  # Must match the name of an existing RedisReplication resource
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:v7.0.15
     imagePullPolicy: IfNotPresent
@@ -87,6 +89,8 @@ spec:
         cpu: 101m
         memory: 128Mi
 ```
+
+**Important**: The `redisReplicationName` field must reference an existing RedisReplication resource. RedisSentinel monitors and manages Redis instances created by RedisReplication, so ensure you have deployed a RedisReplication resource with the same name before applying this manifest.
 
 The yaml manifest can easily get applied by using `kubectl`.
 


### PR DESCRIPTION
- Added a note emphasizing that the `redisReplicationName` parameter must reference an existing RedisReplication resource.
- Included a reminder to deploy a RedisReplication resource before installing Sentinel to ensure proper functionality.

This update clarifies the prerequisites for using Redis Sentinel effectively.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1290

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
