### PR TITLE
feat: add bus port configuration for Redis cluster services

### DIFF
--- a/api/common/v1beta2/common_types.go
+++ b/api/common/v1beta2/common_types.go
@@ -57,14 +57,58 @@ func (in *KubernetesConfig) ShouldCreateAdditionalService() bool {
 	return *in.Service.Additional.Enabled
 }
 
+// ShouldIncludeBusPort returns whether bus port should be included in the service
+func (in *KubernetesConfig) ShouldIncludeBusPort() bool {
+	if in.Service == nil {
+		return false
+	}
+	if in.Service.IncludeBusPort == nil {
+		return false
+	}
+	return *in.Service.IncludeBusPort
+}
+
+// ShouldIncludeBusPortForHeadless returns whether bus port should be included in the headless service
+func (in *KubernetesConfig) ShouldIncludeBusPortForHeadless() bool {
+	if in.Service == nil {
+		return false
+	}
+	if in.Service.Headless == nil {
+		return false
+	}
+	if in.Service.Headless.IncludeBusPort == nil {
+		return false
+	}
+	return *in.Service.Headless.IncludeBusPort
+}
+
+// ShouldIncludeBusPortForAdditional returns whether bus port should be included in the additional service
+func (in *KubernetesConfig) ShouldIncludeBusPortForAdditional() bool {
+	if in.Service == nil {
+		return false
+	}
+	if in.Service.Additional == nil {
+		return false
+	}
+	if in.Service.Additional.IncludeBusPort == nil {
+		return false
+	}
+	return *in.Service.Additional.IncludeBusPort
+}
+
 // ServiceConfig define the type of service to be created and its annotations
 // +k8s:deepcopy-gen=true
 type ServiceConfig struct {
 	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;ClusterIP
 	ServiceType        string            `json:"serviceType,omitempty"`
 	ServiceAnnotations map[string]string `json:"annotations,omitempty"`
-	Headless           *Service          `json:"headless,omitempty"`
-	Additional         *Service          `json:"additional,omitempty"`
+	// IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+	// This field is only used for Redis cluster mode.
+	IncludeBusPort *bool `json:"includeBusPort,omitempty"`
+	// Headless config for which suffix is -headless service
+	Headless *Service `json:"headless,omitempty"`
+	// Additional config for which suffix is -additional service
+	Additional *Service `json:"additional,omitempty"`
 }
 
 // Service is the struct to define the service type and its annotations
@@ -74,6 +118,9 @@ type Service struct {
 	// +kubebuilder:default:=ClusterIP
 	Type                  string            `json:"type,omitempty"`
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+	// IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+	// This field is only used for Redis cluster mode.
+	IncludeBusPort *bool `json:"includeBusPort,omitempty"`
 	// +kubebuilder:default:=true
 	Enabled *bool `json:"enabled,omitempty"`
 }

--- a/api/common/v1beta2/zz_generated.deepcopy.go
+++ b/api/common/v1beta2/zz_generated.deepcopy.go
@@ -465,6 +465,11 @@ func (in *Service) DeepCopyInto(out *Service) {
 			(*out)[key] = val
 		}
 	}
