### PR TITLE
feat: Round robin where to transfer cluster shards when scaling in a Redis Cluster

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				// and makes the subsequent rebalancing step more efficient.
 				// TODO: consider doing the resharding in parallel
 				shardMoveNodeIdx := shardIdx % leaderReplicas
-				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, true, shardMoveNodeIdx)
+				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, shardMoveNodeIdx, true)
 				monitoring.RedisClusterReshardTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()
 			}
 			logger.Info("Redis cluster is downscaled... Rebalancing the cluster")

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -109,6 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				// We round robin over the remaining nodes to pick a node where to move the shard to.
 				// This helps reduce the chance of overloading/OOMing the remaining nodes
 				// and makes the subsequent rebalancing step more efficient.
+				// TODO: consider doing the resharding in parallel
 				shardMoveNodeIdx := shardIdx % leaderReplicas
 				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, true, shardMoveNodeIdx)
 				monitoring.RedisClusterReshardTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -106,7 +106,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				k8sutils.RemoveRedisFollowerNodesFromCluster(ctx, r.K8sClient, instance, shardIdx)
 				monitoring.RedisClusterRemoveFollowerAttempt.WithLabelValues(instance.Namespace, instance.Name).Inc()
 				// Step 2 Reshard the Cluster
-				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, true)
+				// We round robin over the remaining nodes to pick a node where to move the shard to.
+				// This helps reduce the chance of overloading/OOMing the remaining nodes
+				// and makes the subsequent rebalancing step more efficient.
+				shardMoveNodeIdx := shardIdx % leaderReplicas
+				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, true, shardMoveNodeIdx)
 				monitoring.RedisClusterReshardTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()
 			}
 			logger.Info("Redis cluster is downscaled... Rebalancing the cluster")

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -15,15 +15,16 @@ import (
 // ReshardRedisCluster transfer the slots from the last node to the first node.
 //
 // NOTE: when all slot been transferred, the node become slave of the first master node.
-func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, shardIdx int32, remove bool) {
-	redisClient := configureRedisClient(ctx, client, cr, cr.ObjectMeta.Name+"-leader-0")
+func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, shardIdx int32, remove bool, targetNodeIdx int32) {
+	targetNodeName := fmt.Sprintf("%s-leader-%d", cr.ObjectMeta.Name, targetNodeIdx)
+	redisClient := configureRedisClient(ctx, client, cr, targetNodeName)
 	defer redisClient.Close()
 
 	var cmd []string
 
 	// Transfer Pod details
 	transferPOD := RedisDetails{
-		PodName:   cr.ObjectMeta.Name + "-leader-0",
+		PodName:   targetNodeName,
 		Namespace: cr.Namespace,
 	}
 	// Remove POD details

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -15,7 +15,7 @@ import (
 // ReshardRedisCluster transfer the slots from the last node to the provided transfer node.
 //
 // NOTE: when all slot been transferred, the node become slave of the transfer node.
-func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, shardIdx int32, remove bool, transferNodeIdx int32) {
+func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, shardIdx int32, transferNodeIdx int32, remove bool) {
 	transferNodeName := fmt.Sprintf("%s-leader-%d", cr.ObjectMeta.Name, transferNodeIdx)
 	redisClient := configureRedisClient(ctx, client, cr, transferNodeName)
 	defer redisClient.Close()

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -76,9 +76,9 @@ func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *r
 	cmd = append(cmd, "--cluster-yes")
 
 	log.FromContext(ctx).V(1).Info("redis cluster reshard command is", "Command", cmd)
-	log.FromContext(ctx).Info("transferring slots", "slots", slots, "from shard", shardIdx, "to shard", transferNodeIdx)
+	log.FromContext(ctx).Info(fmt.Sprintf("transferring %s slots from shard %d to shard %d", slots, shardIdx, transferNodeIdx))
 	executeCommand(ctx, client, cr, cmd, transferNodeName)
-	log.FromContext(ctx).Info("transferring slots completed", "slots", slots, "from shard", shardIdx, "to shard", transferNodeIdx)
+	log.FromContext(ctx).Info(fmt.Sprintf("transferring %s slots from shard %d to shard %d completed", slots, shardIdx, transferNodeIdx))
 
 	if remove {
 		RemoveRedisNodeFromCluster(ctx, client, cr, removePOD)

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -64,15 +64,15 @@ func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *r
 	cmd = append(cmd, transferNodeID)
 
 	// Cluster Slots
-	slot := getRedisClusterSlots(ctx, redisClient, removeNodeID)
+	slots := getRedisClusterSlots(ctx, redisClient, removeNodeID)
 	cmd = append(cmd, "--cluster-slots")
-	cmd = append(cmd, slot)
+	cmd = append(cmd, slots)
 
 	cmd = append(cmd, "--cluster-yes")
 
 	log.FromContext(ctx).V(1).Info("Redis cluster reshard command is", "Command", cmd)
 
-	if slot == "0" {
+	if slots == "0" {
 		log.FromContext(ctx).V(1).Info("Skipped the execution of", "Cmd", cmd)
 		return
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**


Rather than always picking the first leader node, round robin among the remaining leaders during a scale in event. This should help distribute the load on the remaining nodes during transfer, reduce the chance for OOMKills, and make the subsequent rebalance command more efficient as there will be fewer slots to move. 

Fixes [#1334](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1334)

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass. -- Unfortunately, I'm not sure what's a good way to test this in the current codebase
- [X] Functionality/bugs have been confirmed to be unchanged or fixed. -- Yes, tested manually by creating a cluster and monitoring the distribution of shards during a scale in event (from 10 to 5; from 5 to 3) and the logged messages. 
- [X] I have performed a self-review of my own code. -- Yes
- [X] Documentation has been updated or added where necessary. -- N/A

**Additional Context**

```
...
{"level":"info","ts":"2025-06-18T12:45:16Z","msg":"Transferring 1638 slots from shard 9 to shard 1","controller":"rediscluster","controllerGroup":"[redis.redis.opstreelabs.in](http://redis.redis.opstreelabs.in/)","controllerKind":"RedisCluster","RedisCluster":{"name":"redis-cluster","namespace":"default"},"namespace":"default","name":"redis-cluster","reconcileID":"9460db8a-2391-456b-a53d-0124e5f782ff"}
...
{"level":"info","ts":"2025-06-18T12:46:32Z","msg":"Transferring 1639 slots from shard 8 to shard 0","controller":"rediscluster","controllerGroup":"redis.redis.opstreelabs.in","controllerKind":"RedisCluster","RedisCluster":{"name":"redis-cluster","namespace":"default"},"namespace":"default","name":"redis-cluster","reconcileID":"9460db8a-2391-456b-a53d-0124e5f782ff"}
```
