### PR TITLE
feat: add liveness/readiness probes to values.yaml and templates

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.5
-appVersion: "0.16.5"
+version: 0.17.0
+appVersion: "0.17.0"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -72,10 +72,12 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.clusterVersion | string | `"v7"` |  |
 | redisCluster.enableMasterSlaveAntiAffinity | bool | `false` | Enable pod anti-affinity between leader and follower pods by adding the appropriate label. Notice that this requires the operator to have its mutating webhook enabled, otherwise it will only add an annotation to the RedisCluster CR. Default is false. |
 | redisCluster.follower.affinity | string | `nil` |  |
+| redisCluster.follower.livenessProbe | object | `{}` |  |
 | redisCluster.follower.nodeSelector | string | `nil` |  |
 | redisCluster.follower.pdb.enabled | bool | `false` |  |
 | redisCluster.follower.pdb.maxUnavailable | int | `1` |  |
 | redisCluster.follower.pdb.minAvailable | int | `1` |  |
+| redisCluster.follower.readinessProbe | object | `{}` |  |
 | redisCluster.follower.replicas | int | `3` |  |
 | redisCluster.follower.securityContext | object | `{}` |  |
 | redisCluster.follower.serviceType | string | `"ClusterIP"` |  |
@@ -84,10 +86,12 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisCluster.imagePullSecrets | object | `{}` |  |
 | redisCluster.leader.affinity | object | `{}` |  |
+| redisCluster.leader.livenessProbe | object | `{}` |  |
 | redisCluster.leader.nodeSelector | string | `nil` |  |
 | redisCluster.leader.pdb.enabled | bool | `false` |  |
 | redisCluster.leader.pdb.maxUnavailable | int | `1` |  |
 | redisCluster.leader.pdb.minAvailable | int | `1` |  |
+| redisCluster.leader.readinessProbe | object | `{}` |  |
 | redisCluster.leader.replicas | int | `3` |  |
 | redisCluster.leader.securityContext | object | `{}` |  |
 | redisCluster.leader.serviceType | string | `"ClusterIP"` |  |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -39,6 +39,14 @@ nodeSelector:
 securityContext:
   {{- toYaml .securityContext | nindent 2 }}
 {{- end }}
+{{- if .livenessProbe }}
+livenessProbe:
+  {{- toYaml .livenessProbe | nindent 2 }}
+{{- end }}
+{{- if .readinessProbe }}
+readinessProbe:
+  {{- toYaml .readinessProbe | nindent 2 }}
+{{- end }}
 {{- end -}}
 
 {{/* Generate sidecar properties */}}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -51,6 +51,18 @@ redisCluster:
       enabled: false
       maxUnavailable: 1
       minAvailable: 1
+    livenessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+    readinessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
     
   follower:
     replicas: 3
@@ -76,6 +88,18 @@ redisCluster:
       enabled: false
       maxUnavailable: 1
       minAvailable: 1
+    livenessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+    readinessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
 
 labels: {}
 #   foo: bar


### PR DESCRIPTION
- Updated Chart.yaml to version 0.17.0.
- Added livenessProbe and readinessProbe configurations to values.yaml for both leader and follower.
- Updated _helpers.tpl to include livenessProbe and readinessProbe in the rendered templates.

This update enhances the Redis cluster's health monitoring capabilities.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1328

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
