### PR TITLE
feat: add pprof configuration for performance profiling

### DIFF
--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -116,6 +116,8 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | redisOperator.name | string | `"redis-operator"` |  |
 | redisOperator.podAnnotations | object | `{}` |  |
 | redisOperator.podLabels | object | `{}` |  |
+| redisOperator.pprof.bindAddress | string | `":6060"` |  |
+| redisOperator.pprof.enabled | bool | `false` |  |
 | redisOperator.watchNamespace | string | `""` |  |
 | redisOperator.webhook | bool | `false` |  |
 | replicas | int | `1` |  |

--- a/charts/redis-operator/templates/operator-deployment.yaml
+++ b/charts/redis-operator/templates/operator-deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - manager
         args:
         - --leader-elect
+        {{- if .Values.redisOperator.pprof.enabled }}
+        - --pprof-bind-address={{ .Values.redisOperator.pprof.bindAddress }}
+        {{- end }}
         {{- range $arg := .Values.redisOperator.extraArgs }}
         - {{ $arg }}
         {{- end }}
@@ -54,6 +57,11 @@ spec:
         - containerPort: 8081
           name: probe
           protocol: TCP
+      {{- if .Values.redisOperator.pprof.enabled }}
+        - containerPort: {{ .Values.redisOperator.pprof.bindAddress | regexFind ":[0-9]+" | trimPrefix ":" }}
+          name: pprof
+          protocol: TCP
+      {{- end }}
       {{- if .Values.redisOperator.webhook }}
         - containerPort: 9443
           name: webhook-server

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -24,6 +24,12 @@ redisOperator:
   webhook: false
   automountServiceAccountToken: true
 
+  # pprof configuration for performance profiling
+  pprof:
+    # Enable pprof server for performance profiling
+    enabled: false
+    # The address the pprof endpoint binds to
+    bindAddress: ":6060"
 
 resources:
   limits:

--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -53,6 +53,7 @@ var setupLog = ctrl.Log.WithName("setup")
 type managerOptions struct {
 	metricsAddr             string
 	probeAddr               string
+	pprofAddr               string
 	enableLeaderElection    bool
 	enableWebhooks          bool
 	maxConcurrentReconciles int
@@ -85,6 +86,7 @@ func CMD() *cobra.Command {
 func addFlags(cmd *cobra.Command, opts *managerOptions) {
 	cmd.Flags().StringVar(&opts.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&opts.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	cmd.Flags().StringVar(&opts.pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to. If empty, pprof is disabled. Example: ':6060'")
 	cmd.Flags().BoolVar(&opts.enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().BoolVar(&opts.enableWebhooks, "enable-webhooks", internalenv.IsWebhookEnabled(), "Enable webhooks")
 	cmd.Flags().IntVar(&opts.maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Max concurrent reconciles")
@@ -166,6 +168,10 @@ func createControllerOptions(opts *managerOptions) ctrl.Options {
 		HealthProbeBindAddress: opts.probeAddr,
 		LeaderElection:         opts.enableLeaderElection,
 		LeaderElectionID:       "6cab913b.redis.opstreelabs.in",
+	}
+
+	if opts.pprofAddr != "" {
+		options.PprofBindAddress = opts.pprofAddr
 	}
 
 	watchNamespaces := internalenv.GetWatchNamespaces()


### PR DESCRIPTION
This update allows users to enable and configure pprof for better performance monitoring of the redis-operator.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1415 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