+	if in.IncludeBusPort != nil {
+		in, out := &in.IncludeBusPort, &out.IncludeBusPort
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Enabled != nil {
 		in, out := &in.Enabled, &out.Enabled
 		*out = new(bool)
@@ -491,6 +496,11 @@ func (in *ServiceConfig) DeepCopyInto(out *ServiceConfig) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.IncludeBusPort != nil {
+		in, out := &in.IncludeBusPort, &out.IncludeBusPort
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Headless != nil {
 		in, out := &in.Headless, &out.Headless

--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -1633,8 +1633,8 @@ spec:
                       and its annotations
                     properties:
                       additional:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Additional config for which suffix is -additional
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1642,6 +1642,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1656,8 +1661,8 @@ spec:
                           type: string
                         type: object
                       headless:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Headless config for which suffix is -headless
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1665,6 +1670,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1674,6 +1684,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                      includeBusPort:
+                        description: |-
+                          IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                          This field is only used for Redis cluster mode.
+                        type: boolean
                       serviceType:
                         enum:
                         - LoadBalancer

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -783,8 +783,8 @@ spec:
                       and its annotations
                     properties:
                       additional:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Additional config for which suffix is -additional
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -792,6 +792,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -806,8 +811,8 @@ spec:
                           type: string
                         type: object
                       headless:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Headless config for which suffix is -headless
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -815,6 +820,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -824,6 +834,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                      includeBusPort:
+                        description: |-
+                          IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                          This field is only used for Redis cluster mode.
+                        type: boolean
                       serviceType:
                         enum:
                         - LoadBalancer

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -1642,8 +1642,8 @@ spec:
                       and its annotations
                     properties:
                       additional:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Additional config for which suffix is -additional
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1651,6 +1651,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1665,8 +1670,8 @@ spec:
                           type: string
                         type: object
                       headless:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Headless config for which suffix is -headless
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1674,6 +1679,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1683,6 +1693,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                      includeBusPort:
+                        description: |-
+                          IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                          This field is only used for Redis cluster mode.
+                        type: boolean
                       serviceType:
                         enum:
                         - LoadBalancer

--- a/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
@@ -1568,8 +1568,8 @@ spec:
                       and its annotations
                     properties:
                       additional:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Additional config for which suffix is -additional
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1577,6 +1577,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1591,8 +1596,8 @@ spec:
                           type: string
                         type: object
                       headless:
-                        description: Service is the struct to define the service type
-                          and its annotations
+                        description: Headless config for which suffix is -headless
+                          service
                         properties:
                           additionalAnnotations:
                             additionalProperties:
@@ -1600,6 +1605,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            type: boolean
+                          includeBusPort:
+                            description: |-
+                              IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                              This field is only used for Redis cluster mode.
                             type: boolean
                           type:
                             default: ClusterIP
@@ -1609,6 +1619,11 @@ spec:
                             - ClusterIP
                             type: string
                         type: object
+                      includeBusPort:
+                        description: |-
+                          IncludeBusPort when set to true, it will add bus port to the service, such as 16379.
+                          This field is only used for Redis cluster mode.
+                        type: boolean
                       serviceType:
                         enum:
                         - LoadBalancer

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -316,6 +316,17 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 	} else {
 		epp = disableMetrics
 	}
+
+	busPort := corev1.ServicePort{
+		Name:     "redis-bus",
+		Port:     int32(*cr.Spec.Port + 10000),
+		Protocol: corev1.ProtocolTCP,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: int32(*cr.Spec.Port + 10000),
+		},
+	}
+
 	objectMetaInfo := generateObjectMetaInformation(
 		serviceName,
 		cr.Namespace,
@@ -334,12 +345,20 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 		labels,
 		generateServiceAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.GetServiceAnnotations(), epp),
 	)
-	err := CreateOrUpdateService(ctx, cr.Namespace, headlessObjectMetaInfo, redisClusterAsOwner(cr), disableMetrics, true, "ClusterIP", *cr.Spec.Port, cl)
+	headlessExtraPorts := []corev1.ServicePort{}
+	if cr.Spec.KubernetesConfig.ShouldIncludeBusPortForHeadless() {
+		headlessExtraPorts = append(headlessExtraPorts, busPort)
+	}
+	err := CreateOrUpdateService(ctx, cr.Namespace, headlessObjectMetaInfo, redisClusterAsOwner(cr), disableMetrics, true, "ClusterIP", *cr.Spec.Port, cl, headlessExtraPorts...)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Cannot create headless service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
 	}
