### PR TITLE
fix: tls connection broken in replication with sentinel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,10 +238,13 @@ jobs:
 
       # NOTE: This is a workaround for the issue where the default storage class does not support volume expansion.
       # Since we don't require PVC resizing (unlike physical disks), we can simply ensure that the requested PVC size is met.
-      - name: Set allowVolumeExpansion to true
+      - name: Setup k8s Kind Cluster
         run: |
           DEFAULT_SC=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
           kubectl patch storageclass $DEFAULT_SC -p '{"allowVolumeExpansion": true}'          
+
+          # install cert-manager
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
 
       - name: Load Docker image into Kind
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,7 +2,7 @@ extends: default
 
 rules:
   line-length:
-    max: 200
+    max: 300
     level: warning
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -108,6 +108,8 @@ func GenerateConfig() error {
 			cfg.Append("tls-key-file", redisTLSCertKey)
 			cfg.Append("tls-ca-cert-file", redisTLSCAKey)
 			cfg.Append("tls-auth-clients", "optional")
+			// Sentinel should use tls for replication connection.
+			cfg.Append("tls-replication", "yes")
 		} else {
 			fmt.Println("Running sentinel without TLS mode")
 		}

--- a/internal/controller/common/redis/check.go
+++ b/internal/controller/common/redis/check.go
@@ -71,11 +71,7 @@ func (c *checker) GetMasterFromReplication(ctx context.Context, rr *rr.RedisRepl
 
 	var masterPods []corev1.Pod
 	for _, pod := range pods.Items {
-		connInfo := &redis.ConnectionInfo{
-			IP:       pod.Status.PodIP,
-			Port:     "6379",
-			Password: password,
-		}
+		connInfo := createConnectionInfo(ctx, pod, password, rr.Spec.TLS, c.k8s, rr.Namespace, "6379")
 		isMaster, err := c.redis.Connect(connInfo).IsMaster(ctx)
 		if err != nil {
 			return corev1.Pod{}, err
@@ -87,11 +83,7 @@ func (c *checker) GetMasterFromReplication(ctx context.Context, rr *rr.RedisRepl
 
 	var realMasterPod corev1.Pod
 	for _, pod := range masterPods {
-		connInfo := &redis.ConnectionInfo{
-			IP:       pod.Status.PodIP,
-			Port:     "6379",
-			Password: password,
-		}
+		connInfo := createConnectionInfo(ctx, pod, password, rr.Spec.TLS, c.k8s, rr.Namespace, "6379")
 		count, err := c.redis.Connect(connInfo).GetAttachedReplicaCount(ctx)
 		if err != nil {
 			continue

--- a/internal/controller/common/service.go
+++ b/internal/controller/common/service.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"strconv"
+	"strings"
+)
+
+// GetHeadlessServiceNameFromPodName trims the trailing ordinal (e.g. "-0", "-1") from a pod name to
+// derive the headless service name. If the pod name does not contain a trailing
+// ordinal segment the original name is returned unchanged.
+//
+// Examples for different Redis modes:
+// - RedisReplication: "redis-replication-0" -> "redis-replication-headless"
+// - RedisCluster Leader: "redis-cluster-leader-0" -> "redis-cluster-leader-headless"
+// - RedisCluster Follower: "redis-cluster-follower-1" -> "redis-cluster-follower-headless"
+// - RedisSentinel: "redis-sentinel-sentinel-0" -> "redis-sentinel-sentinel-headless"
+func GetHeadlessServiceNameFromPodName(podName string) string {
+	// Find the last dash in the pod name. If there is none, return the whole name.
+	idx := strings.LastIndex(podName, "-")
+	if idx == -1 {
+		return podName
+	}
+	// Check whether the suffix after the last dash is a number (the StatefulSet
+	// ordinal). If it is, trim it to get the service name; otherwise return the
+	// original pod name.
+	if _, err := strconv.Atoi(podName[idx+1:]); err == nil {
+		return podName[:idx] + "-headless"
+	}
+	return podName
+}

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -287,7 +287,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	for _, fakeRole := range []string{"leader", "follower"} {
 		labels := common.GetRedisLabels(instance.GetName()+"-"+fakeRole, common.SetupTypeCluster, fakeRole, instance.GetLabels())
-		if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret); err != nil {
+		if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret, instance.Spec.TLS); err != nil {
 			return intctrlutil.RequeueE(ctx, err, "")
 		}
 	}

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -2,6 +2,7 @@ package redissentinel
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
@@ -132,7 +133,7 @@ func (r *RedisSentinelReconciler) reconcileSentinel(ctx context.Context, instanc
 		return intctrlutil.RequeueE(ctx, err, "")
 	} else {
 		if instance.Spec.RedisSentinelConfig.ResolveHostnames == "yes" {
-			monitorAddr = common.GetHeadlessServiceNameFromPodName(master.Name)
+			monitorAddr = fmt.Sprintf("%s.%s.%s.svc.cluster.local", master.Name, common.GetHeadlessServiceNameFromPodName(master.Name), rr.Namespace)
 		} else {
 			monitorAddr = master.Status.PodIP
 		}

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -2,7 +2,6 @@ package redissentinel
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
@@ -54,9 +53,9 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	reconcilers := []reconciler{
 		{typ: "finalizer", rec: r.reconcileFinalizer},
 		{typ: "replication", rec: r.reconcileReplication},
-		{typ: "sentinel", rec: r.reconcileSentinel},
 		{typ: "pdb", rec: r.reconcilePDB},
 		{typ: "service", rec: r.reconcileService},
+		{typ: "sentinel", rec: r.reconcileSentinel},
 	}
 
 	for _, reconciler := range reconcilers {
@@ -133,7 +132,7 @@ func (r *RedisSentinelReconciler) reconcileSentinel(ctx context.Context, instanc
 		return intctrlutil.RequeueE(ctx, err, "")
 	} else {
 		if instance.Spec.RedisSentinelConfig.ResolveHostnames == "yes" {
-			monitorAddr = fmt.Sprintf("%s.%s-headless.%s.svc", master.Name, rr.Name, rr.Namespace)
+			monitorAddr = common.GetHeadlessServiceNameFromPodName(master.Name)
 		} else {
 			monitorAddr = master.Status.PodIP
 		}

--- a/internal/k8sutils/redis-sentinel.go
+++ b/internal/k8sutils/redis-sentinel.go
@@ -331,7 +331,11 @@ func getRedisReplicationMasterPod(ctx context.Context, client kubernetes.Interfa
 		log.FromContext(ctx).V(1).Info("Successfully got RedisReplication", "replication name", replicationName, "namespace", replicationNamespace)
 	}
 
-	masterPods := GetRedisNodesByRole(ctx, client, &replicationInstance, "master")
+	masterPods, err := GetRedisNodesByRole(ctx, client, &replicationInstance, "master")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get RedisReplication master pods", "replication name", replicationName, "namespace", replicationNamespace)
+		return emptyRedisInfo
+	}
 	if len(masterPods) == 0 {
 		log.FromContext(ctx).Error(errors.New("no master pods found"), "")
 		return emptyRedisInfo

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -837,7 +837,10 @@ func Test_checkRedisServerRole(t *testing.T) {
 				mock.ExpectInfo("Replication").SetVal(tt.infoReturn)
 			}
 
-			role := checkRedisServerRole(ctx, client, tt.podName)
+			role, err := checkRedisServerRole(ctx, client, tt.podName)
+			if err != nil {
+				assert.Error(t, err)
+			}
 			if tt.shouldFail {
 				assert.Empty(t, role, "Test case: "+tt.name)
 			} else {

--- a/internal/util/cryptutil/tls_verify.go
+++ b/internal/util/cryptutil/tls_verify.go
@@ -1,0 +1,71 @@
+package cryptutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// VerifyCertificateExceptServerName verifies a certificate chain without hostname verification.
+// This function performs the same validation as the standard TLS verification process,
+// but deliberately omits DNS name checking to support scenarios where certificates
+// may not match the internal Kubernetes service names.
+func VerifyCertificateExceptServerName(rawCerts [][]byte, config *tls.Config) ([]*x509.Certificate, [][]*x509.Certificate, error) {
+	if len(rawCerts) == 0 {
+		return nil, nil, errors.New("tls: no certificates provided by peer")
+	}
+
+	if config == nil {
+		return nil, nil, errors.New("tls: config cannot be nil")
+	}
+
+	if config.RootCAs == nil {
+		return nil, nil, errors.New("tls: no root CAs configured for verification")
+	}
+
+	// Parse all certificates in the chain
+	certs := make([]*x509.Certificate, len(rawCerts))
+	for i, asn1Data := range rawCerts {
+		cert, err := x509.ParseCertificate(asn1Data)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tls: failed to parse certificate at index %d: %w", i, err)
+		}
+		certs[i] = cert
+	}
+
+	// Get the verification time
+	var verifyTime time.Time
+	if config.Time != nil {
+		verifyTime = config.Time()
+	} else {
+		verifyTime = time.Now()
+	}
+
+	// Build the intermediate certificate pool from the certificate chain
+	intermediates := x509.NewCertPool()
+	for i := 1; i < len(certs); i++ {
+		intermediates.AddCert(certs[i])
+	}
+
+	// Set up verification options without DNS name validation
+	// This is the key difference from standard TLS verification
+	opts := x509.VerifyOptions{
+		Roots:         config.RootCAs,
+		Intermediates: intermediates,
+		CurrentTime:   verifyTime,
+		// Deliberately omit DNSName to skip hostname verification
+		// This allows certificates that don't match the server hostname
+		// but are still valid and signed by a trusted CA
+	}
+
+	// Verify the leaf certificate (first in the chain)
+	leafCert := certs[0]
+	chains, err := leafCert.Verify(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("tls: certificate verification failed: %w", err)
+	}
+
+	return certs, chains, nil
+}

--- a/tests/data-assert/main.go
+++ b/tests/data-assert/main.go
@@ -25,9 +25,10 @@ const (
 )
 
 var (
-	host string
-	pass string
-	mode string
+	host    string
+	pass    string
+	mode    string
+	tlsFlag bool
 
 	sentinelPass string
 )
@@ -53,6 +54,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&host, hostFlag, "H", "", "redis host")
 	rootCmd.PersistentFlags().StringVarP(&pass, passFlag, "P", "", "redis password")
 	rootCmd.PersistentFlags().StringVarP(&mode, modeFlag, "M", "", "redis mode")
+	rootCmd.PersistentFlags().BoolVarP(&tlsFlag, "tls", "T", false, "enable tls")
 	rootCmd.PersistentFlags().StringVarP(&sentinelPass, sentinelPassFlag, "S", "", "redis sentinel password")
 	rootCmd.Execute()
 }
@@ -75,7 +77,7 @@ func genRedisDataCmd(cmd *cobra.Command, args []string) {
 		hosts[i] = strings.TrimSpace(hosts[i])
 	}
 
-	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass)
+	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass, tlsFlag)
 	if err != nil {
 		fmt.Printf("failed to create redis client: %v\n", err)
 		return
@@ -126,7 +128,7 @@ func checkRedisData() error {
 		hosts[i] = strings.TrimSpace(hosts[i])
 	}
 
-	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass)
+	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass, tlsFlag)
 	if err != nil {
 		return fmt.Errorf("failed to create redis client: %w", err)
 	}
@@ -154,22 +156,28 @@ func checkRedisData() error {
 	return nil
 }
 
-func createRedisClient(mode string, hosts []string, pass string, sentinelPass string) (redis.UniversalClient, error) {
+func createRedisClient(mode string, hosts []string, pass string, sentinelPass string, tlsFlag bool) (redis.UniversalClient, error) {
 	switch mode {
 	case "cluster":
-		return redis.NewClusterClient(&redis.ClusterOptions{
-			Addrs:     hosts,
-			Password:  pass,
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-		}), nil
+		opts := &redis.ClusterOptions{
+			Addrs:    hosts,
+			Password: pass,
+		}
+		if tlsFlag {
+			opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		return redis.NewClusterClient(opts), nil
 	case "sentinel":
-		return redis.NewFailoverClient(&redis.FailoverOptions{
+		opts := &redis.FailoverOptions{
 			MasterName:       "myMaster",
 			SentinelAddrs:    hosts,
 			Password:         pass,
 			SentinelPassword: sentinelPass,
-			TLSConfig:        &tls.Config{InsecureSkipVerify: true},
-		}), nil
+		}
+		if tlsFlag {
+			opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		return redis.NewFailoverClient(opts), nil
 	default:
 		return nil, fmt.Errorf("unsupported redis mode: %s", mode)
 	}

--- a/tests/data-assert/main.go
+++ b/tests/data-assert/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strings"
@@ -157,8 +158,9 @@ func createRedisClient(mode string, hosts []string, pass string, sentinelPass st
 	switch mode {
 	case "cluster":
 		return redis.NewClusterClient(&redis.ClusterOptions{
-			Addrs:    hosts,
-			Password: pass,
+			Addrs:     hosts,
+			Password:  pass,
+			TLSConfig: &tls.Config{InsecureSkipVerify: true},
 		}), nil
 	case "sentinel":
 		return redis.NewFailoverClient(&redis.FailoverOptions{
@@ -166,6 +168,7 @@ func createRedisClient(mode string, hosts []string, pass string, sentinelPass st
 			SentinelAddrs:    hosts,
 			Password:         pass,
 			SentinelPassword: sentinelPass,
+			TLSConfig:        &tls.Config{InsecureSkipVerify: true},
 		}), nil
 	default:
 		return nil, fmt.Errorf("unsupported redis mode: %s", mode)

--- a/tests/data-assert/resources.yaml
+++ b/tests/data-assert/resources.yaml
@@ -32,9 +32,10 @@ data:
     )
     
     var (
-    	host string
-    	pass string
-    	mode string
+    	host    string
+    	pass    string
+    	mode    string
+    	tlsFlag bool
     
     	sentinelPass string
     )
@@ -60,6 +61,7 @@ data:
     	rootCmd.PersistentFlags().StringVarP(&host, hostFlag, "H", "", "redis host")
     	rootCmd.PersistentFlags().StringVarP(&pass, passFlag, "P", "", "redis password")
     	rootCmd.PersistentFlags().StringVarP(&mode, modeFlag, "M", "", "redis mode")
+    	rootCmd.PersistentFlags().BoolVarP(&tlsFlag, "tls", "T", false, "enable tls")
     	rootCmd.PersistentFlags().StringVarP(&sentinelPass, sentinelPassFlag, "S", "", "redis sentinel password")
     	rootCmd.Execute()
     }
@@ -82,7 +84,7 @@ data:
     		hosts[i] = strings.TrimSpace(hosts[i])
     	}
     
-    	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass)
+    	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass, tlsFlag)
     	if err != nil {
     		fmt.Printf("failed to create redis client: %v\n", err)
     		return
@@ -133,7 +135,7 @@ data:
     		hosts[i] = strings.TrimSpace(hosts[i])
     	}
     
-    	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass)
+    	rdb, err := createRedisClient(mode, hosts, pass, sentinelPass, tlsFlag)
     	if err != nil {
     		return fmt.Errorf("failed to create redis client: %w", err)
     	}
@@ -161,22 +163,28 @@ data:
     	return nil
     }
     
-    func createRedisClient(mode string, hosts []string, pass string, sentinelPass string) (redis.UniversalClient, error) {
+    func createRedisClient(mode string, hosts []string, pass string, sentinelPass string, tlsFlag bool) (redis.UniversalClient, error) {
     	switch mode {
     	case "cluster":
-    		return redis.NewClusterClient(&redis.ClusterOptions{
-    			Addrs:     hosts,
-    			Password:  pass,
-    			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-    		}), nil
+    		opts := &redis.ClusterOptions{
+    			Addrs:    hosts,
+    			Password: pass,
+    		}
+    		if tlsFlag {
+    			opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+    		}
+    		return redis.NewClusterClient(opts), nil
     	case "sentinel":
-    		return redis.NewFailoverClient(&redis.FailoverOptions{
+    		opts := &redis.FailoverOptions{
     			MasterName:       "myMaster",
     			SentinelAddrs:    hosts,
     			Password:         pass,
     			SentinelPassword: sentinelPass,
-    			TLSConfig:        &tls.Config{InsecureSkipVerify: true},
-    		}), nil
+    		}
+    		if tlsFlag {
+    			opts.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+    		}
+    		return redis.NewFailoverClient(opts), nil
     	default:
     		return nil, fmt.Errorf("unsupported redis mode: %s", mode)
     	}

--- a/tests/data-assert/resources.yaml
+++ b/tests/data-assert/resources.yaml
@@ -9,6 +9,7 @@ data:
     
     import (
     	"context"
+    	"crypto/tls"
     	"fmt"
     	"os"
     	"strings"
@@ -164,8 +165,9 @@ data:
     	switch mode {
     	case "cluster":
     		return redis.NewClusterClient(&redis.ClusterOptions{
-    			Addrs:    hosts,
-    			Password: pass,
+    			Addrs:     hosts,
+    			Password:  pass,
+    			TLSConfig: &tls.Config{InsecureSkipVerify: true},
     		}), nil
     	case "sentinel":
     		return redis.NewFailoverClient(&redis.FailoverOptions{
@@ -173,6 +175,7 @@ data:
     			SentinelAddrs:    hosts,
     			Password:         pass,
     			SentinelPassword: sentinelPass,
+    			TLSConfig:        &tls.Config{InsecureSkipVerify: true},
     		}), nil
     	default:
     		return nil, fmt.Errorf("unsupported redis mode: %s", mode)
@@ -263,7 +266,7 @@ metadata:
 spec:
   containers:
     - name: data-assert
-      image: docker.io/library/golang:1.23.4
+      image: docker.m.daocloud.io/library/golang:1.23.4
       command: ["/bin/sh", "-c"]
       args:
         - |

--- a/tests/data-assert/resources.yaml.tmpl
+++ b/tests/data-assert/resources.yaml.tmpl
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
     - name: data-assert
-      image: docker.io/library/golang:1.23.4
+      image: docker.m.daocloud.io/library/golang:1.23.4
       command: ["/bin/sh", "-c"]
       args:
         - |

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
@@ -55,7 +55,8 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning \
+              --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
               export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
               if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:
@@ -90,7 +91,8 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning \
+              --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
               export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
               if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
@@ -55,8 +55,7 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning \
-              --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
               export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
               if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:
@@ -91,8 +90,7 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning \
-              --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
               export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
               if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
@@ -70,6 +70,7 @@ spec:
               bash -c  "cd /go/src/data-assert && go run main.go gen-redis-data \
                         --host redis-sentinel-sentinel.${NAMESPACE}.svc.cluster.local:26379 \
                         --mode sentinel \
+                        --tls \
                         --password-sentinel Opstree@1234sentinel \
                         --password Opstree@1234replication"
             check:
@@ -105,6 +106,7 @@ spec:
               bash -c "cd /go/src/data-assert && go run main.go chk-redis-data \
                        --host redis-sentinel-sentinel.${NAMESPACE}.svc.cluster.local:26379 \
                        --mode sentinel \
+                       --tls \
                        --password-sentinel Opstree@1234sentinel \
                        --password Opstree@1234replication"
             check:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
@@ -17,6 +17,35 @@ spec:
             file: ha.yaml
         - apply:
             file: ../../../../data-assert/resources.yaml
+        # create certificate secret use script, because the namespace name is unknown in the yaml file
+        - script:
+            timeout: 10s
+            content: |
+              cat <<EOF | kubectl apply -f -
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Issuer
+              metadata:
+                name: selfsigned-issuer
+                namespace: ${NAMESPACE}
+              spec:
+                selfSigned: {}
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: redis-tls
+                namespace: ${NAMESPACE}
+              spec:
+                commonName: redis-replication
+                dnsNames:
+                  - "*.redis-replication-headless.${NAMESPACE}.svc.cluster.local"
+                  - "*.redis-sentinel-sentinel-headless.${NAMESPACE}.svc.cluster.local"
+                issuerRef:
+                  name: selfsigned-issuer
+                  kind: Issuer
+                secretName: redis-tls-cert
+              EOF
 
     - name: Test Master IP consistency
       try:
@@ -26,10 +55,9 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export MASTER_IP_FROM_STATUS=$(kubectl -n ${NAMESPACE} get pod ${MASTER_POD_FROM_STATUS} -o jsonpath='{.status.podIP}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -- redis-cli -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1);
-              export MASTER_IP_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].status.podIP}');
-              if [ "$FROM_SENTINEL" = "$MASTER_IP_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_IP_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
+              if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:
               (contains($stdout, 'OK')): true
 
@@ -62,10 +90,9 @@ spec:
             timeout: 10s
             content: |
               export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export MASTER_IP_FROM_STATUS=$(kubectl -n ${NAMESPACE} get pod ${MASTER_POD_FROM_STATUS} -o jsonpath='{.status.podIP}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -- redis-cli -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1);
-              export MASTER_IP_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].status.podIP}');
-              if [ "$FROM_SENTINEL" = "$MASTER_IP_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_IP_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
+              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
+              export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
+              if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
             check:
               (contains($stdout, 'OK')): true
 

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/ha.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/ha.yaml
@@ -14,6 +14,12 @@ kind: RedisReplication
 metadata:
   name: redis-replication
 spec:
+  TLS:
+    ca: ca.crt
+    cert: tls.crt
+    key: tls.key
+    secret:
+      secretName: redis-tls-cert
   clusterSize: 3
   podSecurityContext:
     runAsUser: 1000
@@ -53,13 +59,22 @@ kind: RedisSentinel
 metadata:
   name: redis-sentinel
 spec:
+  TLS:
+    ca: ca.crt
+    cert: tls.crt
+    key: tls.key
+    secret:
+      secretName: redis-tls-cert
   clusterSize: 1
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   redisSentinelConfig:
+    resolveHostnames: "yes"
+    announceHostnames: "yes"
     redisReplicationName: redis-replication
     quorum: '1'
+    failoverTimeout: '10000'
     redisReplicationPassword:
       secretKeyRef:
         name: redis-replication-password


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1462 https://github.com/OT-CONTAINER-KIT/redis/issues/91

When creating Redis with Sentinel, the Sentinel could not connect to Redis because it did not have TLS enabled. In this PR, we set tls-replication to yes for Sentinel, which instructs Sentinel to use a TLS connection for replication. This requires enabling the agent init container by setting `--set featureGates.GenerateConfigInInitContainer=true`.

When updating the redis-role label of the pod, the operator needs to connect to Redis to check its role. This PR adds TLS support when performing this role check.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
