### PR TITLE
fix: Init-config fixes and update default versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # Build the manager or agent binary
 FROM golang:1.23-alpine3.21 AS builder
+ARG IMG
+		RUN if [ -z "$IMG" ]; then \
+			echo "\n[ERROR] The required build argument IMG is missing!" >&2; \
+			echo "You must build the image with: --build-arg IMG=<image>:<tag>" >&2; \
+			echo "Example: docker build -f Dockerfile -t redis-operator:v0.23.0 --build-arg IMG=quay.io/opstree/redis-operator:v0.23.0 ." >&2; \
+			exit 1; \
+		fi
 ARG BUILDOS
 ARG BUILDPLATFORM
 ARG BUILDARCH
@@ -8,7 +15,6 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG IMG
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/config/samples/redis_v1beta2_redis.yaml
+++ b/config/samples/redis_v1beta2_redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-sample
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:

--- a/config/samples/redis_v1beta2_rediscluster.yaml
+++ b/config/samples/redis_v1beta2_rediscluster.yaml
@@ -10,7 +10,7 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: Always
   storage:
     volumeClaimTemplate:

--- a/config/samples/redis_v1beta2_redisreplication.yaml
+++ b/config/samples/redis_v1beta2_redisreplication.yaml
@@ -8,7 +8,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig: 
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/docs/content/en/docs/Advance Configuration/Upgrading/_index.md
+++ b/docs/content/en/docs/Advance Configuration/Upgrading/_index.md
@@ -56,7 +56,7 @@ For YAML manifest based upgrade, please update the `spec` section of Redis Objec
 ```yaml
 spec:
   kubernetesConfig:
-    image: "quay.io/opstree/redis:v7.0.15"
+    image: "quay.io/opstree/redis:v7.4.5"
     imagePullPolicy: "IfNotPresent"
 ```
 
@@ -158,7 +158,7 @@ For YAML manifest based upgrade, please update the `spec` section of Redis Objec
 ```yaml
 spec:
   kubernetesConfig:
-    image: "quay.io/opstree/redis:v7.0.15"
+    image: "quay.io/opstree/redis:v7.4.5"
     imagePullPolicy: "IfNotPresent"
 ```
 
@@ -198,7 +198,7 @@ metadata:
     redis.opstreelabs.in/recreate-statefulset-strategy: "orphan"
 spec:
   kubernetesConfig:
