### PR TITLE
fix: Recover redisreplication from master pod deletion

### DIFF
--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -4,19 +4,18 @@ import (
 	"context"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/client-go/kubernetes"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	redis "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/redis"
 	intctrlutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/controllerutil"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/monitoring"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -160,11 +159,11 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	} else if len(masterNodes) == 1 && len(slaveNodes) > 0 {
 		realMaster = masterNodes[0]
 		currentRealMaster := k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
-		
+
 		if currentRealMaster == "" {
-			log.FromContext(ctx).Info("Detected disconnected slaves, reconfiguring replication", 
+			log.FromContext(ctx).Info("Detected disconnected slaves, reconfiguring replication",
 				"master", realMaster, "slaves", slaveNodes)
-			
+
 			allPods := append(masterNodes, slaveNodes...)
 			if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, allPods, realMaster); err != nil {
 				log.FromContext(ctx).Error(err, "Failed to reconfigure master-slave replication",


### PR DESCRIPTION
**Description**

When the master of a redisreplication is deleted, the slaves continue to point to the IP address of the old master until the pods are restarted.

Fixes [NO ISSUE EXISTS - BUT DESCRIPTION OF ISSUE IS BELOW]

We encountered an issue where the node that a master pod of a redisreplication was running on was cycled, and the master pod was evicted / killed as a result.  The cluster never recovered, because the slaves were all pointing to the old master.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- X Functionality/bugs have been confirmed to be unchanged or fixed.
- X I have performed a self-review of my own code.
- X Documentation has been updated or added where necessary.

**Additional Context**

The operator was previously only set up to handle a split brain (i.e. multiple master) scenario, so I've extended the logic to handle a orphaned master scenario as well.