### PR TITLE
fix: sentinel controller should reconcile on statefulset updated

### DIFF
--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/redis"
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/controllerutil"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -68,9 +69,7 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Periodically reconcile so we catch pod restarts or lost endpoints
-	// even if no CR change was recorded.
-	return intctrlutil.RequeueAfter(ctx, time.Minute, "periodic Sentinel reconcile")
+	return intctrlutil.Reconciled()
 }
 
 type reconciler struct {
@@ -168,6 +167,7 @@ func (r *RedisSentinelReconciler) reconcileService(ctx context.Context, instance
 func (r *RedisSentinelReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rsvb2.RedisSentinel{}).
+		Owns(&appsv1.StatefulSet{}).
 		WithOptions(opts).
 		Watches(&rrvb2.RedisReplication{}, r.ReplicationWatcher).
 		Complete(r)

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -68,9 +68,9 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// DO NOT REQUEUE.
-	// only reconcile on resource(sentinel && watched redis replication) changes
-	return intctrlutil.Reconciled()
+	// Periodically reconcile so we catch pod restarts or lost endpoints
+	// even if no CR change was recorded.
+	return intctrlutil.RequeueAfter(ctx, time.Minute, "periodic Sentinel reconcile")
 }
 
 type reconciler struct {

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/sentinel.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/sentinel.yaml
@@ -8,9 +8,6 @@ spec:
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
-  redisSentinelConfig:
-    redisReplicationName: redis-replication
-    quorum: '1'
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:latest
     imagePullPolicy: Always


### PR DESCRIPTION
### Description
Add watch resource of Redis Sentinel, so a sentinel is reconciled, even after restarting due to deletion or failure.

Fixes #1429.

### Checklist
- [x] E2E test covers pod deletion / rejoin
- [x] No dual-master labels observed in logs
- [x] Docs updated