### PR TITLE
docs: Update edit URL path

### DIFF
--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -2,7 +2,7 @@
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/main/site/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $editURL := printf "%s/edit/main/docs/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" data-proofer-ignore target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>


### PR DESCRIPTION
This PR corrects the "Edit this page" link in the documentation, ensuring it points to the accurate file path within the repository for direct editing.