### PR TITLE
fix: proper order for flags to redis-cli command

### DIFF
--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -338,7 +338,8 @@ func TestGetRedisHostname(t *testing.T) {
 
 func TestCreateSingleLeaderRedisCommand(t *testing.T) {
 	cr := &rcvb2.RedisCluster{}
-	cmd := CreateSingleLeaderRedisCommand(context.TODO(), cr)
+	invocation := CreateSingleLeaderRedisCommand(context.TODO(), cr)
+	cmd := invocation.Args()
 
 	assert.Equal(t, "redis-cli", cmd[0])
 	assert.Equal(t, "CLUSTER", cmd[1])
@@ -404,7 +405,8 @@ func TestCreateMultipleLeaderRedisCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := mock_utils.CreateFakeClientWithPodIPs_LeaderPods(tt.redisCluster)
 
-			cmd := CreateMultipleLeaderRedisCommand(context.TODO(), client, tt.redisCluster)
+			invocation := CreateMultipleLeaderRedisCommand(context.TODO(), client, tt.redisCluster)
+			cmd := invocation.Args()
 			assert.Equal(t, tt.expectedCommands, cmd)
 		})
 	}


### PR DESCRIPTION
closes #1517 

**Description**

The command passed to Redis must come after the flags. This struct allows for flags to be set after the command for redis is defined.

Fixes #1517 

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

- In theory this struct could be used everywhere, but this is the only place that passes a command that is interpreted by _redis's interpreter_ rather than a cli command of redis-cli.
- I inlined the BaseCommand. Seemed much simpler than writing an algorithmic way to determine this
- It can't be used just for `CreateSingleLeaderRedisCommand` since the TLS flags are added later
- This solution removes the temporal coupling that would be introduced by just reordering the statements that add flags
