### PR TITLE
fix: Fix the issue where Sentinel fails to work when starting 1 Master Replication

### DIFF
--- a/internal/controller/common/redis/check.go
+++ b/internal/controller/common/redis/check.go
@@ -91,6 +91,12 @@ func (c *checker) GetMasterFromReplication(ctx context.Context, rr *rr.RedisRepl
 		if count != 0 {
 			realMasterPod = pod
 			break
+		} else {
+			replicaNum := *sts.Spec.Replicas
+			if replicaNum == 1 {
+				realMasterPod = pod
+				break
+			}
 		}
 	}
 	return realMasterPod, nil


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
I noticed that you previously fixed the bug where starting Sentinel in a single-node setup didn't work: https://github.com/OT-CONTAINER-KIT/redis-operator/pull/523. However, in order to address another bug — where the cluster would mistakenly enter the single-node processing logic after restarting all pods (related link: https://github.com/OT-CONTAINER-KIT/redis-operator/pull/964) — this piece of logic was removed. To solve this problem, I've made some optimizations to distinguish between single-node mode and cluster mode using the clusterSize in CR's spec.


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #521 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
