### PR TITLE
docs: add example for password protected redis cluster for helmreleas…

### DIFF
--- a/example/v1beta2/password_protected/cluster.yaml
+++ b/example/v1beta2/password_protected/cluster.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ot-helm
+  namespace: redis
+spec:
+  interval: 24h
+  url: https://ot-container-kit.github.io/helm-charts/
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: redis-cluster
+  namespace: redis
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: redis-cluster
+      version: "0.17.0"
+      sourceRef:
+        kind: HelmRepository
+        name: ot-helm
+        namespace: redis
+      interval: 24h
+  values:
+    redisCluster:
+      clusterSize: 3
+      persistenceEnabled: true
+      redisSecret:
+        secretName: "redis-default-credential"
+        secretKey: "password"
+      resources:
+        requests:
+          cpu: 101m
+          memory: 128Mi
+        limits:
+          cpu: 101m
+          memory: 128Mi
+    acl:
+      secret:
+        secretName: redis-acl


### PR DESCRIPTION
This PR is intended to extend the documentation when deploying a cluster using the HelmRelease for deploying a redis-cluster with password_protected