-    image: "quay.io/opstree/redis:v7.0.5"
+    image: "quay.io/opstree/redis:v7.4.5"
     imagePullPolicy: "IfNotPresent"
   # ... other configuration ...
 ```

--- a/docs/content/en/docs/Getting Started/Cluster/_index.md
+++ b/docs/content/en/docs/Getting Started/Cluster/_index.md
@@ -96,7 +96,7 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: Always
   storage:
     volumeClaimTemplate:

--- a/docs/content/en/docs/Getting Started/Replication/_index.md
+++ b/docs/content/en/docs/Getting Started/Replication/_index.md
@@ -82,7 +82,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/docs/content/en/docs/Getting Started/Standalone/_index.md
+++ b/docs/content/en/docs/Getting Started/Standalone/_index.md
@@ -68,7 +68,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:

--- a/example/v1beta2/acl_config/cluster.yaml
+++ b/example/v1beta2/acl_config/cluster.yaml
@@ -30,7 +30,7 @@ spec:
       secretName: acl-secret
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/acl_config/replication.yaml
+++ b/example/v1beta2/acl_config/replication.yaml
@@ -11,7 +11,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -31,7 +31,7 @@ spec:
 
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/acl_config/standalone.yaml
+++ b/example/v1beta2/acl_config/standalone.yaml
@@ -27,7 +27,7 @@ spec:
 
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/additional_config/clusterd.yaml
+++ b/example/v1beta2/additional_config/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   redisLeader:
     redisConfig:
       additionalRedisConfig: redis-external-config

--- a/example/v1beta2/additional_config/replication.yaml
+++ b/example/v1beta2/additional_config/replication.yaml
@@ -8,7 +8,7 @@ spec:
   redisConfig:
     additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -23,4 +23,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/additional_config/standalone.yaml
+++ b/example/v1beta2/additional_config/standalone.yaml
@@ -7,7 +7,7 @@ spec:
   redisConfig:
     additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -22,4 +22,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/advance_config/clusterd.yaml
+++ b/example/v1beta2/advance_config/clusterd.yaml
@@ -11,7 +11,7 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     resources:
       requests:
         cpu: 101m
@@ -23,7 +23,7 @@ spec:
       - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/advance_config/standalone.yaml
+++ b/example/v1beta2/advance_config/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -27,7 +27,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     # nodeSelector: {}
     # podSecurityContext: {}
     # priorityClassName: ""

--- a/example/v1beta2/affinity/clusterd.yaml
+++ b/example/v1beta2/affinity/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   redisLeader:
     affinity:
       podAntiAffinity:

--- a/example/v1beta2/affinity/replication.yaml
+++ b/example/v1beta2/affinity/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -21,7 +21,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/example/v1beta2/affinity/standalone.yaml
+++ b/example/v1beta2/affinity/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/example/v1beta2/backup_restore/restore/redis-cluster.yaml
+++ b/example/v1beta2/backup_restore/restore/redis-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/example/v1beta2/disruption_budget/clusterd.yaml
+++ b/example/v1beta2/disruption_budget/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: "quay.io/opstree/redis-exporter:v1.44.0"
+    image: "quay.io/opstree/redis-exporter:v1.76.0"
   redisFollower:
     affinity:
       podAntiAffinity:

--- a/example/v1beta2/env_vars/redis-cluster.yaml
+++ b/example/v1beta2/env_vars/redis-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/example/v1beta2/env_vars/redis-replication.yaml
+++ b/example/v1beta2/env_vars/redis-replication.yaml
@@ -11,7 +11,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/example/v1beta2/env_vars/redis-standalone.yaml
+++ b/example/v1beta2/env_vars/redis-standalone.yaml
@@ -10,7 +10,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -26,7 +26,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/external_service/clusterd.yaml
+++ b/example/v1beta2/external_service/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/external_service/replication.yaml
+++ b/example/v1beta2/external_service/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -21,4 +21,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/external_service/standalone.yaml
+++ b/example/v1beta2/external_service/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -20,4 +20,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/node-selector/clusterd.yaml
+++ b/example/v1beta2/node-selector/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   redisLeader:
     nodeSelector:
       kubernetes.io/os: linux

--- a/example/v1beta2/node-selector/replication.yaml
+++ b/example/v1beta2/node-selector/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -21,6 +21,6 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   nodeSelector:
     kubernetes.io/os: linux

--- a/example/v1beta2/node-selector/standalone.yaml
+++ b/example/v1beta2/node-selector/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -20,6 +20,6 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   nodeSelector:
     kubernetes.io/os: linux

--- a/example/v1beta2/password_protected/clusterd.yaml
+++ b/example/v1beta2/password_protected/clusterd.yaml
@@ -11,14 +11,14 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
       key: password
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/password_protected/replication.yaml
+++ b/example/v1beta2/password_protected/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
@@ -21,7 +21,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/password_protected/sentinel.yaml
+++ b/example/v1beta2/password_protected/sentinel.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
@@ -53,7 +53,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/password_protected/standalone.yaml
+++ b/example/v1beta2/password_protected/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/private_registry/clusterd.yaml
+++ b/example/v1beta2/private_registry/clusterd.yaml
@@ -11,13 +11,13 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/private_registry/replication.yaml
+++ b/example/v1beta2/private_registry/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: regcred
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/private_registry/standalone.yaml
+++ b/example/v1beta2/private_registry/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: regcred
@@ -19,7 +19,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/probes/clusterd.yaml
+++ b/example/v1beta2/probes/clusterd.yaml
@@ -11,10 +11,10 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   redisLeader:
     readinessProbe:
       failureThreshold: 5

--- a/example/v1beta2/probes/replication.yaml
+++ b/example/v1beta2/probes/replication.yaml
@@ -9,7 +9,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:
@@ -21,7 +21,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   readinessProbe:
     failureThreshold: 5
     initialDelaySeconds: 15

--- a/example/v1beta2/probes/standalone.yaml
+++ b/example/v1beta2/probes/standalone.yaml
@@ -8,7 +8,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   readinessProbe:
     failureThreshold: 5
     initialDelaySeconds: 15

--- a/example/v1beta2/pvc_retention_policy/clusterd.yaml
+++ b/example/v1beta2/pvc_retention_policy/clusterd.yaml
@@ -11,14 +11,14 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     persistentVolumeClaimRetentionPolicy:
       whenScaled: Delete
       whenDeleted: Delete
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/pvc_retention_policy/replication.yaml
+++ b/example/v1beta2/pvc_retention_policy/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     persistentVolumeClaimRetentionPolicy:
       whenScaled: Delete
@@ -24,4 +24,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/pvc_retention_policy/standalone.yaml
+++ b/example/v1beta2/pvc_retention_policy/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     persistentVolumeClaimRetentionPolicy:
       whenScaled: Delete
@@ -23,4 +23,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/recreate-statefulset/clusterd.yaml
+++ b/example/v1beta2/recreate-statefulset/clusterd.yaml
@@ -13,11 +13,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/recreate-statefulset/replication.yaml
+++ b/example/v1beta2/recreate-statefulset/replication.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -23,5 +23,5 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   priorityClassName: system-cluster-critical

--- a/example/v1beta2/recreate-statefulset/standalone.yaml
+++ b/example/v1beta2/recreate-statefulset/standalone.yaml
@@ -7,7 +7,7 @@ metadata:
     redis.opstreelabs.in/recreate-statefulset: "true"
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -22,5 +22,5 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   priorityClassName: system-cluster-critical

--- a/example/v1beta2/redis-cluster-deploy/role-anti-affinity.yaml
+++ b/example/v1beta2/redis-cluster-deploy/role-anti-affinity.yaml
@@ -19,7 +19,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -30,7 +30,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/redis-cluster.yaml
+++ b/example/v1beta2/redis-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -27,7 +27,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/redis-replication.yaml
+++ b/example/v1beta2/redis-replication.yaml
@@ -11,7 +11,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -27,7 +27,7 @@ spec:
       #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/redis-standalone.yaml
+++ b/example/v1beta2/redis-standalone.yaml
@@ -10,7 +10,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -26,7 +26,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/redis_monitoring/clusterd.yaml
+++ b/example/v1beta2/redis_monitoring/clusterd.yaml
@@ -13,11 +13,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: Always
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
   storage:
     volumeClaimTemplate:

--- a/example/v1beta2/redis_monitoring/replication.yaml
+++ b/example/v1beta2/redis_monitoring/replication.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     # env:
     # - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS

--- a/example/v1beta2/redis_monitoring/standalone.yaml
+++ b/example/v1beta2/redis_monitoring/standalone.yaml
@@ -7,7 +7,7 @@ metadata:
 #    redis.opstreelabs.in/skip-reconcile: "true"
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:
@@ -19,7 +19,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     # env:
     # - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS

--- a/example/v1beta2/sidecar_features/sidecar.yaml
+++ b/example/v1beta2/sidecar_features/sidecar.yaml
@@ -7,7 +7,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -23,7 +23,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/tls_enabled/redis-cluster.yaml
+++ b/example/v1beta2/tls_enabled/redis-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -33,7 +33,7 @@ spec:
 
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/tls_enabled/redis-replication.yaml
+++ b/example/v1beta2/tls_enabled/redis-replication.yaml
@@ -17,7 +17,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -28,7 +28,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/tls_enabled/redis-standalone.yaml
+++ b/example/v1beta2/tls_enabled/redis-standalone.yaml
@@ -16,7 +16,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -27,7 +27,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/tolerations/clusterd.yaml
+++ b/example/v1beta2/tolerations/clusterd.yaml
@@ -11,11 +11,11 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   redisLeader:
     tolerations:
       - key: "key1"

--- a/example/v1beta2/tolerations/replication.yaml
+++ b/example/v1beta2/tolerations/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   storage:
     volumeClaimTemplate:
@@ -18,7 +18,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/example/v1beta2/tolerations/standalone.yaml
+++ b/example/v1beta2/tolerations/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -20,7 +20,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/example/v1beta2/topology_spread_constraints/redis-cluster.yaml
+++ b/example/v1beta2/topology_spread_constraints/redis-cluster.yaml
@@ -13,7 +13,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -45,7 +45,7 @@ spec:
             clusterId: redis-cluster
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/topology_spread_constraints/redis-replication.yaml
+++ b/example/v1beta2/topology_spread_constraints/redis-replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
   podSecurityContext:
     runAsUser: 1000
@@ -21,7 +21,7 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname

--- a/example/v1beta2/upgrade-strategy/clusterd.yaml
+++ b/example/v1beta2/upgrade-strategy/clusterd.yaml
@@ -11,14 +11,14 @@ spec:
     fsGroup: 1000
   persistenceEnabled: true
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     updateStrategy:
       type: OnDelete
   #      type: RollingUpdate
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/upgrade-strategy/replication.yaml
+++ b/example/v1beta2/upgrade-strategy/replication.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     # type: RollingUpdate
   podSecurityContext:
@@ -22,4 +22,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/upgrade-strategy/standalone.yaml
+++ b/example/v1beta2/upgrade-strategy/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-standalone
 spec:
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     updateStrategy:
       type: OnDelete
@@ -23,4 +23,4 @@ spec:
             storage: 1Gi
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0

--- a/example/v1beta2/volume_mount/redis-cluster.yaml
+++ b/example/v1beta2/volume_mount/redis-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -27,7 +27,7 @@ spec:
       #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/volume_mount/redis-replication.yaml
+++ b/example/v1beta2/volume_mount/redis-replication.yaml
@@ -8,7 +8,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -24,7 +24,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/example/v1beta2/volume_mount/redis-standalone.yaml
+++ b/example/v1beta2/volume_mount/redis-standalone.yaml
@@ -7,7 +7,7 @@ spec:
   # redisConfig:
   #   additionalRedisConfig: redis-external-config
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -23,7 +23,7 @@ spec:
         #   - name: regcred
   redisExporter:
     enabled: false
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -24,7 +24,8 @@ timeout 0
 tcp-keepalive 300
 daemonize no
 supervised no
-pidfile /var/run/redis.pid
+pidfile /etc/redis/redis.pid
+include /etc/redis/external.conf.d/*.conf
 `
 
 // GenerateConfig generates Redis configuration file
