### PR TITLE
feat: avoid sentinel restart after replication failover

### DIFF
--- a/api/redisreplication/v1beta2/redisreplication_types.go
+++ b/api/redisreplication/v1beta2/redisreplication_types.go
@@ -57,6 +57,10 @@ type RedisReplication struct {
 	Status RedisReplicationStatus `json:"status,omitempty"`
 }
 
+func (rr *RedisReplication) GetStatefulSetName() string {
+	return rr.Name
+}
+
 // +kubebuilder:object:root=true
 
 // RedisList contains a list of Redis

--- a/api/redissentinel/v1beta2/redissentinel_types.go
+++ b/api/redissentinel/v1beta2/redissentinel_types.go
@@ -57,6 +57,10 @@ type RedisSentinel struct {
 	Status RedisSentinelStatus `json:"status,omitempty"`
 }
 
+func (rs *RedisSentinel) GetStatefulSetName() string {
+	return rs.Name + "-sentinel"
+}
+
 // +kubebuilder:object:root=true
 
 // RedisList contains a list of Redis

--- a/internal/cmd/manager/manager.go
+++ b/internal/cmd/manager/manager.go
@@ -23,6 +23,7 @@ import (
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/redis"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/scheme"
 	rediscontroller "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/redis"
 	redisclustercontroller "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/rediscluster"
@@ -231,6 +232,8 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, dk8sClie
 	}
 	if err := (&redissentinelcontroller.RedisSentinelReconciler{
 		Client:             mgr.GetClient(),
+		Checker:            redis.NewChecker(k8sClient),
+		Healer:             redis.NewHealer(k8sClient),
 		K8sClient:          k8sClient,
 		Dk8sClient:         dk8sClient,
 		ReplicationWatcher: intctrlutil.NewResourceWatcher(),

--- a/internal/controller/common/redis/check.go
+++ b/internal/controller/common/redis/check.go
@@ -1,0 +1,105 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rr "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Checker interface {
+	GetMasterFromReplication(ctx context.Context, rr *rr.RedisReplication) (corev1.Pod, error)
+	GetPassword(ctx context.Context, ns string, secret *common.ExistingPasswordSecret) (string, error)
+}
+
+type checker struct {
+	redis redis.Client
+	k8s   kubernetes.Interface
+}
+
+func NewChecker(clientset kubernetes.Interface) Checker {
+	return &checker{
+		k8s:   clientset,
+		redis: redis.NewClient(),
+	}
+}
+
+func (c *checker) GetPassword(ctx context.Context, ns string, secret *common.ExistingPasswordSecret) (string, error) {
+	if secret == nil {
+		return "", nil
+	}
+	secretName, err := c.k8s.CoreV1().Secrets(ns).Get(ctx, *secret.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for key, value := range secretName.Data {
+		if key == *secret.Key {
+			return strings.TrimSpace(string(value)), nil
+		}
+	}
+	return "", errors.New("secret key not found")
+}
+
+func (c *checker) GetMasterFromReplication(ctx context.Context, rr *rr.RedisReplication) (corev1.Pod, error) {
+	sts, err := c.k8s.AppsV1().StatefulSets(rr.Namespace).Get(ctx, rr.GetStatefulSetName(), metav1.GetOptions{})
+	if err != nil {
+		return corev1.Pod{}, err
+	}
+
+	var labels []string
+	for k, v := range sts.Spec.Selector.MatchLabels {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	pods, err := c.k8s.CoreV1().Pods(rr.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: strings.Join(labels, ","),
+	})
+	if err != nil {
+		return corev1.Pod{}, err
+	}
+
+	password, err := c.GetPassword(ctx, rr.Namespace, rr.Spec.KubernetesConfig.ExistingPasswordSecret)
+	if err != nil {
+		return corev1.Pod{}, err
+	}
+
+	var masterPods []corev1.Pod
+	for _, pod := range pods.Items {
+		connInfo := &redis.ConnectionInfo{
+			IP:       pod.Status.PodIP,
+			Port:     "6379",
+			Password: password,
+		}
+		isMaster, err := c.redis.Connect(connInfo).IsMaster(ctx)
+		if err != nil {
+			return corev1.Pod{}, err
+		}
+		if isMaster {
+			masterPods = append(masterPods, pod)
+		}
+	}
+
+	var realMasterPod corev1.Pod
+	for _, pod := range masterPods {
+		connInfo := &redis.ConnectionInfo{
+			IP:       pod.Status.PodIP,
+			Port:     "6379",
+			Password: password,
+		}
+		count, err := c.redis.Connect(connInfo).GetAttachedReplicaCount(ctx)
+		if err != nil {
+			continue
+		}
+		if count != 0 {
+			realMasterPod = pod
+			break
+		}
+	}
+	return realMasterPod, nil
+}

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -1,0 +1,124 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Healer interface {
+	SentinelMonitor(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error
+	SentinelReset(ctx context.Context, rs *rsvb2.RedisSentinel) error
+}
+
+type healer struct {
+	redis redis.Client
+	k8s   kubernetes.Interface
+}
+
+func NewHealer(clientset kubernetes.Interface) Healer {
+	return &healer{
+		k8s:   clientset,
+		redis: redis.NewClient(),
+	}
+}
+
+// SentinelReset range all sentinel execute `sentinel reset *`
+func (h *healer) SentinelReset(ctx context.Context, rs *rsvb2.RedisSentinel) error {
+	pods, err := h.getSentinelPods(ctx, rs)
+	if err != nil {
+		return err
+	}
+
+	sentinelPass, err := NewChecker(h.k8s).GetPassword(ctx, rs.Namespace, rs.Spec.KubernetesConfig.ExistingPasswordSecret)
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		connInfo := &redis.ConnectionInfo{
+			IP:       pod.Status.PodIP,
+			Port:     "26379",
+			Password: sentinelPass,
+		}
+		err = h.redis.Connect(connInfo).SentinelReset(ctx, rs.Spec.RedisSentinelConfig.MasterGroupName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SentinelMonitor range all sentinel execute `sentinel monitor`
+func (h *healer) SentinelMonitor(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error {
+	pods, err := h.getSentinelPods(ctx, rs)
+	if err != nil {
+		return err
+	}
+
+	sentinelPass, err := NewChecker(h.k8s).GetPassword(ctx, rs.Namespace, rs.Spec.KubernetesConfig.ExistingPasswordSecret)
+	if err != nil {
+		return err
+	}
+
+	var masterPass string
+	if rs.Spec.RedisSentinelConfig.RedisReplicationPassword != nil && rs.Spec.RedisSentinelConfig.RedisReplicationPassword.SecretKeyRef != nil {
+		masterPass, err = NewChecker(h.k8s).GetPassword(ctx, rs.Namespace, &common.ExistingPasswordSecret{
+			Name: &rs.Spec.RedisSentinelConfig.RedisReplicationPassword.SecretKeyRef.Name,
+			Key:  &rs.Spec.RedisSentinelConfig.RedisReplicationPassword.SecretKeyRef.Key,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, pod := range pods.Items {
+		connInfo := &redis.ConnectionInfo{
+			IP:       pod.Status.PodIP,
+			Port:     "26379",
+			Password: sentinelPass,
+		}
+		masterConnInfo := &redis.ConnectionInfo{
+			IP:       master,
+			Port:     "6379",
+			Password: masterPass,
+		}
+		err = h.redis.Connect(connInfo).SentinelMonitor(
+			ctx,
+			masterConnInfo,
+			rs.Spec.RedisSentinelConfig.MasterGroupName,
+			rs.Spec.RedisSentinelConfig.Quorum,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *healer) getSentinelPods(ctx context.Context, rs *rsvb2.RedisSentinel) (*v1.PodList, error) {
+	sentinelSTS, err := h.k8s.AppsV1().StatefulSets(rs.Namespace).Get(ctx, rs.GetStatefulSetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []string
+	for k, v := range sentinelSTS.Spec.Selector.MatchLabels {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	pods, err := h.k8s.CoreV1().Pods(rs.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: strings.Join(labels, ","),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pods, nil
+}

--- a/internal/controller/redis/redis_controller.go
+++ b/internal/controller/redis/redis_controller.go
@@ -41,11 +41,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
 	if err != nil {
-		return intctrlutil.RequeueWithErrorChecking(ctx, err, "failed to get redis instance")
+		return intctrlutil.RequeueECheck(ctx, err, "failed to get redis instance")
 	}
 	if instance.ObjectMeta.GetDeletionTimestamp() != nil {
 		if err = k8sutils.HandleRedisFinalizer(ctx, r.Client, instance); err != nil {
-			return intctrlutil.RequeueWithError(ctx, err, "failed to handle redis finalizer")
+			return intctrlutil.RequeueE(ctx, err, "failed to handle redis finalizer")
 		}
 		return intctrlutil.Reconciled()
 	}
@@ -53,15 +53,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return intctrlutil.Reconciled()
 	}
 	if err = k8sutils.AddFinalizer(ctx, instance, k8sutils.RedisFinalizer, r.Client); err != nil {
-		return intctrlutil.RequeueWithError(ctx, err, "failed to add finalizer")
+		return intctrlutil.RequeueE(ctx, err, "failed to add finalizer")
 	}
 	err = k8sutils.CreateStandaloneRedis(ctx, instance, r.K8sClient)
 	if err != nil {
-		return intctrlutil.RequeueWithError(ctx, err, "failed to create redis")
+		return intctrlutil.RequeueE(ctx, err, "failed to create redis")
 	}
 	err = k8sutils.CreateStandaloneService(ctx, instance, r.K8sClient)
 	if err != nil {
-		return intctrlutil.RequeueWithError(ctx, err, "failed to create service")
+		return intctrlutil.RequeueE(ctx, err, "failed to create service")
 	}
 	return intctrlutil.RequeueAfter(ctx, time.Second*10, "requeue after 10 seconds")
 }

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -115,6 +115,10 @@ func (r *RedisSentinelReconciler) reconcileSentinel(ctx context.Context, instanc
 		return ctrl.Result{}, err
 	}
 
+	if instance.Spec.RedisSentinelConfig == nil {
+		return ctrl.Result{}, nil
+	}
+
 	rr := &rrvb2.RedisReplication{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Namespace: instance.Namespace,

--- a/internal/controller/redissentinel/redissentinel_controller_suite_test.go
+++ b/internal/controller/redissentinel/redissentinel_controller_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/redis"
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/controllerutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -102,8 +103,12 @@ var _ = BeforeSuite(func() {
 	dk8sClient, err := dynamic.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
+	checker := redis.NewChecker(k8sClient)
+	healer := redis.NewHealer(k8sClient)
 	err = (&RedisSentinelReconciler{
 		Client:             k8sManager.GetClient(),
+		Checker:            checker,
+		Healer:             healer,
 		K8sClient:          k8sClient,
 		Dk8sClient:         dk8sClient,
 		ReplicationWatcher: intctrlutil.NewResourceWatcher(),

--- a/internal/controllerutil/controller_common.go
+++ b/internal/controllerutil/controller_common.go
@@ -25,7 +25,7 @@ func RequeueAfter(ctx context.Context, duration time.Duration, msg string, keysA
 	}, nil
 }
 
-func RequeueWithError(ctx context.Context, err error, msg string, keysAndValues ...interface{}) (reconcile.Result, error) {
+func RequeueE(ctx context.Context, err error, msg string, keysAndValues ...interface{}) (reconcile.Result, error) {
 	if msg == "" {
 		msg = "requeue with error"
 	}
@@ -33,9 +33,9 @@ func RequeueWithError(ctx context.Context, err error, msg string, keysAndValues 
 	return reconcile.Result{}, err
 }
 
-func RequeueWithErrorChecking(ctx context.Context, err error, msg string, keysAndValues ...interface{}) (reconcile.Result, error) {
+func RequeueECheck(ctx context.Context, err error, msg string, keysAndValues ...interface{}) (reconcile.Result, error) {
 	if apierrors.IsNotFound(err) {
 		return Reconciled()
 	}
-	return RequeueWithError(ctx, err, msg, keysAndValues...)
+	return RequeueE(ctx, err, msg, keysAndValues...)
 }

--- a/internal/k8sutils/redis-sentinel.go
+++ b/internal/k8sutils/redis-sentinel.go
@@ -268,26 +268,26 @@ func getSentinelEnvVariable(ctx context.Context, client kubernetes.Interface, cr
 		return &[]corev1.EnvVar{}, nil
 	}
 
-	var IP string
-	if cr.Spec.RedisSentinelConfig.ResolveHostnames == "yes" {
-		IP = getRedisReplicationMasterName(ctx, client, cr, dcl)
-	} else {
-		IP = getRedisReplicationMasterIP(ctx, client, cr, dcl)
-	}
+	// var IP string
+	// if cr.Spec.RedisSentinelConfig.ResolveHostnames == "yes" {
+	// 	IP = getRedisReplicationMasterName(ctx, client, cr, dcl)
+	// } else {
+	// 	IP = getRedisReplicationMasterIP(ctx, client, cr, dcl)
+	// }
 
-	if IP == "" {
-		return &[]corev1.EnvVar{}, fmt.Errorf("failed to get master IP/hostname")
-	}
+	// if IP == "" {
+	// 	return &[]corev1.EnvVar{}, fmt.Errorf("failed to get master IP/hostname")
+	// }
 
 	envVar := &[]corev1.EnvVar{
 		{
 			Name:  "MASTER_GROUP_NAME",
 			Value: cr.Spec.RedisSentinelConfig.MasterGroupName,
 		},
-		{
-			Name:  "IP",
-			Value: IP,
-		},
+		// {
+		// 	Name:  "IP",
+		// 	Value: IP,
+		// },
 		{
 			Name:  "PORT",
 			Value: cr.Spec.RedisSentinelConfig.RedisPort,

--- a/internal/k8sutils/redis-sentinel.go
+++ b/internal/k8sutils/redis-sentinel.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
@@ -397,14 +396,5 @@ func getRedisReplicationMasterIP(ctx context.Context, client kubernetes.Interfac
 		return ""
 	} else {
 		return getRedisServerIP(ctx, client, RedisDetails)
-	}
-}
-
-func getRedisReplicationMasterName(ctx context.Context, client kubernetes.Interface, cr *rsvb2.RedisSentinel, dcl dynamic.Interface) string {
-	RedisDetails := getRedisReplicationMasterPod(ctx, client, cr, dcl)
-	if RedisDetails.PodName == "" || RedisDetails.Namespace == "" {
-		return ""
-	} else {
-		return fmt.Sprintf("%s.%s-headless.%s.svc", RedisDetails.PodName, cr.Spec.RedisSentinelConfig.RedisReplicationName, RedisDetails.Namespace)
 	}
 }

--- a/internal/service/redis/client.go
+++ b/internal/service/redis/client.go
@@ -1,0 +1,158 @@
+package redis
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+
+	rediscli "github.com/redis/go-redis/v9"
+)
+
+const (
+	redisRoleMaster = "role:master"
+)
+
+type ConnectionInfo struct {
+	IP       string
+	Port     string
+	Password string
+}
+
+type Client interface {
+	Connect(info *ConnectionInfo) Service
+}
+
+func (c *client) Connect(info *ConnectionInfo) Service {
+	service := &service{}
+	service.client = &client{
+		new: func(ctx context.Context) (*rediscli.Client, error) {
+			opts := &rediscli.Options{
+				Addr:     net.JoinHostPort(info.IP, info.Port),
+				Password: info.Password,
+				DB:       0,
+			}
+			rClient := rediscli.NewClient(opts)
+			defer rClient.Close()
+			return rClient, nil
+		},
+	}
+	return service
+}
+
+type client struct {
+	new func(ctx context.Context) (*rediscli.Client, error)
+}
+
+func NewClient() Client {
+	return &client{}
+}
+
+type Service interface {
+	IsMaster(ctx context.Context) (bool, error)
+	GetAttachedReplicaCount(ctx context.Context) (int, error)
+	SentinelMonitor(ctx context.Context, master *ConnectionInfo, masterGroupName, quorum string) error
+	SentinelReset(ctx context.Context, masterGroupName string) error
+}
+
+type service struct {
+	client *client
+}
+
+func NewService() Service {
+	return &service{}
+}
+
+func (c *service) SentinelReset(ctx context.Context, masterGroupName string) error {
+	client, err := c.client.new(ctx)
+	if err != nil {
+		return err
+	}
+	cmd := rediscli.NewStringCmd(ctx, "SENTINEL", "RESET", masterGroupName)
+	err = client.Process(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	if err = cmd.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *service) SentinelMonitor(ctx context.Context, master *ConnectionInfo, masterGroupName, quorum string) error {
+
+	var (
+		cmd *rediscli.BoolCmd
+		err error
+	)
+
+	client, err := c.client.new(ctx)
+	if err != nil {
+		return err
+	}
+	cmd = rediscli.NewBoolCmd(ctx, "SENTINEL", "REMOVE", masterGroupName)
+	err = client.Process(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	if err = cmd.Err(); err != nil {
+		return err
+	}
+
+	cmd = rediscli.NewBoolCmd(ctx, "SENTINEL", "MONITOR", masterGroupName, master.IP, master.Port, quorum)
+	err = client.Process(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	if err = cmd.Err(); err != nil {
+		return err
+	}
+
+	if master.Password != "" {
+		cmd = rediscli.NewBoolCmd(ctx, "SENTINEL", "SET", masterGroupName, "auth-pass", master.Password)
+		err = client.Process(ctx, cmd)
+		if err != nil {
+			return err
+		}
+		if err = cmd.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *service) IsMaster(ctx context.Context) (bool, error) {
+	client, err := c.client.new(ctx)
+	if err != nil {
+		return false, err
+	}
+	result, err := client.Info(ctx, "replication").Result()
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(result, redisRoleMaster), nil
+}
+
+func (c *service) GetAttachedReplicaCount(ctx context.Context) (int, error) {
+	client, err := c.client.new(ctx)
+	if err != nil {
+		return 0, err
+	}
+	result, err := client.Info(ctx, "replication").Result()
+	if err != nil {
+		return 0, err
+	}
+
+	var count int
+	for _, line := range strings.Split(result, "\r\n") {
+		if strings.HasPrefix(line, "connected_slaves:") {
+			count, err = strconv.Atoi(strings.TrimPrefix(line, "connected_slaves:"))
+			if err != nil {
+				return 0, err
+			}
+			return count, nil
+		}
+	}
+	return count, nil
+}

--- a/internal/service/redis/client.go
+++ b/internal/service/redis/client.go
@@ -80,7 +80,6 @@ func (c *service) SentinelReset(ctx context.Context, masterGroupName string) err
 }
 
 func (c *service) SentinelMonitor(ctx context.Context, master *ConnectionInfo, masterGroupName, quorum string) error {
-
 	var (
 		cmd *rediscli.BoolCmd
 		err error


### PR DESCRIPTION
- Added Checker and Healer interfaces to manage Redis replication and sentinel health.
- Introduced methods for checking master status and resetting sentinels.
- Updated RedisSentinelReconciler to utilize the new health check and healing functionalities.

This enhancement improves the reliability and self-healing capabilities of the Redis operator.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #436 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
