### PR TITLE
docs: Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ To monitor Redis performance we will be using Prometheus. In any case, extra Pro
     prometheus.io/port: "9121"
 ```
 
+In addition to the annotations you have the possibility to deploy a `ServiceMonitor` for each of the Redis installations (configurable via Helm values file).
+
 ## Contribution
 
 Please see our [CONTRIBUTING.md](./CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ $ helm upgrade redis ot-helm/redis \
 
 ```shell
 # Create Redis replication setup
-$ helm upgrade redis-replication ot-helm/replication \
+$ helm upgrade redis-replication ot-helm/redis-replication \
   --install --namespace ot-operators
 ```
 
 ```shell
 # Create Redis sentinel setup
-$ helm upgrade redis-sentinel ot-helm/sentinel \
+$ helm upgrade redis-sentinel ot-helm/redis-sentinel \
   --install --namespace ot-operators
 ```
 


### PR DESCRIPTION
**Description**

- fix wrong helm chart installation commands in readme
- add information about serviceMonitor

I'm not sure why you still set the old prometheus annotation labels: 

```yaml
  annotations:
    redis.opstreelabs.in: "true"
    prometheus.io/scrape: "true"
    prometheus.io/port: "9121"
```

They are not used anymore nowadays and since you have the serviceMonitor anways ... but ok, leaving this at it is ;) 

Regards,
Kilian