@@ -130,9 +131,6 @@ func GenerateConfig() error {
 			cfg.Append("cluster-announce-bus-port", clusterAnnounceBusPort)
 		}
 	}
-
-	// Always include all .conf files from /etc/redis/external.conf.d (even if not present yet)
-	cfg.Append("include", "/etc/redis/external.conf.d/*.conf")
 
 	// Add cluster announcement IP and hostname for cluster mode
 	if setupMode, ok := util.CoalesceEnv("SETUP_MODE", ""); ok && setupMode == "cluster" {

--- a/internal/controller/redis/testdata/full.yaml
+++ b/internal/controller/redis/testdata/full.yaml
@@ -8,7 +8,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -19,7 +19,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/internal/controller/rediscluster/testdata/full.yaml
+++ b/internal/controller/rediscluster/testdata/full.yaml
@@ -11,7 +11,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -30,7 +30,7 @@ spec:
         memory: 129Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/internal/controller/redisreplication/testdata/full.yaml
+++ b/internal/controller/redisreplication/testdata/full.yaml
@@ -9,7 +9,7 @@ spec:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -20,7 +20,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/internal/controller/testutil/constants.go
+++ b/internal/controller/testutil/constants.go
@@ -11,5 +11,5 @@ const (
 	DefaultInterval = time.Millisecond * 250
 
 	// Common test image
-	DefaultRedisImage = "quay.io/opstree/redis:v7.0.12"
+	DefaultRedisImage = "quay.io/opstree/redis:v7.4.5"
 )

--- a/internal/k8sutils/redis-cluster_test.go
+++ b/internal/k8sutils/redis-cluster_test.go
@@ -197,7 +197,7 @@ func Test_generateRedisClusterParams(t *testing.T) {
 func Test_generateRedisClusterContainerParams(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "testdata", "redis-cluster.yaml")
 	expectedLeaderContainer := containerParameters{
-		Image:           "quay.io/opstree/redis:v7.0.12",
+		Image:           "quay.io/opstree/redis:v7.4.5",
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -219,7 +219,7 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 			},
 		},
-		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.44.0",
+		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.76.0",
 		RedisExporterImagePullPolicy: corev1.PullPolicy("Always"),
 		RedisExporterResources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -308,7 +308,7 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 	}
 
 	expectedFollowerContainer := containerParameters{
-		Image:           "quay.io/opstree/redis:v7.0.12",
+		Image:           "quay.io/opstree/redis:v7.4.5",
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -330,7 +330,7 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 			},
 		},