-	err = CreateOrUpdateService(ctx, cr.Namespace, objectMetaInfo, redisClusterAsOwner(cr), epp, false, "ClusterIP", *cr.Spec.Port, cl)
+	extraPorts := []corev1.ServicePort{}
+	if cr.Spec.KubernetesConfig.ShouldIncludeBusPort() {
+		extraPorts = append(extraPorts, busPort)
+	}
+	err = CreateOrUpdateService(ctx, cr.Namespace, objectMetaInfo, redisClusterAsOwner(cr), epp, false, "ClusterIP", *cr.Spec.Port, cl, extraPorts...)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Cannot create service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
@@ -354,9 +373,12 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 			return err
 		}
 	}
-	// Only create additional service if it's enabled
+	additionalExtraPorts := []corev1.ServicePort{}
+	if cr.Spec.KubernetesConfig.ShouldIncludeBusPortForAdditional() {
+		additionalExtraPorts = append(additionalExtraPorts, busPort)
+	}
 	if cr.Spec.KubernetesConfig.ShouldCreateAdditionalService() {
-		err = CreateOrUpdateService(ctx, cr.Namespace, additionalObjectMetaInfo, redisClusterAsOwner(cr), disableMetrics, false, additionalServiceType, *cr.Spec.Port, cl)
+		err = CreateOrUpdateService(ctx, cr.Namespace, additionalObjectMetaInfo, redisClusterAsOwner(cr), disableMetrics, false, additionalServiceType, *cr.Spec.Port, cl, additionalExtraPorts...)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "Cannot create additional service for Redis", "Setup.Type", service.RedisServiceRole)
 			return err

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
@@ -15,9 +15,13 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     service:
+      includeBusPort: true
       headless:
+        includeBusPort: true
         additionalAnnotations:
           test: test
+      additional:
+        includeBusPort: true
     image: quay.io/opstree/redis:latest
     imagePullPolicy: Always
     resources:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/ready-svc.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/ready-svc.yaml
@@ -246,10 +246,6 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
-    - name: redis-bus
-      port: 16379
-      protocol: TCP
-      targetPort: 16379
   selector:
     cluster: redis-cluster-v1beta2
     redis-role: master

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/ready-svc.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/ready-svc.yaml
@@ -23,6 +23,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-leader
     redis_setup_type: cluster
@@ -59,6 +63,10 @@ spec:
       port: 9121
       protocol: TCP
       targetPort: 9121
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-leader
     redis_setup_type: cluster
@@ -93,6 +101,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-leader
     redis_setup_type: cluster
@@ -129,6 +141,10 @@ spec:
       port: 9121
       protocol: TCP
       targetPort: 9121
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-follower
     redis_setup_type: cluster
@@ -161,6 +177,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-follower
     redis_setup_type: cluster
@@ -195,6 +215,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     app: redis-cluster-v1beta2-follower
     redis_setup_type: cluster
@@ -222,6 +246,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-bus
+      port: 16379
+      protocol: TCP
+      targetPort: 16379
   selector:
     cluster: redis-cluster-v1beta2
     redis-role: master


### PR DESCRIPTION
- Introduced new methods in KubernetesConfig to determine if the bus port should be included for headless and additional services.
- Updated ServiceConfig and Service structs to include an optional IncludeBusPort field.
- Enhanced service creation logic to conditionally add the bus port based on the new configuration.
- Updated CRD definitions to reflect the new IncludeBusPort field and its description.
- Modified e2e tests to validate the inclusion of the bus port in service configurations.

This enhancement allows for better customization of Redis service configurations, particularly for Redis cluster mode.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1039

Add includeBusPort Configuration for Redis Cluster Services

This PR adds a new includeBusPort field to control Redis bus port (16379) inclusion in cluster services with granular configuration options.
```
apiVersion: redis.redis.opstreelabs.in/v1beta2
kind: RedisCluster
spec:
  kubernetesConfig:
    service:
      includeBusPort: true      
      headless:
        includeBusPort: true    # Headless service
      additional:
        includeBusPort: false   # Additional service
```

* Three configuration levels: service, headless service, and additional service
* Default value: false (bus port not included)
* Backward compatible: Existing deployments unchanged

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
