### PR TITLE
fix: Unassigned slots and abnormal status in single-node cluster due to skipped initialization

### DIFF
--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -242,6 +242,7 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, maxConcu
 		Client:      mgr.GetClient(),
 		K8sClient:   k8sClient,
 		Healer:      healer,
+		Checker:     redis.NewChecker(k8sClient),
 		Recorder:    mgr.GetEventRecorderFor("rediscluster-controller"),
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {

--- a/internal/controller/common/redis/check.go
+++ b/internal/controller/common/redis/check.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	rr "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +18,7 @@ import (
 type Checker interface {
 	GetMasterFromReplication(ctx context.Context, rr *rr.RedisReplication) (corev1.Pod, error)
 	GetPassword(ctx context.Context, ns string, secret *commonapi.ExistingPasswordSecret) (string, error)
+	CheckClusterSlotsAssigned(ctx context.Context, cr *rcvb2.RedisCluster, tlsConfig *commonapi.TLSConfig) (bool, error)
 }
 
 type checker struct {
@@ -100,4 +102,29 @@ func (c *checker) GetMasterFromReplication(ctx context.Context, rr *rr.RedisRepl
 		}
 	}
 	return realMasterPod, nil
+}
+
+// CheckClusterSlotsAssigned verifies if all Redis cluster slots (16384 total) are properly assigned
+func (c *checker) CheckClusterSlotsAssigned(ctx context.Context, cr *rcvb2.RedisCluster, tlsConfig *commonapi.TLSConfig) (bool, error) {
+	leaderPodName := cr.Name + "-leader-0"
+	pod, err := c.k8s.CoreV1().Pods(cr.Namespace).Get(ctx, leaderPodName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	password, err := c.GetPassword(ctx, cr.Namespace, cr.Spec.KubernetesConfig.ExistingPasswordSecret)
+	if err != nil {
+		return false, err
+	}
+
+	connInfo := createConnectionInfo(ctx, *pod, password, tlsConfig, c.k8s, cr.Namespace, "6379")
+
+	clusterStatus, err := c.redis.Connect(connInfo).GetClusterInfo(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	allAssigned := clusterStatus.SlotsAssigned == 16384
+
+	return allAssigned, nil
 }

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -194,7 +194,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// When the number of leader replicas is 1 (single-node cluster)
 	if leaderReplicas == 1 {
 		// Check if the Redis cluster has no unassigned slots (i.e., all slots are properly allocated)
-		if slotsAssigned, err := r.Checker.CheckClusterSlotsAssigned(ctx, instance, instance.Spec.TLS); err != nil {
+		if slotsAssigned, err := r.Checker.CheckClusterSlotsAssigned(ctx, instance); err != nil {
 			return intctrlutil.RequeueE(ctx, err, "failed to get cluster slots")
 		} else {
 			if !slotsAssigned {

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -404,7 +404,6 @@ func RedisClusterCheckSlotsAllAssigned(ctx context.Context, client kubernetes.In
 	}
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 	out, err := executeCommand1(ctx, client, cr, cmd, cr.Name+"-leader-0")
-
 	if err != nil {
 		log.FromContext(ctx).Info(out)
 	}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -388,43 +388,6 @@ func CheckRedisNodeCount(ctx context.Context, client kubernetes.Interface, cr *r
 	return int32(count)
 }
 
-// RedisClusterCheckSlotsAllAssigned Checks if slots in the Redis cluster all assigned
-func RedisClusterCheckSlotsAllAssigned(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) bool {
-	redisClient := configureRedisClient(ctx, client, cr, cr.Name+"-leader-0")
-	defer redisClient.Close()
-
-	cmd := []string{"redis-cli", "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", *cr.Spec.Port)}
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
-	}
-	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
-	out, err := executeCommand1(ctx, client, cr, cmd, cr.Name+"-leader-0")
-	if err != nil {
-		log.FromContext(ctx).Info(out)
-	}
-
-	// Check if there are prompts about unallocated slots in the output
-	// Under normal circumstances, there will be "[OK] All 16384 slots covered."
-	// If there are unallocated slots, a message similar to "[ERR] Not all 16384 slots are covered by nodes." will appear
-	if strings.Contains(out, "[ERR] Not all 16384 slots are covered") {
-		return false
-	}
-
-	// Check if the OK message indicating all slots are covered is missing
-	// The original health check requires 3 OKs, and the last one is about slot coverage
-	if strings.Count(out, "[OK]") < 3 || !strings.Contains(out, "All 16384 slots covered") {
-		return false
-	}
-
-	// All slots have been allocated
-	return true
-}
-
 // RedisClusterStatusHealth use `redis-cli --cluster check 127.0.0.1:6379`
 func RedisClusterStatusHealth(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) bool {
 	redisClient := configureRedisClient(ctx, client, cr, cr.Name+"-leader-0")


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
**Problem**
The Operator has a logic issue in managing clusters: in a single-node deployment, the cluster initialization process is skipped. This results in unassigned slots within the cluster and an abnormal cluster status.
The current logic uses the CLUSTER NODES command to check the number of cluster nodes. If the node count does not match the value defined in the Custom Resource (CR), it considers the cluster is uninitialized and triggers slot assignment via initialization logic.
However, in a single-node scenario, the node count remains 1 regardless of whether the cluster is actually initialized. This causes the initialization logic to be incorrectly skipped, leading to empty slots and abnormal cluster status.
<img width="830" height="261" alt="图片" src="https://github.com/user-attachments/assets/362e40c8-1660-4b09-8302-f5b173342031" />


**Solution**
To resolve this, we’ve modified the logic as follows:
When the number of masters is set to 1 (single-node scenario), explicitly check the cluster’s initialization status. If uninitialized, trigger initialization first.
The initialization check is determined by verifying slot assignment via cluster status inspection: if slots are unassigned, the cluster is considered uninitialized.
<img width="861" height="317" alt="图片" src="https://github.com/user-attachments/assets/2438fa9a-58d4-4a6e-98c7-b8591a738c99" />


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
