### PR TITLE
Fix Redis master promotion and replication logic to prevent stale pod promotion

### DIFF
--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -2,6 +2,9 @@ package redisreplication
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
@@ -10,7 +13,10 @@ import (
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/controllerutil"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/monitoring"
+	goredis "github.com/redis/go-redis/v9"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -136,34 +142,154 @@ func (r *Reconciler) reconcileService(ctx context.Context, instance *rrvb2.Redis
 	return intctrlutil.Reconciled()
 }
 
-func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisReplication) (ctrl.Result, error) {
+func (r *Reconciler) reconcileRedis(
+	ctx context.Context,
+	instance *rrvb2.RedisReplication,
+) (ctrl.Result, error) {
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	var realMaster string
-	masterNodes := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "master")
-	slaveNodes := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "slave")
-	if len(masterNodes) > 1 {
-		log.FromContext(ctx).Info("Creating redis replication by executing replication creation commands")
+	//----------------------------------------------------------------------
+	// 0. Resolve Redis password from Secret (pointer-safe)
+	//----------------------------------------------------------------------
+	secretRef := instance.Spec.KubernetesConfig.ExistingPasswordSecret
+	if secretRef == nil ||
+		secretRef.Name == nil || secretRef.Key == nil ||
+		*secretRef.Name == "" || *secretRef.Key == "" {
 
-		realMaster = k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
-		if len(slaveNodes) == 0 {
-			realMaster = masterNodes[0]
+		log.FromContext(ctx).Info("existingPasswordSecret name/key not set")
+		return intctrlutil.RequeueAfter(ctx, 10*time.Second, "password ref missing")
+	}
+
+	secret, err := r.K8sClient.CoreV1().
+		Secrets(instance.Namespace).
+		Get(ctx, *secretRef.Name, metav1.GetOptions{})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "unable to read redis password secret")
+		return intctrlutil.RequeueAfter(ctx, 10*time.Second, "secret not ready")
+	}
+
+	rawPwd, ok := secret.Data[*secretRef.Key]
+	if !ok {
+		log.FromContext(ctx).Info("password key not present in secret", "key", *secretRef.Key)
+		return intctrlutil.RequeueAfter(ctx, 10*time.Second, "key missing in secret")
+	}
+	password := string(rawPwd)
+
+	//----------------------------------------------------------------------
+	// 1. List all Redis pods for this instance
+	//----------------------------------------------------------------------
+	pods, err := r.K8sClient.CoreV1().
+		Pods(instance.Namespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", instance.Name),
+		})
+	if err != nil {
+		return intctrlutil.RequeueE(ctx, err, "list pods")
+	}
+	if len(pods.Items) == 0 {
+		return intctrlutil.RequeueAfter(ctx, 10*time.Second, "no pods yet")
+	}
+
+	//----------------------------------------------------------------------
+	// 2. Healthy topology shortcut
+	//----------------------------------------------------------------------
+	masters := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "master")
+	slaves := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "slave")
+	if len(masters) == 1 && len(slaves) > 0 {
+		return intctrlutil.Reconciled()
+	}
+
+	//----------------------------------------------------------------------
+	// 3. Pick best pod by master_repl_offset
+	//----------------------------------------------------------------------
+	var (
+		bestPod    *corev1.Pod
+		bestOffset int64 = -1
+	)
+
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.PodIP == "" {
+			continue
 		}
-		if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, masterNodes, realMaster); err != nil {
-			return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
+
+		rdb := goredis.NewClient(&goredis.Options{
+			Addr:     fmt.Sprintf("%s:6379", p.Status.PodIP),
+			Password: password,
+		})
+		info, err := rdb.Info(ctx, "replication").Result()
+		rdb.Close()
+		if err != nil {
+			continue
+		}
+
+		for _, line := range strings.Split(info, "\r\n") {
+			if strings.HasPrefix(line, "master_repl_offset:") {
+				val := strings.TrimSpace(strings.TrimPrefix(line, "master_repl_offset:"))
+				if off, err := strconv.ParseInt(val, 10, 64); err == nil && off > bestOffset {
+					bestOffset = off
+					bestPod = p
+				}
+				break
+			}
 		}
 	}
 
