### PR TITLE
fix: do not remove default config volume when providing additional config

### DIFF
--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -330,7 +330,7 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, createPVCTemplate(pvcTplName, stsMeta, params.PersistentVolumeClaim))
 	}
 	if params.ExternalConfig != nil {
-		statefulset.Spec.Template.Spec.Volumes = getExternalConfig(*params.ExternalConfig)
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, getExternalConfig(*params.ExternalConfig)...)
 	}
 	if containerParams.AdditionalVolume != nil {
 		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, containerParams.AdditionalVolume...)

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -1800,6 +1800,12 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
+									Name: "config",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
 									Name: "external-config",
 									VolumeSource: corev1.VolumeSource{
 										ConfigMap: &corev1.ConfigMapVolumeSource{},


### PR DESCRIPTION
closes #1479

**Description**

Adds the extra volume in `additionalRedisConfig` to the volumes, instead of replacing the existing "config" volume.

Fixes #1479

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [-] Documentation has been updated or added where necessary.

**Additional Context**

- This MR does not address `spec.redisConfig.additionalRedisConfig` on redisclusters being ignored. There's a semantic issue of how this should behave
- LMK if docs should be updated
