### PR TITLE
docs: Update slack channel link and improve sharding section clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ Please see our [CHANGELOG.md](./CHANGELOG.md) for details.
 
 This project is managed by [OpsTree Solutions](http://opstree.com). For any queries or suggestions, you can reach out to us at [opensource@opstree.com](mailto:opensource@opstree.com).
 
-Join our Slack Channel: [#redis-operator](https://opstree.slack.com/archives/C05MBRB50JG).
+Join our Slack Channel: [#redis-operator](https://join.slack.com/t/opstree/shared_invite/zt-3o8jp35x-UGMU2Cy0WSBk3Lbzqa2wVw).

--- a/docs/content/en/docs/Redis Overview/_index.md
+++ b/docs/content/en/docs/Redis Overview/_index.md
@@ -34,20 +34,16 @@ There are two models of setting up cluster in redis:
 - Sharding
 - Replication
 
-Replication is also known as mirroring of data. In replication, all the data get copied from the leader node to the follower node. Sharding is also known as partitioning. It splits up the data by the key to multiple nodes.
+Replication is also known as mirroring of data. In replication, all the data get copied from the leader node to the follower node. 
 
 <div align="center">
     <img src="../../../images/replication.png">
 </div>
 
+Sharding is also known as partitioning. It splits up the data by the key to multiple nodes. In sharding, the keys are getting distributed across both machine A and B. That is, the machine A will hold the 1, 2 key and machine B will hold 3, 4 key.
+
 <div align="center">
     <img src="../../../images/sharding.png">
-</div>
-
-In sharding, the keys are getting distributed across both machine A and B. That is, the machine A will hold the 1, 3 key and machine B will hold 2, 4 key:
-
-<div align="center">
-    <img src="https://blog2opstree.files.wordpress.com/2019/06/08d40-1ylzieskl-3rvar6kleoziq.png">
 </div>
 
 ## Redis cluster challenges on Kubernetes


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
This pull request addresses two main documentation updates:

1.  **Slack Channel Link Update:** The `README.md` file's Slack channel invitation link was outdated. This PR updates it to the correct and active invitation link, ensuring users can easily join our community Slack channel.
2.  **Sharding Section Organization:** In `docs/content/en/docs/Redis Overview/_index.md`, the "Sharding" explanation was slightly redundant and could be clearer. This change refines the text to provide a more concise and accurate description of sharding, removing duplicate or confusing sentences. It also ensures the accompanying image correctly illustrates the concept.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Documentation update

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
