### PR TITLE
Add PersistentVolumeClaimRetentionPolicy support

### DIFF
--- a/api/common/v1beta2/common_types.go
+++ b/api/common/v1beta2/common_types.go
@@ -8,15 +8,16 @@ import (
 // KubernetesConfig will be the JSON struct for Basic Redis Config
 // +k8s:deepcopy-gen=true
 type KubernetesConfig struct {
-	Image                  string                           `json:"image"`
-	ImagePullPolicy        corev1.PullPolicy                `json:"imagePullPolicy,omitempty"`
-	Resources              *corev1.ResourceRequirements     `json:"resources,omitempty"`
-	ExistingPasswordSecret *ExistingPasswordSecret          `json:"redisSecret,omitempty"`
-	ImagePullSecrets       *[]corev1.LocalObjectReference   `json:"imagePullSecrets,omitempty"`
-	UpdateStrategy         appsv1.StatefulSetUpdateStrategy `json:"updateStrategy,omitempty"`
-	Service                *ServiceConfig                   `json:"service,omitempty"`
-	IgnoreAnnotations      []string                         `json:"ignoreAnnotations,omitempty"`
-	MinReadySeconds        *int32                           `json:"minReadySeconds,omitempty"`
+	Image                                string                                                  `json:"image"`
+	ImagePullPolicy                      corev1.PullPolicy                                       `json:"imagePullPolicy,omitempty"`
+	Resources                            *corev1.ResourceRequirements                            `json:"resources,omitempty"`
+	ExistingPasswordSecret               *ExistingPasswordSecret                                 `json:"redisSecret,omitempty"`
+	ImagePullSecrets                     *[]corev1.LocalObjectReference                          `json:"imagePullSecrets,omitempty"`
+	UpdateStrategy                       appsv1.StatefulSetUpdateStrategy                        `json:"updateStrategy,omitempty"`
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
+	Service                              *ServiceConfig                                          `json:"service,omitempty"`
+	IgnoreAnnotations                    []string                                                `json:"ignoreAnnotations,omitempty"`
+	MinReadySeconds                      *int32                                                  `json:"minReadySeconds,omitempty"`
 }
 
 func (in *KubernetesConfig) GetServiceType() string {

--- a/api/common/v1beta2/zz_generated.deepcopy.go
+++ b/api/common/v1beta2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package api
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 )
 
@@ -172,6 +173,11 @@ func (in *KubernetesConfig) DeepCopyInto(out *KubernetesConfig) {
 		}
 	}
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
+		**out = **in
+	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
 		*out = new(ServiceConfig)

--- a/charts/redis-operator/crds/crds.yaml
+++ b/charts/redis-operator/crds/crds.yaml
@@ -1564,6 +1564,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret
@@ -6085,6 +6106,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret
@@ -14779,6 +14821,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret
@@ -20277,6 +20340,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret

--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -1565,6 +1565,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -715,6 +715,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -1574,6 +1574,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret

--- a/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redissentinels.yaml
@@ -1500,6 +1500,27 @@ spec:
                   minReadySeconds:
                     format: int32
                     type: integer
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   redisSecret:
                     description: ExistingPasswordSecret is the struct to access the
                       existing secret

