### PR TITLE
fix: cluster TLS configuration for init-config container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	emperror.dev/errors v0.8.0 // indirect
+	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -1,16 +1,19 @@
 package bootstrap
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	agentutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/agent/util"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/consts"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
+	"github.com/Showmax/go-fqdn"
 )
 
 // defaultRedisConfig from https://github.com/OT-CONTAINER-KIT/redis/blob/master/redis.conf
@@ -34,156 +37,127 @@ func GenerateConfig() error {
 		nodeConfDir, _        = util.CoalesceEnv("NODE_CONF_DIR", "/node-conf")
 		externalConfigFile, _ = util.CoalesceEnv("EXTERNAL_CONFIG_FILE", "/etc/redis/external.conf.d/redis-additional.conf")
 		redisMajorVersion, _  = util.CoalesceEnv("REDIS_MAJOR_VERSION", "v7")
+		redisPort, _          = util.CoalesceEnv("REDIS_PORT", "6379")
 	)
 
-	// set_redis_password - configure Redis password
-	{
-		if val, ok := util.CoalesceEnv("REDIS_PASSWORD", ""); ok && val != "" {
-			cfg.Append("masterauth", val)
-			cfg.Append("requirepass", val)
-			cfg.Append("protected-mode", "yes")
-		} else {
-			fmt.Println("Redis is running without password which is not recommended")
-			cfg.Append("protected-mode", "no")
-		}
+	if val, ok := util.CoalesceEnv("REDIS_PASSWORD", ""); ok && val != "" {
+		cfg.Append("masterauth", val)
+		cfg.Append("requirepass", val)
+		cfg.Append("protected-mode", "yes")
+	} else {
+		fmt.Println("Redis is running without password which is not recommended")
+		cfg.Append("protected-mode", "no")
 	}
 
-	// redis_mode_setup - configure Redis mode (cluster or standalone)
-	{
-		if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {
-			cfg.Append("cluster-enabled", "yes")
-			cfg.Append("cluster-node-timeout", "5000")
-			cfg.Append("cluster-require-full-coverage", "no")
-			cfg.Append("cluster-migration-barrier", "1")
-			cfg.Append("cluster-config-file", fmt.Sprintf("%s/nodes.conf", nodeConfDir))
+	if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {
+		nodeConfPath := filepath.Join(nodeConfDir, "nodes.conf")
 
-			// Get Pod IP
-			cmd := exec.Command("hostname", "-i")
-			output, err := cmd.Output()
+		cfg.Append("cluster-enabled", "yes")
+		cfg.Append("cluster-node-timeout", "5000")
+		cfg.Append("cluster-require-full-coverage", "no")
+		cfg.Append("cluster-migration-barrier", "1")
+		cfg.Append("cluster-config-file", nodeConfPath)
+
+		if ip, err := util.GetLocalIP(); err != nil {
+			log.Printf("Warning: Failed to get local IP: %v", err)
+		} else {
+			_, err = updateMyselfIP(nodeConfPath, strings.TrimSpace(string(ip)))
 			if err != nil {
-				log.Printf("Warning: Failed to get pod IP: %v", err)
-			} else {
-				podIP := strings.TrimSpace(string(output))
-
-				// Update IP in nodes.conf file
-				nodesConfPath := filepath.Join(nodeConfDir, "nodes.conf")
-				if _, err := os.Stat(nodesConfPath); err == nil {
-					cmd := exec.Command("sed", "-i", fmt.Sprintf("/myself/ s/[0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}/%s/", podIP), nodesConfPath)
-					if err := cmd.Run(); err != nil {
-						log.Printf("Warning: Failed to update nodes.conf: %v", err)
-					}
-				}
-			}
-		} else {
-			fmt.Println("Setting up redis in standalone mode")
-		}
-	}
-
-	// tls_setup - configure TLS
-	{
-		if tlsMode, ok := util.CoalesceEnv("TLS_MODE", ""); ok && tlsMode == "true" {
-			redisTLSCert, _ := util.CoalesceEnv("REDIS_TLS_CERT", "")
-			redisTLSCertKey, _ := util.CoalesceEnv("REDIS_TLS_CERT_KEY", "")
-			redisTLSCAKey, _ := util.CoalesceEnv("REDIS_TLS_CA_KEY", "")
-
-			cfg.Append("tls-cert-file", redisTLSCert)
-			cfg.Append("tls-key-file", redisTLSCertKey)
-			cfg.Append("tls-ca-cert-file", redisTLSCAKey)
-			cfg.Append("tls-auth-clients", "optional")
-			cfg.Append("tls-replication", "yes")
-
-			if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {
-				cfg.Append("tls-cluster", "yes")
-
-				if redisMajorVersion == "v7" {
-					cfg.Append("cluster-preferred-endpoint-type", "hostname")
-				}
-			}
-		} else {
-			fmt.Println("Running without TLS mode")
-		}
-	}
-
-	// acl_setup - configure ACL
-	{
-		if aclMode, ok := util.CoalesceEnv("ACL_MODE", ""); ok && aclMode == "true" {
-			cfg.Append("aclfile", "/etc/redis/user.acl")
-		} else {
-			fmt.Println("ACL_MODE is not true, skipping ACL file modification")
-		}
-	}
-
-	// persistence_setup - configure persistence
-	{
-		if persistenceEnabled == "true" {
-			cfg.Append("save", "900 1")
-			cfg.Append("save", "300 10")
-			cfg.Append("save", "60 10000")
-			cfg.Append("Appendonly", "yes")
-			cfg.Append("Appendfilename", "\"Appendonly.aof\"")
-			cfg.Append("dir", dataDir)
-		} else {
-			fmt.Println("Running without persistence mode")
-		}
-	}
-
-	// port_setup - configure ports
-	{
-		redisPort, _ := util.CoalesceEnv("REDIS_PORT", "6379")
-
-		if tlsMode, ok := util.CoalesceEnv("TLS_MODE", ""); ok && tlsMode == "true" {
-			cfg.Append("port", "0")
-			cfg.Append("tls-port", redisPort)
-		} else {
-			cfg.Append("port", redisPort)
-		}
-
-		if nodePort, ok := util.CoalesceEnv("NODEPORT", ""); ok && nodePort == "true" {
-			podHostname, _ := os.Hostname()
-			announcePortVar := "announce_port_" + strings.ReplaceAll(podHostname, "-", "_")
-			announceBusPortVar := "announce_bus_port_" + strings.ReplaceAll(podHostname, "-", "_")
-
-			// Get environment variables
-			clusterAnnouncePort := os.Getenv(announcePortVar)
-			clusterAnnounceBusPort := os.Getenv(announceBusPortVar)
-
-			if clusterAnnouncePort != "" {
-				cfg.Append("cluster-announce-port", clusterAnnouncePort)
-			}
-			if clusterAnnounceBusPort != "" {
-				cfg.Append("cluster-announce-bus-port", clusterAnnounceBusPort)
+				log.Printf("Warning: Failed to update nodes.conf: %v", err)
 			}
 		}
+	} else {
+		fmt.Println("Setting up redis in standalone mode")
 	}
 
-	// external_config - include external config file
-	{
-		if _, err := os.Stat(externalConfigFile); err == nil {
-			cfg.Append("include", externalConfigFile)
+	if tlsMode, ok := util.CoalesceEnv("TLS_MODE", ""); ok && tlsMode == "true" {
+		redisTLSCert, _ := util.CoalesceEnv("REDIS_TLS_CERT", "")
+		redisTLSCertKey, _ := util.CoalesceEnv("REDIS_TLS_CERT_KEY", "")
+		redisTLSCAKey, _ := util.CoalesceEnv("REDIS_TLS_CA_KEY", "")
+
+		cfg.Append("tls-cert-file", redisTLSCert)
+		cfg.Append("tls-key-file", redisTLSCertKey)
+		cfg.Append("tls-ca-cert-file", redisTLSCAKey)
+		cfg.Append("tls-auth-clients", "optional")
+		cfg.Append("tls-replication", "yes")
+
+		if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {
+			cfg.Append("tls-cluster", "yes")
+			if redisMajorVersion == "v7" {
+				cfg.Append("cluster-preferred-endpoint-type", "hostname")
+			}
 		}
+	} else {
+		fmt.Println("Running without TLS mode")
+	}
+
+	if aclMode, ok := util.CoalesceEnv("ACL_MODE", ""); ok && aclMode == "true" {
+		cfg.Append("aclfile", "/etc/redis/user.acl")
+	} else {
+		fmt.Println("ACL_MODE is not true, skipping ACL file modification")
+	}
+
+	if persistenceEnabled == "true" {
+		cfg.Append("save", "900 1")
+		cfg.Append("save", "300 10")
+		cfg.Append("save", "60 10000")
+		cfg.Append("Appendonly", "yes")
+		cfg.Append("Appendfilename", "\"Appendonly.aof\"")
+		cfg.Append("dir", dataDir)
+	} else {
+		fmt.Println("Running without persistence mode")
+	}
+
+	if tlsMode, ok := util.CoalesceEnv("TLS_MODE", ""); ok && tlsMode == "true" {
+		cfg.Append("port", "0")
+		cfg.Append("tls-port", redisPort)
+	} else {
+		cfg.Append("port", redisPort)
+	}
+
+	if nodePort, ok := util.CoalesceEnv("NODEPORT", ""); ok && nodePort == "true" {
+		podHostname, _ := os.Hostname()
+		announcePortVar := "announce_port_" + strings.ReplaceAll(podHostname, "-", "_")
+		announceBusPortVar := "announce_bus_port_" + strings.ReplaceAll(podHostname, "-", "_")
+
+		// Get environment variables
+		clusterAnnouncePort := os.Getenv(announcePortVar)
+		clusterAnnounceBusPort := os.Getenv(announceBusPortVar)
+
+		if clusterAnnouncePort != "" {
+			cfg.Append("cluster-announce-port", clusterAnnouncePort)
+		}
+		if clusterAnnounceBusPort != "" {
+			cfg.Append("cluster-announce-bus-port", clusterAnnounceBusPort)
+		}
+	}
+
+	if _, err := os.Stat(externalConfigFile); err == nil {
+		cfg.Append("include", externalConfigFile)
 	}
 
 	// Add cluster announcement IP and hostname for cluster mode
 	if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {
-		// Get Pod hostname and IP
-		podHostname, err := os.Hostname()
-		if err == nil {
-			var clusterAnnounceIP string
+		var err error
+		var clusterAnnounceIP string
+		if nodePort, ok := util.CoalesceEnv("NODEPORT", ""); ok && nodePort == "true" {
+			clusterAnnounceIP = os.Getenv("HOST_IP")
+		} else {
+			clusterAnnounceIP, err = util.GetLocalIP()
+			if err != nil {
+				log.Printf("Warning: Failed to get local IP: %v", err)
+			}
+		}
+		if clusterAnnounceIP != "" {
+			cfg.Append("cluster-announce-ip", clusterAnnounceIP)
+		}
 
-			if nodePort, ok := util.CoalesceEnv("NODEPORT", ""); ok && nodePort == "true" {
-				clusterAnnounceIP = os.Getenv("HOST_IP")
+		if redisMajorVersion == "v7" {
+			fqdnName, err := fqdn.FqdnHostname()
+			if err != nil {
+				log.Printf("Warning: Failed to get FQDN: %v", err)
 			} else {
-				cmd := exec.Command("hostname", "-i")
-				output, err := cmd.Output()
-				if err == nil {
-					clusterAnnounceIP = strings.TrimSpace(string(output))
-				}
-			}
-			if clusterAnnounceIP != "" {
-				cfg.Append("cluster-announce-ip", clusterAnnounceIP)
-			}
-			if redisMajorVersion == "v7" {
-				cfg.Append("cluster-announce-hostname", podHostname)
+				cfg.Append("cluster-announce-hostname", fqdnName)
 			}
 		}
 	}
@@ -192,6 +166,36 @@ func GenerateConfig() error {
 		cfg.Append("maxmemory", maxMemory)
 	}
 
-	// Commit configuration to file
 	return cfg.Commit()
+}
+
+func updateMyselfIP(nodesConfPath, newIP string) (updated []byte, err error) {
+	raw, err := os.ReadFile(nodesConfPath)
+	if err != nil {
+		return nil, err
+	}
+	ipRe := regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	changed := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if bytes.Contains([]byte(line), []byte("myself")) {
+			replaced := ipRe.ReplaceAllString(line, newIP)
+			if replaced != line {
+				changed = true
+				line = replaced
+			}
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if changed {
+		return out.Bytes(), os.WriteFile(nodesConfPath, out.Bytes(), 0644)
+	}
+	return nil, nil
 }

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -61,7 +61,7 @@ func GenerateConfig() error {
 		if ip, err := util.GetLocalIP(); err != nil {
 			log.Printf("Warning: Failed to get local IP: %v", err)
 		} else {
-			_, err = updateMyselfIP(nodeConfPath, strings.TrimSpace(string(ip)))
+			_, err = updateMyselfIP(nodeConfPath, strings.TrimSpace(ip))
 			if err != nil {
 				log.Printf("Warning: Failed to update nodes.conf: %v", err)
 			}
@@ -195,7 +195,7 @@ func updateMyselfIP(nodesConfPath, newIP string) (updated []byte, err error) {
 		return nil, err
 	}
 	if changed {
-		return out.Bytes(), os.WriteFile(nodesConfPath, out.Bytes(), 0644)
+		return out.Bytes(), os.WriteFile(nodesConfPath, out.Bytes(), 0o644)
 	}
 	return nil, nil
 }

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -1,0 +1,44 @@
+package bootstrap
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_updateMyselfIP(t *testing.T) {
+	testData := `7a6b5f4f99496c97f4e32c30c077aa95cab92664 10.244.0.246:0@16379,,tls-port=6379,shard-id=a03445a0d3f6d405af261041e0cb77a8a176f42b slave b66f2fa597eeda567cf05f3701419be9a3b2f50e 0 1756463509000 1 connected
+93ad60e9ce21430683a3534d2c96ab1b8077cfe8 10.244.0.237:0@16379,,tls-port=6379,shard-id=2f177491b895051f91e91e554a2a9da2cd167aeb master - 0 1756463509685 2 connected 5461-10922
+b66f2fa597eeda567cf05f3701419be9a3b2f50e 10.244.0.222:0@16379,,tls-port=6379,shard-id=a03445a0d3f6d405af261041e0cb77a8a176f42b myself,master - 0 0 1 connected 0-5460
+88456cac1830f3e00f6ab681fb819b4b1d7ad36b 10.244.0.252:0@16379,,tls-port=6379,shard-id=b61110535f09b9c0703517f79da79118fee8d1a4 slave 580e234a8dcd74717c37d01ed8097929c64536ff 0 1756463509691 3 connected
+580e234a8dcd74717c37d01ed8097929c64536ff 10.244.0.240:0@16379,,tls-port=6379,shard-id=b61110535f09b9c0703517f79da79118fee8d1a4 master - 0 1756463509583 3 connected 10923-16383
+c0fc3c21460fec045775d2dcde220fb26ca668c1 10.244.0.249:0@16379,,tls-port=6379,shard-id=2f177491b895051f91e91e554a2a9da2cd167aeb slave 93ad60e9ce21430683a3534d2c96ab1b8077cfe8 0 1756463509583 2 connected
+vars currentEpoch 3 lastVoteEpoch 0
+`
+
+	tmpFile := "/tmp/test_nodes.conf"
+	err := os.WriteFile(tmpFile, []byte(testData), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	defer os.Remove(tmpFile)
+
+	newIP := "10.244.0.9"
+	updated, err := updateMyselfIP(tmpFile, newIP)
+	if err != nil {
+		t.Errorf("updateMyselfIP() error = %v", err)
+	}
+
+	if updated == nil {
+		t.Errorf("Expected changes to be made, but updated is nil")
+		return
+	}
+	expectedContent := strings.ReplaceAll(testData, "10.244.0.222", newIP)
+	updatedContent := string(updated)
+
+	if updatedContent != expectedContent {
+		t.Errorf("Expected updated content to match:\nExpected:\n%s\nGot:\n%s", expectedContent, updatedContent)
+	}
+
+	t.Logf("Successfully updated nodes.conf with new IP %s", newIP)
+}

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -17,7 +17,7 @@ vars currentEpoch 3 lastVoteEpoch 0
 `
 
 	tmpFile := "/tmp/test_nodes.conf"
-	err := os.WriteFile(tmpFile, []byte(testData), 0644)
+	err := os.WriteFile(tmpFile, []byte(testData), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}

--- a/internal/util/net.go
+++ b/internal/util/net.go
@@ -1,0 +1,13 @@
+package util
+
+import "net"
+
+func GetLocalIP() (string, error) {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP.String(), nil
+}

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
@@ -13,6 +13,34 @@ spec:
             file: secret.yaml
         - apply:
             file: ../../../../data-assert/resources.yaml
+        - script:
+            timeout: 10s
+            content: |
+              cat <<EOF | kubectl apply -f -
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Issuer
+              metadata:
+                name: selfsigned-issuer
+                namespace: ${NAMESPACE}
+              spec:
+                selfSigned: {}
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: redis-tls
+                namespace: ${NAMESPACE}
+              spec:
+                commonName: redis-cluster-v1beta2
+                dnsNames:
+                  - "*.redis-cluster-v1beta2-leader-headless.${NAMESPACE}.svc.cluster.local"
+                  - "*.redis-cluster-v1beta2-follower-headless.${NAMESPACE}.svc.cluster.local"
+                issuerRef:
+                  name: selfsigned-issuer
+                  kind: Issuer
+                secretName: redis-tls-cert
+              EOF
         - assert:
             file: ready-cluster.yaml
         - assert:
@@ -40,7 +68,7 @@ spec:
 
               # Check leader configuration
               LEADER_CMD="kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-leader-${LEADER_INDEX}"
-              LEADER_CMD="${LEADER_CMD} -c redis-cluster-v1beta2-leader -- redis-cli -a Opstree1234"
+              LEADER_CMD="${LEADER_CMD} -c redis-cluster-v1beta2-leader -- redis-cli -a Opstree1234 --tls --cacert /tls/ca.crt"
               SLOWLOG_VALUE=$(${LEADER_CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
               if [ "$SLOWLOG_VALUE" != "5000" ]; then
                 echo "leader-${LEADER_INDEX} slowlog-log-slower-than value is $SLOWLOG_VALUE, expected 5000"
@@ -49,7 +77,7 @@ spec:
 
               # Check follower configuration
               FOLLOWER_CMD="kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-follower-${FOLLOWER_INDEX}"
-              FOLLOWER_CMD="${FOLLOWER_CMD} -c redis-cluster-v1beta2-follower -- redis-cli -a Opstree1234"
+              FOLLOWER_CMD="${FOLLOWER_CMD} -c redis-cluster-v1beta2-follower -- redis-cli -a Opstree1234 --tls --cacert /tls/ca.crt"
               SLOWLOG_VALUE=$(${FOLLOWER_CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
               if [ "$SLOWLOG_VALUE" != "5000" ]; then
                 echo "follower-${FOLLOWER_INDEX} slowlog-log-slower-than value is $SLOWLOG_VALUE, expected 5000"
@@ -71,7 +99,7 @@ spec:
 
               # maxmemory should not equal to 0
               MAXMEMORY=$(kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader -- \
-              redis-cli --no-auth-warning -a Opstree1234 config get maxmemory | grep -A1 "maxmemory" | tail -n1)
+              redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree1234 config get maxmemory | grep -A1 "maxmemory" | tail -n1)
               if [ "$MAXMEMORY" == "0" ]; then
                 echo "maxmemory value is $MAXMEMORY, expected not 0"
                 exit 1
@@ -84,7 +112,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} --container data-assert data-assert --
-              bash -c  "cd /go/src/data-assert && go run main.go gen-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234"
+              bash -c  "cd /go/src/data-assert && go run main.go gen-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234 --tls"
             check:
               (contains($stdout, 'OK')): true
 
@@ -94,7 +122,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-follower-0 -c redis-cluster-v1beta2-follower --
-              bash -c  "redis-cli -a Opstree1234 cluster failover"
+              bash -c  "redis-cli -a Opstree1234 --tls --cacert /tls/ca.crt cluster failover"
             check:
               (contains($stdout, 'OK')): true
 
@@ -115,7 +143,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader --
-              bash -c  "redis-cli -a Opstree1234 cluster failover"
+              bash -c  "redis-cli -a Opstree1234 --tls --cacert /tls/ca.crt cluster failover"
             check:
               (contains($stdout, 'OK')): true
         - sleep:
@@ -152,7 +180,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} --container data-assert data-assert --
-              bash -c "cd /go/src/data-assert && go run main.go chk-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234"
+              bash -c "cd /go/src/data-assert && go run main.go chk-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234 --tls"
             check:
               (contains($stdout, 'OK')): true
 
@@ -169,7 +197,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} --container data-assert data-assert --
-              bash -c "cd /go/src/data-assert && go run main.go chk-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234"
+              bash -c "cd /go/src/data-assert && go run main.go chk-redis-data --host redis-cluster-v1beta2-leader.${NAMESPACE}.svc.cluster.local:6379 --mode cluster --password Opstree1234 --tls"
             check:
               (contains($stdout, 'OK')): true
 

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
@@ -4,6 +4,12 @@ kind: RedisCluster
 metadata:
   name: redis-cluster-v1beta2
 spec:
+  TLS:
+    ca: ca.crt
+    cert: tls.crt
+    key: tls.key
+    secret:
+      secretName: redis-tls-cert
   clusterSize: 3
   clusterVersion: v7
   persistenceEnabled: true

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/secret.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/secret.yaml
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: redis-secret
 data:
-  password: T3BzdHJlZTEyMzQ=
+  password: T3BzdHJlZTEyMzQ= # Opstree1234
 type: Opaque

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/secret.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/secret.yaml
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: redis-secret
 data:
-  password: T3BzdHJlZTEyMzQ= # Opstree1234
+  password: T3BzdHJlZTEyMzQ=
 type: Opaque


### PR DESCRIPTION
  - **Set FQDN for `cluster-announce-hostname`**
  - Refactored Redis cluster configuration generation to improve IP handling and code structure
  - Replace exec commands with Go-native implementations using fqdn.FqdnHostname() for hostname resolution
  - Add proper IP address handling in nodes.conf file updates using regex patterns

  This change is only applicable when the GenerateConfigInInitContainer feature gate is enabled.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1441

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
