### PR TITLE
feat: scale single-node redis cluster up and down

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -134,11 +134,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				k8sutils.ReshardRedisCluster(ctx, r.K8sClient, instance, shardIdx, shardMoveNodeIdx, true)
 				monitoring.RedisClusterReshardTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()
 			}
-			logger.Info("Redis cluster is downscaled... Rebalancing the cluster")
-			// Step 3 Rebalance the cluster
-			k8sutils.RebalanceRedisCluster(ctx, r.K8sClient, instance)
-			logger.Info("Redis cluster is downscaled... Rebalancing the cluster is done")
-			monitoring.RedisClusterRebalanceTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()
+			// Step 3 Rebalance the cluster. With a single remaining leader there is
+			// nothing to rebalance: all slots were already resharded to leader-0 and
+			// the rebalance command targets leader-1, which is no longer part of the
+			// cluster at this point.
+			if leaderReplicas > 1 {
+				logger.Info("Redis cluster is downscaled... Rebalancing the cluster")
+				k8sutils.RebalanceRedisCluster(ctx, r.K8sClient, instance)
+				logger.Info("Redis cluster is downscaled... Rebalancing the cluster is done")
+				monitoring.RedisClusterRebalanceTotal.WithLabelValues(instance.Namespace, instance.Name).Inc()
+			} else {
+				logger.Info("Redis cluster is downscaled... Skipping rebalance for single-node cluster")
+			}
 			return intctrlutil.RequeueAfter(ctx, time.Second*10, "")
 		} else {
 			logger.Info("masterCount is not equal to leader statefulset replicas,skip downscale", "masterCount", masterCount, "leaderReplicas", leaderReplicas)
@@ -250,11 +257,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		leaderCount := k8sutils.CheckRedisNodeCount(ctx, r.K8sClient, instance, "leader")
 		if leaderCount != leaderReplicas {
 			logger.Info("Not all leader are part of the cluster...", "Leaders.Count", leaderCount, "Instance.Size", leaderReplicas)
-			if leaderCount <= 2 {
-				k8sutils.ExecuteRedisClusterCommand(ctx, r.K8sClient, instance)
-			} else {
-				if leaderCount < leaderReplicas {
+			if leaderCount < leaderReplicas {
+				scaleUp, err := r.shouldScaleUpExistingCluster(ctx, instance, leaderCount)
+				if err != nil {
+					return intctrlutil.RequeueE(ctx, err, "failed to determine whether an existing cluster is being scaled up")
+				}
+				if scaleUp {
 					// Scale up the cluster
+					logger.Info("Scaling up existing cluster", "Current.Leaders", leaderCount, "Desired.Leaders", leaderReplicas)
 					// Step 1 : Fix any open slots from previous interrupted operations
 					if err := k8sutils.FixRedisCluster(ctx, r.K8sClient, instance); err != nil {
 						logger.Error(err, "Failed to fix redis cluster slots, proceeding with scale-up")
@@ -265,6 +275,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 					return intctrlutil.RequeueAfter(ctx, 10*time.Second, "added node, waiting for cluster convergence before rebalancing")
 				}
+				// No functioning cluster exists yet, create one from scratch.
+				logger.Info("Creating cluster", "Current.Leaders", leaderCount, "Desired.Leaders", leaderReplicas)
+				k8sutils.ExecuteRedisClusterCommand(ctx, r.K8sClient, instance)
 			}
 		} else {
 			stable, err := k8sutils.ClusterStableNoOpenSlots(ctx, r.K8sClient, instance)
@@ -382,6 +395,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	return intctrlutil.RequeueAfter(ctx, time.Second*10, "")
+}
+
+// shouldScaleUpExistingCluster reports whether the missing leaders should be
+// added to an already-formed cluster (`--cluster add-node`) instead of running
+// the initial cluster creation command. More than two leaders always means the
+// cluster has been formed, since `--cluster create` requires at least three
+// nodes. With one or two leaders the cluster is either a formed single-node
+// cluster being scaled up (issue #1521) or an initial creation that has not
+// completed yet; slot assignment distinguishes the two, because a formed
+// cluster has all 16384 slots assigned and running `--cluster create` against
+// its non-empty nodes would fail.
+func (r *Reconciler) shouldScaleUpExistingCluster(ctx context.Context, instance *rcvb2.RedisCluster, leaderCount int32) (bool, error) {
+	if leaderCount > 2 {
+		return true, nil
+	}
+	if leaderCount == 0 {
+		return false, nil
+	}
+	return r.Checker.CheckClusterSlotsAssigned(ctx, instance)
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, rc *rcvb2.RedisCluster, status rcvb2.RedisClusterStatus) (requeue bool, err error) {

--- a/internal/controller/rediscluster/rediscluster_controller_unit_test.go
+++ b/internal/controller/rediscluster/rediscluster_controller_unit_test.go
@@ -1,0 +1,90 @@
+package rediscluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeChecker struct {
+	redis.Checker
+	slotsAssigned bool
+	err           error
+	called        bool
+}
+
+func (f *fakeChecker) CheckClusterSlotsAssigned(ctx context.Context, cr *rcvb2.RedisCluster) (bool, error) {
+	f.called = true
+	return f.slotsAssigned, f.err
+}
+
+func TestShouldScaleUpExistingCluster(t *testing.T) {
+	tests := []struct {
+		name           string
+		leaderCount    int32
+		slotsAssigned  bool
+		checkErr       error
+		wantScaleUp    bool
+		wantErr        bool
+		wantCheckerHit bool
+	}{
+		{
+			name:           "formed single-node cluster scales up via add-node (issue #1521)",
+			leaderCount:    1,
+			slotsAssigned:  true,
+			wantScaleUp:    true,
+			wantCheckerHit: true,
+		},
+		{
+			name:           "fresh nodes without assigned slots fall back to cluster creation",
+			leaderCount:    1,
+			slotsAssigned:  false,
+			wantScaleUp:    false,
+			wantCheckerHit: true,
+		},
+		{
+			name:           "formed two-leader cluster scales up via add-node",
+			leaderCount:    2,
+			slotsAssigned:  true,
+			wantScaleUp:    true,
+			wantCheckerHit: true,
+		},
+		{
+			name:        "no leaders means initial creation, slot check skipped",
+			leaderCount: 0,
+			wantScaleUp: false,
+		},
+		{
+			name:        "more than two leaders is always a formed cluster, slot check skipped",
+			leaderCount: 3,
+			wantScaleUp: true,
+		},
+		{
+			name:           "slot check error is propagated",
+			leaderCount:    1,
+			checkErr:       errors.New("connection refused"),
+			wantErr:        true,
+			wantCheckerHit: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &fakeChecker{slotsAssigned: tt.slotsAssigned, err: tt.checkErr}
+			r := &Reconciler{Checker: checker}
+
+			scaleUp, err := r.shouldScaleUpExistingCluster(context.Background(), &rcvb2.RedisCluster{}, tt.leaderCount)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantScaleUp, scaleUp)
+			}
+			assert.Equal(t, tt.wantCheckerHit, checker.called)
+		})
+	}
+}

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/chainsaw-test.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: single-node-scaling-redis-cluster
+spec:
+  steps:
+    - name: Install single-node cluster
+      try:
+        - apply:
+            file: cluster.yaml
+        - assert:
+            file: ready-cluster-single.yaml
+
+    - name: Verify single-node cluster is formed
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              #!/bin/bash
+              CMD="kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader -- redis-cli"
+              for i in $(seq 1 30); do
+                INFO=$(${CMD} cluster info 2>/dev/null)
+                if echo "$INFO" | grep -q "cluster_state:ok" && echo "$INFO" | grep -q "cluster_slots_assigned:16384"; then
+                  echo "single-node cluster is formed"
+                  exit 0
+                fi
+                sleep 10
+              done
+              echo "single-node cluster did not form: $INFO"
+              exit 1
+            check:
+              (contains($stdout, 'single-node cluster is formed')): true
+
+    - name: Put data
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader --
+              redis-cli -c set single-node-scaling-key persisted
+            check:
+              (contains($stdout, 'OK')): true
+
+    - name: Scale up to three nodes
+      try:
+        - apply:
+            file: cluster-scale-up.yaml
+        - assert:
+            file: ready-cluster-scaled.yaml
+
+    - name: Verify scaled-up cluster
+      try:
+        - script:
+            timeout: 10m
+            content: |
+              #!/bin/bash
+              CMD="kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader -- redis-cli"
+              for i in $(seq 1 60); do
+                INFO=$(${CMD} cluster info 2>/dev/null)
+                if echo "$INFO" | grep -q "cluster_state:ok" &&
+                   echo "$INFO" | grep -q "cluster_slots_assigned:16384" &&
+                   echo "$INFO" | grep -q "cluster_known_nodes:6"; then
+                  echo "cluster scaled up to three nodes"
+                  exit 0
+                fi
+                sleep 10
+              done
+              echo "cluster did not scale up: $INFO"
+              exit 1
+            check:
+              (contains($stdout, 'cluster scaled up to three nodes')): true
+
+    - name: Assert data after scale-up
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader --
+              redis-cli -c get single-node-scaling-key
+            check:
+              (contains($stdout, 'persisted')): true
+
+    - name: Scale back down to single node
+      try:
+        - apply:
+            file: cluster.yaml
+        - assert:
+            file: ready-cluster-single.yaml
+
+    - name: Verify scaled-down cluster
+      try:
+        - script:
+            timeout: 10m
+            content: |
+              #!/bin/bash
+              CMD="kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader -- redis-cli"
+              for i in $(seq 1 60); do
+                INFO=$(${CMD} cluster info 2>/dev/null)
+                if echo "$INFO" | grep -q "cluster_state:ok" &&
+                   echo "$INFO" | grep -q "cluster_slots_assigned:16384" &&
+                   echo "$INFO" | grep -q "cluster_known_nodes:2"; then
+                  echo "cluster scaled down to single node"
+                  exit 0
+                fi
+                sleep 10
+              done
+              echo "cluster did not scale down: $INFO"
+              exit 1
+            check:
+              (contains($stdout, 'cluster scaled down to single node')): true
+
+    - name: Assert data after scale-down
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader --
+              redis-cli -c get single-node-scaling-key
+            check:
+              (contains($stdout, 'persisted')): true
+
+    - name: Uninstall
+      try:
+        - delete:
+            ref:
+              name: redis-cluster-v1beta2
+              kind: RedisCluster
+              apiVersion: redis.redis.opstreelabs.in/v1beta2
+        - error:
+            file: ready-cluster-single.yaml

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster-scale-up.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster-scale-up.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+spec:
+  clusterSize: 1
+  clusterVersion: v7
+  persistenceEnabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/ready-cluster-scaled.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/ready-cluster-scaled.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  readyFollowerReplicas: 3
+  readyLeaderReplicas: 3
+  state: Ready
+  reason: RedisCluster is ready

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/ready-cluster-single.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/ready-cluster-single.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  readyFollowerReplicas: 1
+  readyLeaderReplicas: 1
+  state: Ready
+  reason: RedisCluster is ready


### PR DESCRIPTION
**Description**

Add the ability to scale up from single-node cluster to multi-node cluster and vice versa.
Fixes #1521 

**Type of change**
* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Create new single-node cluster then:
Scale up from 1 to 3 = OK
Scale down from 3 to 1 = OK
Create new 3 node cluster = OK