--- a/docs/content/en/docs/CRD Reference/Redis API/_index.md
+++ b/docs/content/en/docs/CRD Reference/Redis API/_index.md
@@ -75,6 +75,7 @@ _Appears in:_
 | `redisSecret` _[ExistingPasswordSecret](#existingpasswordsecret)_ |  |
 | `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ |  |
 | `updateStrategy` _[StatefulSetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetupdatestrategy-v1-apps)_ |  |
+| `persistentVolumeClaimRetentionPolicy` _[StatefulSetPersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps)_ |  |
 
 #### VolumeMount
 

--- a/example/v1beta2/pvc_retention_policy/clusterd.yaml
+++ b/example/v1beta2/pvc_retention_policy/clusterd.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  persistenceEnabled: true
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.12
+    imagePullPolicy: IfNotPresent
+    persistentVolumeClaimRetentionPolicy:
+      whenScaled: Delete
+      whenDeleted: Delete
+  redisExporter:
+    enabled: false
+    image: quay.io/opstree/redis-exporter:v1.44.0
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/example/v1beta2/pvc_retention_policy/replication.yaml
+++ b/example/v1beta2/pvc_retention_policy/replication.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: redis-replication
+spec:
+  clusterSize: 3
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.12
+    imagePullPolicy: IfNotPresent
+    persistentVolumeClaimRetentionPolicy:
+      whenScaled: Delete
+      whenDeleted: Delete
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+  redisExporter:
+    enabled: false
+    image: quay.io/opstree/redis-exporter:v1.44.0

--- a/example/v1beta2/pvc_retention_policy/standalone.yaml
+++ b/example/v1beta2/pvc_retention_policy/standalone.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: redis-standalone
+spec:
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.12
+    imagePullPolicy: IfNotPresent
+    persistentVolumeClaimRetentionPolicy:
+      whenScaled: Delete
+      whenDeleted: Delete
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  storage:
+    volumeClaimTemplate:
+      spec:
+        # storageClassName: standard
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+  redisExporter:
+    enabled: false
+    image: quay.io/opstree/redis-exporter:v1.44.0

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -42,21 +42,22 @@ func generateRedisClusterParams(ctx context.Context, cr *rcvb2.RedisCluster, rep
 		minreadyseconds = *cr.Spec.KubernetesConfig.MinReadySeconds
 	}
 	res := statefulSetParameters{
-		Replicas:                      &replicas,
-		ClusterMode:                   true,
-		ClusterVersion:                cr.Spec.ClusterVersion,
-		NodeSelector:                  params.NodeSelector,
-		TopologySpreadConstraints:     params.TopologySpreadConstraints,
-		PodSecurityContext:            cr.Spec.PodSecurityContext,
-		PriorityClassName:             cr.Spec.PriorityClassName,
-		Affinity:                      params.Affinity,
-		TerminationGracePeriodSeconds: params.TerminationGracePeriodSeconds,
-		Tolerations:                   params.Tolerations,
-		ServiceAccountName:            cr.Spec.ServiceAccountName,
-		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-		HostNetwork:                   cr.Spec.HostNetwork,
-		MinReadySeconds:               minreadyseconds,
+		Replicas:                             &replicas,
+		ClusterMode:                          true,
+		ClusterVersion:                       cr.Spec.ClusterVersion,
+		NodeSelector:                         params.NodeSelector,
+		TopologySpreadConstraints:            params.TopologySpreadConstraints,
+		PodSecurityContext:                   cr.Spec.PodSecurityContext,
+		PriorityClassName:                    cr.Spec.PriorityClassName,
+		Affinity:                             params.Affinity,
+		TerminationGracePeriodSeconds:        params.TerminationGracePeriodSeconds,
+		Tolerations:                          params.Tolerations,
+		ServiceAccountName:                   cr.Spec.ServiceAccountName,
+		UpdateStrategy:                       cr.Spec.KubernetesConfig.UpdateStrategy,
+		PersistentVolumeClaimRetentionPolicy: cr.Spec.KubernetesConfig.PersistentVolumeClaimRetentionPolicy,
+		IgnoreAnnotations:                    cr.Spec.KubernetesConfig.IgnoreAnnotations,
+		HostNetwork:                          cr.Spec.HostNetwork,
+		MinReadySeconds:                      minreadyseconds,
 	}
 	if cr.Spec.RedisExporter != nil {
 		res.EnableMetrics = cr.Spec.RedisExporter.Enabled

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -94,19 +94,20 @@ func generateRedisReplicationParams(cr *rrvb2.RedisReplication) statefulSetParam
 		minreadyseconds = *cr.Spec.KubernetesConfig.MinReadySeconds
 	}
 	res := statefulSetParameters{
-		Replicas:                      &replicas,
-		ClusterMode:                   false,
-		NodeConfVolume:                false,
-		NodeSelector:                  cr.Spec.NodeSelector,
-		PodSecurityContext:            cr.Spec.PodSecurityContext,
-		PriorityClassName:             cr.Spec.PriorityClassName,
-		Affinity:                      cr.Spec.Affinity,
-		Tolerations:                   cr.Spec.Tolerations,
-		TopologySpreadConstraints:     cr.Spec.TopologySpreadConstrains,
-		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
-		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-		MinReadySeconds:               minreadyseconds,
+		Replicas:                             &replicas,
+		ClusterMode:                          false,
+		NodeConfVolume:                       false,
+		NodeSelector:                         cr.Spec.NodeSelector,
+		PodSecurityContext:                   cr.Spec.PodSecurityContext,
+		PriorityClassName:                    cr.Spec.PriorityClassName,
+		Affinity:                             cr.Spec.Affinity,
+		Tolerations:                          cr.Spec.Tolerations,
+		TopologySpreadConstraints:            cr.Spec.TopologySpreadConstrains,
+		TerminationGracePeriodSeconds:        cr.Spec.TerminationGracePeriodSeconds,
+		UpdateStrategy:                       cr.Spec.KubernetesConfig.UpdateStrategy,
+		PersistentVolumeClaimRetentionPolicy: cr.Spec.KubernetesConfig.PersistentVolumeClaimRetentionPolicy,
+		IgnoreAnnotations:                    cr.Spec.KubernetesConfig.IgnoreAnnotations,
+		MinReadySeconds:                      minreadyseconds,
 	}
 	if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
 		res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets

--- a/internal/k8sutils/redis-sentinel.go
+++ b/internal/k8sutils/redis-sentinel.go
@@ -92,20 +92,21 @@ func generateRedisSentinelParams(ctx context.Context, cr *rsvb2.RedisSentinel, r
 		minreadyseconds = *cr.Spec.KubernetesConfig.MinReadySeconds
 	}
 	res := statefulSetParameters{
-		Replicas:                      &replicas,
-		ClusterMode:                   false,
-		NodeConfVolume:                false,
-		NodeSelector:                  cr.Spec.NodeSelector,
-		PodSecurityContext:            cr.Spec.PodSecurityContext,
-		PriorityClassName:             cr.Spec.PriorityClassName,
-		Affinity:                      affinity,
-		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
-		Tolerations:                   cr.Spec.Tolerations,
-		TopologySpreadConstraints:     cr.Spec.TopologySpreadConstrains,
-		ServiceAccountName:            cr.Spec.ServiceAccountName,
-		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-		MinReadySeconds:               minreadyseconds,
+		Replicas:                             &replicas,
+		ClusterMode:                          false,
+		NodeConfVolume:                       false,
+		NodeSelector:                         cr.Spec.NodeSelector,
+		PodSecurityContext:                   cr.Spec.PodSecurityContext,
+		PriorityClassName:                    cr.Spec.PriorityClassName,
+		Affinity:                             affinity,
+		TerminationGracePeriodSeconds:        cr.Spec.TerminationGracePeriodSeconds,
+		Tolerations:                          cr.Spec.Tolerations,
+		TopologySpreadConstraints:            cr.Spec.TopologySpreadConstrains,
+		ServiceAccountName:                   cr.Spec.ServiceAccountName,
+		UpdateStrategy:                       cr.Spec.KubernetesConfig.UpdateStrategy,
+		PersistentVolumeClaimRetentionPolicy: cr.Spec.KubernetesConfig.PersistentVolumeClaimRetentionPolicy,
+		IgnoreAnnotations:                    cr.Spec.KubernetesConfig.IgnoreAnnotations,
+		MinReadySeconds:                      minreadyseconds,
 	}
 
 	if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {

--- a/internal/k8sutils/redis-standalone.go
+++ b/internal/k8sutils/redis-standalone.go
@@ -102,18 +102,19 @@ func generateRedisStandaloneParams(cr *rvb2.Redis) statefulSetParameters {
 		minreadyseconds = *cr.Spec.KubernetesConfig.MinReadySeconds
 	}
 	res := statefulSetParameters{
-		Replicas:                      &replicas,
-		ClusterMode:                   false,
-		NodeConfVolume:                false,
-		NodeSelector:                  cr.Spec.NodeSelector,
-		PodSecurityContext:            cr.Spec.PodSecurityContext,
-		PriorityClassName:             cr.Spec.PriorityClassName,
-		Affinity:                      cr.Spec.Affinity,
-		TerminationGracePeriodSeconds: cr.Spec.TerminationGracePeriodSeconds,
-		Tolerations:                   cr.Spec.Tolerations,
-		UpdateStrategy:                cr.Spec.KubernetesConfig.UpdateStrategy,
-		IgnoreAnnotations:             cr.Spec.KubernetesConfig.IgnoreAnnotations,
-		MinReadySeconds:               minreadyseconds,
+		Replicas:                             &replicas,
+		ClusterMode:                          false,
+		NodeConfVolume:                       false,
+		NodeSelector:                         cr.Spec.NodeSelector,
+		PodSecurityContext:                   cr.Spec.PodSecurityContext,
+		PriorityClassName:                    cr.Spec.PriorityClassName,
+		Affinity:                             cr.Spec.Affinity,
+		TerminationGracePeriodSeconds:        cr.Spec.TerminationGracePeriodSeconds,
+		Tolerations:                          cr.Spec.Tolerations,
+		UpdateStrategy:                       cr.Spec.KubernetesConfig.UpdateStrategy,
+		PersistentVolumeClaimRetentionPolicy: cr.Spec.KubernetesConfig.PersistentVolumeClaimRetentionPolicy,
+		IgnoreAnnotations:                    cr.Spec.KubernetesConfig.IgnoreAnnotations,
+		MinReadySeconds:                      minreadyseconds,
 	}
 	if cr.Spec.KubernetesConfig.ImagePullSecrets != nil {
 		res.ImagePullSecrets = cr.Spec.KubernetesConfig.ImagePullSecrets

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -97,29 +97,30 @@ const (
 
 // statefulSetParameters will define statefulsets input params
 type statefulSetParameters struct {
-	Replicas                      *int32
-	ClusterMode                   bool
-	ClusterVersion                *string
-	NodeConfVolume                bool
-	NodeSelector                  map[string]string
-	TopologySpreadConstraints     []corev1.TopologySpreadConstraint
-	PodSecurityContext            *corev1.PodSecurityContext
-	PriorityClassName             string
-	Affinity                      *corev1.Affinity
-	Tolerations                   *[]corev1.Toleration
-	EnableMetrics                 bool
-	PersistentVolumeClaim         corev1.PersistentVolumeClaim
-	NodeConfPersistentVolumeClaim corev1.PersistentVolumeClaim
-	ImagePullSecrets              *[]corev1.LocalObjectReference
-	ExternalConfig                *string
-	ServiceAccountName            *string
-	UpdateStrategy                appsv1.StatefulSetUpdateStrategy
-	RecreateStatefulSet           bool
-	RecreateStatefulsetStrategy   *metav1.DeletionPropagation
-	TerminationGracePeriodSeconds *int64
-	IgnoreAnnotations             []string
-	HostNetwork                   bool
-	MinReadySeconds               int32
+	Replicas                             *int32
+	ClusterMode                          bool
+	ClusterVersion                       *string
+	NodeConfVolume                       bool
+	NodeSelector                         map[string]string
+	TopologySpreadConstraints            []corev1.TopologySpreadConstraint
+	PodSecurityContext                   *corev1.PodSecurityContext
+	PriorityClassName                    string
+	Affinity                             *corev1.Affinity
+	Tolerations                          *[]corev1.Toleration
+	EnableMetrics                        bool
+	PersistentVolumeClaim                corev1.PersistentVolumeClaim
+	NodeConfPersistentVolumeClaim        corev1.PersistentVolumeClaim
+	ImagePullSecrets                     *[]corev1.LocalObjectReference
+	ExternalConfig                       *string
+	ServiceAccountName                   *string
+	UpdateStrategy                       appsv1.StatefulSetUpdateStrategy
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy
+	RecreateStatefulSet                  bool
+	RecreateStatefulsetStrategy          *metav1.DeletionPropagation
+	TerminationGracePeriodSeconds        *int64
+	IgnoreAnnotations                    []string
+	HostNetwork                          bool
+	MinReadySeconds                      int32
 }
 
 // containerParameters will define container input params
@@ -277,11 +278,12 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
 		Spec: appsv1.StatefulSetSpec{
-			Selector:        LabelSelectors(selectorLabels),
-			ServiceName:     fmt.Sprintf("%s-headless", stsMeta.Name),
-			Replicas:        params.Replicas,
-			UpdateStrategy:  params.UpdateStrategy,
-			MinReadySeconds: params.MinReadySeconds,
+			Selector:                             LabelSelectors(selectorLabels),
+			ServiceName:                          fmt.Sprintf("%s-headless", stsMeta.Name),
+			Replicas:                             params.Replicas,
+			UpdateStrategy:                       params.UpdateStrategy,
+			PersistentVolumeClaimRetentionPolicy: params.PersistentVolumeClaimRetentionPolicy,
+			MinReadySeconds:                      params.MinReadySeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      stsMeta.GetLabels(),


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

StatefulSet has a `.spec.persistentVolumeClaimRetentionPolicy` that allows to control what happens to PVCs on scale and/or on STS deletion. This is very important setting to control cost sprawl because otherwise (default behavior) STS leaves all PVCs and their respective PVs lingering orphaned. This may result in accumulation of quite a lot of volumes and they are expensive if they backed by something like AWS EBS.

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
  I was following UpdateStrategy implementation and did not find any tests covering it, so I did not add any tests for PersistentVolumeClaimRetentionPolicy. I am new to the project and if someone can point me to where/what to add, I will gladly add it. Tested it manually though (see comment below with the test evidence).
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
