### PR TITLE
refactor: remove dynamic client usage and streamline Kubernetes client interactions

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller_suite_test.go
+++ b/internal/controller/rediscluster/rediscluster_controller_suite_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -96,13 +95,10 @@ var _ = BeforeSuite(func() {
 	k8sClient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	dk8sClient, err := dynamic.NewForConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{
 		Client:      k8sManager.GetClient(),
 		K8sClient:   k8sClient,
-		Dk8sClient:  dk8sClient,
 		Healer:      redis.NewHealer(k8sClient),
 		Recorder:    k8sManager.GetEventRecorderFor("rediscluster-controller"),
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -12,7 +12,6 @@ import (
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/controllerutil"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,7 +24,6 @@ type RedisSentinelReconciler struct {
 	Checker            redis.Checker
 	Healer             redis.Healer
 	K8sClient          kubernetes.Interface
-	Dk8sClient         dynamic.Interface
 	ReplicationWatcher *intctrlutil.ResourceWatcher
 }
 
@@ -90,7 +88,7 @@ func (r *RedisSentinelReconciler) reconcileFinalizer(ctx context.Context, instan
 }
 
 func (r *RedisSentinelReconciler) reconcileReplication(ctx context.Context, instance *rsvb2.RedisSentinel) (ctrl.Result, error) {
-	if instance.Spec.RedisSentinelConfig != nil && !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, r.Dk8sClient, instance) {
+	if instance.Spec.RedisSentinelConfig != nil && !k8sutils.IsRedisReplicationReady(ctx, r.K8sClient, r.Client, instance) {
 		return intctrlutil.RequeueAfter(ctx, time.Second*10, "Redis Replication is specified but not ready")
 	}
 
@@ -111,7 +109,7 @@ func (r *RedisSentinelReconciler) reconcileReplication(ctx context.Context, inst
 }
 
 func (r *RedisSentinelReconciler) reconcileSentinel(ctx context.Context, instance *rsvb2.RedisSentinel) (ctrl.Result, error) {
-	if err := k8sutils.CreateRedisSentinel(ctx, r.K8sClient, instance, r.K8sClient, r.Dk8sClient); err != nil {
+	if err := k8sutils.CreateRedisSentinel(ctx, r.K8sClient, instance, r.K8sClient, r.Client); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
 

--- a/internal/controller/redissentinel/redissentinel_controller_suite_test.go
+++ b/internal/controller/redissentinel/redissentinel_controller_suite_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -100,9 +99,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	dk8sClient, err := dynamic.NewForConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
-
 	checker := redis.NewChecker(k8sClient)
 	healer := redis.NewHealer(k8sClient)
 	err = (&RedisSentinelReconciler{
@@ -110,7 +106,6 @@ var _ = BeforeSuite(func() {
 		Checker:            checker,
 		Healer:             healer,
 		K8sClient:          k8sClient,
-		Dk8sClient:         dk8sClient,
 		ReplicationWatcher: intctrlutil.NewResourceWatcher(),
 	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/k8sutils/client.go
+++ b/internal/k8sutils/client.go
@@ -2,7 +2,7 @@ package k8sutils
 
 import (
 	// custom "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/dynamic"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -17,15 +17,6 @@ func GenerateK8sClient(configProvider K8sConfigProvider) (kubernetes.Interface, 
 		return nil, err
 	}
 	return kubernetes.NewForConfig(config)
-}
-
-// GenerateK8sClient create Dynamic client for kubernetes
-func GenerateK8sDynamicClient(configProvider K8sConfigProvider) (dynamic.Interface, error) {
-	config, err := configProvider()
-	if err != nil {
-		return nil, err
-	}
-	return dynamic.NewForConfig(config)
 }
 
 // GenerateK8sConfig will load the kube config file

--- a/internal/k8sutils/client_test.go
+++ b/internal/k8sutils/client_test.go
@@ -46,34 +46,3 @@ func TestGenerateK8sClient(t *testing.T) {
 		})
 	}
 }
-
-func TestGenerateK8sDynamicClient(t *testing.T) {
-	tests := []struct {
-		name           string
-		configProvider func() (*rest.Config, error)
-		wantErr        bool
-	}{
-		{
-			name:           "valid config",
-			configProvider: mockK8sConfigProvider,
-			wantErr:        false,
-		},
-		{
-			name:           "invalid config",
-			configProvider: mockInvalidK8sConfigProvider,
-			wantErr:        true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client, err := GenerateK8sDynamicClient(tt.configProvider)
-			if tt.wantErr {
-				assert.Error(t, err, "GenerateK8sDynamicClient() should return an error for invalid config")
-			} else {
-				assert.NoError(t, err, "GenerateK8sDynamicClient() should not return an error for valid config")
-				assert.NotNil(t, client, "expected a non-nil Kubernetes client")
-			}
-		})
-	}
-}

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -6,9 +6,9 @@ import (
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -221,7 +221,7 @@ func generateRedisReplicationInitContainerParams(cr *rrvb2.RedisReplication) ini
 	return initcontainerProp
 }
 
-func IsRedisReplicationReady(ctx context.Context, client kubernetes.Interface, dClient dynamic.Interface, rs *rsvb2.RedisSentinel) bool {
+func IsRedisReplicationReady(ctx context.Context, client kubernetes.Interface, ctrlClient client.Client, rs *rsvb2.RedisSentinel) bool {
 	// statefulset name the same as the redis replication name
 	sts, err := GetStatefulSet(ctx, client, rs.GetNamespace(), rs.Spec.RedisSentinelConfig.RedisReplicationName)
 	if err != nil {
@@ -239,7 +239,7 @@ func IsRedisReplicationReady(ctx context.Context, client kubernetes.Interface, d
 	// Enhanced check: When the pod is ready, it may not have been
 	// created as part of a replication cluster, so we should verify
 	// whether there is an actual master node.
-	if master := getRedisReplicationMasterIP(ctx, client, rs, dClient); master == "" {
+	if master := getRedisReplicationMasterIP(ctx, client, rs, ctrlClient); master == "" {
 		return false
 	}
 	return true

--- a/internal/k8sutils/status.go
+++ b/internal/k8sutils/status.go
@@ -5,16 +5,12 @@ import (
 	"reflect"
 
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // UpdateRedisClusterStatus will update the status of the RedisCluster
-func UpdateRedisClusterStatus(ctx context.Context, cr *rcvb2.RedisCluster, state rcvb2.RedisClusterState, reason string, readyLeaderReplicas, readyFollowerReplicas int32, dcl dynamic.Interface) error {
+func UpdateRedisClusterStatus(ctx context.Context, cr *rcvb2.RedisCluster, state rcvb2.RedisClusterState, reason string, readyLeaderReplicas, readyFollowerReplicas int32, k8sClient client.Client) error {
 	newStatus := rcvb2.RedisClusterStatus{
 		State:                 state,
 		Reason:                reason,
@@ -25,20 +21,8 @@ func UpdateRedisClusterStatus(ctx context.Context, cr *rcvb2.RedisCluster, state
 		return nil
 	}
 	cr.Status = newStatus
-	gvr := schema.GroupVersionResource{
-		Group:    "redis.redis.opstreelabs.in",
-		Version:  "v1beta2",
-		Resource: "redisclusters",
-	}
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "Failed to convert CR to unstructured object")
-		return err
-	}
-	unstructuredRedisCluster := &unstructured.Unstructured{Object: unstructuredObj}
 
-	_, err = dcl.Resource(gvr).Namespace(cr.Namespace).UpdateStatus(context.TODO(), unstructuredRedisCluster, metav1.UpdateOptions{})
-	if err != nil {
+	if err := k8sClient.Status().Update(ctx, cr); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to update status")
 		return err
 	}


### PR DESCRIPTION

- Eliminated the dynamic Kubernetes client from the codebase, simplifying client creation and usage across controllers and utility functions.
- Updated relevant functions and method signatures to use the standard Kubernetes client interface, enhancing code clarity and maintainability.
- Adjusted controller logic to ensure proper handling of Redis cluster and sentinel operations without the dynamic client.

This refactor improves the overall architecture and reduces complexity in client management.