-	monitoring.RedisReplicationReplicasSizeMismatch.WithLabelValues(instance.Namespace, instance.Name).Set(0)
-	if instance.Spec.Size != nil && int(*instance.Spec.Size) != (len(masterNodes)+len(slaveNodes)) {
-		monitoring.RedisReplicationReplicasSizeMismatch.WithLabelValues(instance.Namespace, instance.Name).Set(1)
+	if bestPod == nil || bestPod.Status.PodIP == "" {
+		return intctrlutil.RequeueAfter(ctx, 10*time.Second, "no reachable redis pods")
+	}
+	masterIP := bestPod.Status.PodIP
+
+	log.FromContext(ctx).Info("Reconfiguring replication",
+		"newMaster", bestPod.Name, "offset", bestOffset)
+
+	//----------------------------------------------------------------------
+	// 4. Re-attach others as replicas
+	//----------------------------------------------------------------------
+	for _, p := range pods.Items {
+		if p.Name == bestPod.Name || p.Status.PodIP == "" {
+			continue
+		}
+		rdb := goredis.NewClient(&goredis.Options{
+			Addr:     fmt.Sprintf("%s:6379", p.Status.PodIP),
+			Password: password,
+		})
+		if err := rdb.SlaveOf(ctx, masterIP, "6379").Err(); err != nil {
+			log.FromContext(ctx).Error(err, "SLAVEOF failed", "pod", p.Name)
+		}
+		rdb.Close()
 	}
 
-	monitoring.RedisReplicationReplicasSizeCurrent.WithLabelValues(instance.Namespace, instance.Name).Set(float64(len(masterNodes) + len(slaveNodes)))
-	monitoring.RedisReplicationReplicasSizeDesired.WithLabelValues(instance.Namespace, instance.Name).Set(float64(*instance.Spec.Size))
+	// ------------------------------------------------------------------
+	// 4b. Immediately correct pod labels so we don't have 2 masters
+	// ------------------------------------------------------------------
+	labels := common.GetRedisLabels(
+		instance.GetName(),
+		common.SetupTypeReplication,
+		"replication",
+		instance.GetLabels(),
+	)
 
-	return intctrlutil.Reconciled()
+	if err := r.Healer.UpdateRedisRoleLabel(
+		ctx,
+		instance.Namespace,
+		labels,
+		instance.Spec.KubernetesConfig.ExistingPasswordSecret,
+	); err != nil {
+
+		log.FromContext(ctx).Error(err, "failed to update redis-role labels")
+	}
+
+	//----------------------------------------------------------------------
+	// 5. Update CR status
+	//----------------------------------------------------------------------
+	if err := r.UpdateRedisReplicationMaster(ctx, instance, bestPod.Name); err != nil {
+		return intctrlutil.RequeueE(ctx, err, "update master status")
+	}
+
+	return intctrlutil.RequeueAfter(ctx, 30*time.Second, "verify replication")
 }
 
 // reconcileStatus update status and label.
@@ -173,6 +299,58 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisR
 
 	masterNodes := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "master")
 	realMaster = k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
+	if realMaster != "" && len(masterNodes) == 1 {
+		// ------------------------------------------------------------------
+		// Inline: fetch master_repl_offset for the sole master pod.
+		// If it is 0 (empty dataset), treat as “no valid master”.
+		// ------------------------------------------------------------------
+		var offset int64 = -1
+
+		// 1.  Pull password from Secret (pointer-safe)
+		if ref := instance.Spec.KubernetesConfig.ExistingPasswordSecret; ref != nil &&
+			ref.Name != nil && ref.Key != nil &&
+			*ref.Name != "" && *ref.Key != "" {
+
+			if sec, err := r.K8sClient.CoreV1().
+				Secrets(instance.Namespace).
+				Get(ctx, *ref.Name, metav1.GetOptions{}); err == nil {
+
+				if pwd, ok := sec.Data[*ref.Key]; ok {
+					password := string(pwd)
+
+					// 2. Get the master pod’s IP
+					if pod, err := r.K8sClient.CoreV1().
+						Pods(instance.Namespace).
+						Get(ctx, realMaster, metav1.GetOptions{}); err == nil &&
+						pod.Status.PodIP != "" {
+
+						// 3. Query INFO replication and parse master_repl_offset
+						rdb := goredis.NewClient(&goredis.Options{
+							Addr:     fmt.Sprintf("%s:6379", pod.Status.PodIP),
+							Password: password,
+						})
+						if info, err := rdb.Info(ctx, "replication").Result(); err == nil {
+							for _, line := range strings.Split(info, "\r\n") {
+								if strings.HasPrefix(line, "master_repl_offset:") {
+									v := strings.TrimSpace(strings.TrimPrefix(line, "master_repl_offset:"))
+									if o, err := strconv.ParseInt(v, 10, 64); err == nil {
+										offset = o
+									}
+									break
+								}
+							}
+						}
+						rdb.Close()
+					}
+				}
+			}
+		}
+
+		// 4. Empty dataset? -> act as if no master exists
+		if offset == 0 {
+			realMaster = ""
+		}
+	}
 	if err = r.UpdateRedisReplicationMaster(ctx, instance, realMaster); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -68,9 +68,9 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// DO NOT REQUEUE.
-	// only reconcile on resource(sentinel && watched redis replication) changes
-	return intctrlutil.Reconciled()
+	// Periodically reconcile so we catch pod restarts or lost endpoints
+	// even if no CR change was recorded.
+	return intctrlutil.RequeueAfter(ctx, time.Minute, "periodic Sentinel reconcile")
 }
 
 type reconciler struct {


### PR DESCRIPTION
**Description**

This PR improves the RedisReplication controller to correctly promote the replica with the most recent data when all other nodes are unavailable or in a broken state. It prevents a newly started empty Redis pod from being incorrectly promoted to master due to lack of existing masters.

Additionally, it ensures that once a healthy master is selected, all other pods are reattached as replicas and role labels are updated immediately within the same reconcile loop. This prevents having multiple pods temporarily labeled as `redis-role=master`, which could lead to misrouting or alerting issues.

Fixes [#1429](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1429) and [#1403](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1403)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

This PR introduces a more robust fallback in the `reconcileRedis` function when no master is available by:
- Selecting the pod with the highest `master_repl_offset` as the new master.
- Ensuring stale or rebooted pods do not automatically become master just because they start first.
- Immediately updating `redis-role` labels to reflect the new topology, preventing dual-master labelling between reconcile loops.

This addresses production issues seen with sentinel reconcile race conditions and replication gaps on pod restart.
