### PR TITLE
fix: Set correct operator image in init containers

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -42,7 +42,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            IMG=${{ env.QuayImageName }}:${{ env.TAG }}
+            IMG=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/redis-operator:${{ env.TAG }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/redis-operator:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/redis-operator:latest

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -39,11 +39,13 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            IMG=${{ env.QuayImageName }}:${{ env.TAG }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/redis-operator:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/redis-operator:latest
-          platforms: linux/amd64,linux/arm64
 
   release-quay-image:
     runs-on: ubuntu-latest
@@ -76,36 +78,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            IMG=${{ env.QuayImageName }}:${{ env.TAG }}
           tags: |
             ${{ env.QuayImageName }}:${{ env.TAG }}
             ${{ env.QuayImageName }}:latest
-
-#   trivy_scan:
-#     needs: [release_image]
-#     runs-on: ubuntu-latest
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v2
-#     - name: Run Trivy vulnerability scanner for arm64 image
-#       uses: aquasecurity/trivy-action@master
-
-#     - name: Run Trivy vulnerability scanner for multi-arch image
-#       uses: aquasecurity/trivy-action@master
-#       with:
-#         image-ref: ${{ env.QuayImageName }}:${{ env.APP_VERSION }}
-#         format: 'template'
-#         template: '@/contrib/sarif.tpl'
-#         output: 'trivy-results-latest.sarif'
-#         exit-code: '1'
-#         ignore-unfixed: true
-#         severity: 'CRITICAL,HIGH'
-#     - name: Run Trivy vulnerability scanner for latest image
-#       uses: aquasecurity/trivy-action@master
-#       with:
-#         image-ref:  ${{ env.QuayImageName }}:latest
-#         format: 'template'
-#         template: '@/contrib/sarif.tpl'
-#         output: 'trivy-results-latest.sarif'
-#         exit-code: '1'
-#         ignore-unfixed: true
-#         severity: 'CRITICAL,HIGH'

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -6,7 +6,6 @@ description: Provides easy redis setup definitions for Kubernetes services, and 
 engine: gotpl
 maintainers:
   - name: iamabhishek-dubey
-  
   - name: sandy724
   - name: shubham-cmyk
 name: redis-operator

--- a/charts/redis-operator/templates/operator-deployment.yaml
+++ b/charts/redis-operator/templates/operator-deployment.yaml
@@ -86,6 +86,8 @@ spec:
           readOnly: true
       {{- end }}
         env:
+        - name: OPERATOR_IMAGE
+          value: {{ .Values.redisOperator.imageName }}:{{ .Values.redisOperator.imageTag | default (printf "v%s" .Chart.AppVersion) }}
         - name: ENABLE_WEBHOOKS
           value: {{ .Values.redisOperator.webhook | quote }}
         {{- if .Values.redisOperator.watchNamespace }}


### PR DESCRIPTION
  - Add missing IMG build-arg to Docker builds in publish workflow
  - Add OPERATOR_IMAGE env var to Helm deployment template
  - Fix GHCR build to use correct registry URL instead of Quay.io
  - Ensures init-config containers use proper versioned images instead of :latest

  Resolves issue where init-config containers defaulted to :latest tag
  when GenerateConfigInInitContainer feature gate was enabled.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1512

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