-		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.44.0",
+		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.76.0",
 		RedisExporterImagePullPolicy: corev1.PullPolicy("Always"),
 		RedisExporterResources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/k8sutils/redis-replication_test.go
+++ b/internal/k8sutils/redis-replication_test.go
@@ -108,7 +108,7 @@ func Test_generateRedisReplicationParams(t *testing.T) {
 func Test_generateRedisReplicationContainerParams(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "testdata", "redis-replication.yaml")
 	expected := containerParameters{
-		Image:           "quay.io/opstree/redis:v7.0.12",
+		Image:           "quay.io/opstree/redis:v7.4.5",
 		Port:            ptr.To(6379),
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Resources: &corev1.ResourceRequirements{
@@ -131,7 +131,7 @@ func Test_generateRedisReplicationContainerParams(t *testing.T) {
 				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 			},
 		},
-		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.44.0",
+		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.76.0",
 		RedisExporterImagePullPolicy: corev1.PullPolicy("Always"),
 		RedisExporterResources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/k8sutils/redis-sentinel_test.go
+++ b/internal/k8sutils/redis-sentinel_test.go
@@ -100,7 +100,7 @@ func Test_generateRedisSentinelParams(t *testing.T) {
 func Test_generateRedisSentinelContainerParams(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "testdata", "redis-sentinel.yaml")
 	expected := containerParameters{
-		Image:           "quay.io/opstree/redis:v7.0.12",
+		Image:           "quay.io/opstree/redis:v7.4.5",
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -122,7 +122,7 @@ func Test_generateRedisSentinelContainerParams(t *testing.T) {
 				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 			},
 		},
-		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.44.0",
+		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.76.0",
 		RedisExporterImagePullPolicy: corev1.PullPolicy("Always"),
 		RedisExporterResources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/k8sutils/redis-standalone_test.go
+++ b/internal/k8sutils/redis-standalone_test.go
@@ -103,7 +103,7 @@ func Test_generateRedisStandaloneParams(t *testing.T) {
 func Test_generateRedisStandaloneContainerParams(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "testdata", "redis-standalone.yaml")
 	expected := containerParameters{
-		Image:           "quay.io/opstree/redis:v7.0.12",
+		Image:           "quay.io/opstree/redis:v7.4.5",
 		Port:            ptr.To(6379),
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Resources: &corev1.ResourceRequirements{
@@ -126,7 +126,7 @@ func Test_generateRedisStandaloneContainerParams(t *testing.T) {
 				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 			},
 		},
-		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.44.0",
+		RedisExporterImage:           "quay.io/opstree/redis-exporter:v1.76.0",
 		RedisExporterImagePullPolicy: corev1.PullPolicy("Always"),
 		RedisExporterResources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -594,7 +594,7 @@ func generateInitContainerDef(role, name string, initcontainerParams initContain
 		container := corev1.Container{
 			Name:            "init-config",
 			Image:           image,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/operator", "agent"},
 			SecurityContext: initcontainerParams.SecurityContext,
 			Env: getEnvironmentVariables(

--- a/tests/e2e-chainsaw/v1beta2/acl-user/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-user/redis-cluster/cluster.yaml
@@ -25,7 +25,7 @@ spec:
       secretName: acl-secret
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-cluster/cluster.yaml
@@ -22,7 +22,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/e2e-chainsaw/v1beta2/nodeport/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/nodeport/redis-cluster/cluster.yaml
@@ -24,7 +24,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
@@ -26,7 +26,7 @@ spec:
         memory: 128Mi
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster-scale-out.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster-scale-out.yaml
@@ -25,7 +25,7 @@ spec:
       key: password
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
@@ -43,7 +43,7 @@ spec:
       key: password
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/testdata/redis-cluster.yaml
+++ b/tests/testdata/redis-cluster.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterSize: 3
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: mysecret
@@ -86,7 +86,7 @@ spec:
                   values: [redisFollower]
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/testdata/redis-replication.yaml
+++ b/tests/testdata/redis-replication.yaml
@@ -24,7 +24,7 @@ spec:
       drop: [ALL]
       add: [NET_BIND_SERVICE]
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: mysecret
@@ -42,7 +42,7 @@ spec:
     minReadySeconds: 5
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/testdata/redis-sentinel.yaml
+++ b/tests/testdata/redis-sentinel.yaml
@@ -22,7 +22,7 @@ spec:
       drop: [ALL]
       add: [NET_BIND_SERVICE]
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: mysecret
@@ -40,7 +40,7 @@ spec:
     minReadySeconds: 5
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:

--- a/tests/testdata/redis-standalone.yaml
+++ b/tests/testdata/redis-standalone.yaml
@@ -23,7 +23,7 @@ spec:
       drop: [ALL]
       add: [NET_BIND_SERVICE]
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.12
+    image: quay.io/opstree/redis:v7.4.5
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: mysecret
@@ -41,7 +41,7 @@ spec:
     minReadySeconds: 5
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.44.0
+    image: quay.io/opstree/redis-exporter:v1.76.0
     imagePullPolicy: Always
     resources:
       requests:


### PR DESCRIPTION
**Description**

Fixes #1512 as latest tag was being used and older image was getting cached on node causing the error.

It also includes: 

1. `include /etc/redis/external.conf.d/*.conf` by default as the current logic does not work for init-config due to volume not being mounted to the pod at this stage. If no files exist this is just ignored.
2. `pidfile /etc/redis/redis.pid` to clear the permission denied while redis tries to write the PID file.
3. updates the default redis to v7.4.5 and exporter to v.1.76.0

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

