### PR TITLE
feat: Add ServiceMonitor to the redis-operator helm chart

### DIFF
--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -115,8 +115,14 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | redisOperator.imagePullPolicy | string | `"Always"` |  |
 | redisOperator.imagePullSecrets | list | `[]` |  |
 | redisOperator.imageTag | string | `""` |  |
-| redisOperator.metrics.bindAddress | string | `":8080"` |  |
-| redisOperator.metrics.enabled | bool | `true` |  |
+| redisOperator.metrics.bindAddress | string | `":8080"` | The address the metrics endpoint binds to |
+| redisOperator.metrics.enabled | bool | `true` | Enable metrics server |
+| redisOperator.metrics.port | string | `"8080"` | The port the metrics endpoint binds to |
+| redisOperator.metrics.serviceMonitor.enabled | bool | `false` |  |
+| redisOperator.metrics.serviceMonitor.extraLabels | object | `{}` | extraLabels are added to the servicemonitor when enabled set to true |
+| redisOperator.metrics.serviceMonitor.interval | string | `"30s"` |  |
+| redisOperator.metrics.serviceMonitor.namespace | string | `""` | Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the operator |
+| redisOperator.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | redisOperator.name | string | `"redis-operator"` |  |
 | redisOperator.podAnnotations | object | `{}` |  |
 | redisOperator.podLabels | object | `{}` |  |

--- a/charts/redis-operator/templates/service-metrics.yaml
+++ b/charts/redis-operator/templates/service-metrics.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.redisOperator.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name : {{ .Values.redisOperator.name | default .Release.Name }}-metrics
+    helm.sh/chart : {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by : {{ .Release.Service }}
+    app.kubernetes.io/instance : {{ .Release.Name }}
+    app.kubernetes.io/version : {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of : {{ .Release.Name }}
+  name: {{ .Values.redisOperator.name | default .Release.Name }}-metrics
+  namespace:  {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: redis-operator-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: {{ .Values.redisOperator.metrics.port }}
+  selector:
+    name: {{ .Values.redisOperator.name }}
+{{ end }}

--- a/charts/redis-operator/templates/servicemonitor.yaml
+++ b/charts/redis-operator/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.redisOperator.metrics.serviceMonitor.enabled true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.redisOperator.name | default .Release.Name }}-prometheus-monitoring
+  namespace: {{ .Values.redisOperator.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.redisOperator.name | default .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.redisOperator.name | default .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: middleware
+    {{- with .Values.redisOperator.metrics.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name : {{ .Values.redisOperator.name | default .Release.Name }}-metrics
+      app.kubernetes.io/component: metrics
+  endpoints:
+  - port: redis-operator-metrics
+    interval: {{ .Values.redisOperator.metrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.redisOperator.metrics.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -33,10 +33,23 @@ redisOperator:
 
   # metrics configuration for monitoring
   metrics:
-    # Enable metrics server
+    # -- Enable metrics server
     enabled: true
-    # The address the metrics endpoint binds to
+    # -- The address the metrics endpoint binds to
     bindAddress: ":8080"
+    # -- The port the metrics endpoint binds to
+    port: "8080"
+    # serviceMonitor configuration
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: 10s
+      # -- Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the operator
+      namespace: ""
+      # -- extraLabels are added to the servicemonitor when enabled set to true
+      extraLabels: {}
+        # foo: bar
+        # team: devops
 
 resources:
   limits:


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
Hi,

Installing the **redis-operator** via helm today, I've found that the `Service` and the `ServiceMonitor` for the redis-operator helm chart was missing. This trivial PR fixes that. I've run `helm-docs` as well for updating the README.md file.

Thank you!

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes NONE

**Type of change**

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**

Tested with,

```console
helm template template-operator --values custom_value.yaml -n test-namespace . > manifests.yaml
```

<details>
<summary>Click to expand custom_value.yaml</summary>

```yaml
redisOperator:
  name: redis-operator
  imageName: quay.io/opstree/redis-operator

  # When not specified, the operator will watch all namespaces. It can be set to a specific namespace or multiple namespaces separated by commas.
  watchNamespace: "infra-oauth2-proxy"
  # If set to true, webhook server will be enabled for masterSlaveAntiAffinity feature
  # When enabled, you need to either:
  # 1. Enable cert-manager (certmanager.enabled=true) for automatic certificate management, or
  # 2. Manually create a certificate secret (see "How to generate private key" section in README)
  webhook: true
  automountServiceAccountToken: true

  # pprof configuration for performance profiling
  pprof:
    # Enable pprof server for performance profiling
    enabled: false

  # metrics configuration for monitoring
  metrics:
    # Enable metrics server
    enabled: true
    # The address the metrics endpoint binds to
    bindAddress: ":8080"
    # Enable ServiceMonitor resource creation for Prometheus Operator
    serviceMonitor:
      enabled: true
      interval: 30s
      scrapeTimeout: 10s
      # Namespace where servicemonitor resource will be created, if empty it
      # will be created in the same namespace as the operator
      namespace: ""
      # -- extraLabels are added to the servicemonitor when enabled set to true
      extraLabels:
        team: infra

resources:
  limits:
    cpu: 500m
    memory: 500Mi
  requests:
    cpu: 500m
    memory: 500Mi

replicas: 1

rbac:
  enabled: true
serviceAccountName: redis-operator

serviceAccount:
  automountServiceAccountToken: true

service:
  name: webhook-service
  namespace: infra-mgmt

certificate:
  name: redis-serving-cert
  secretName: redis-webhook-server-cert

issuer:
  # Whether to create the issuer or not. You might want to disable this if instead you
  # want to use a ClusterIssuer that you simply want to provide.
  create: true
  # You can choose Issuer or ClusterIssuer here. The first one is namespaced, the second one
  # is available for global usage.
  kind: Issuer
  type: selfSigned
  name: redis-operator-issuer
  email: sysadmin@mimacom.com
  server: https://acme-v02.api.letsencrypt.org/directory
  privateKeySecretName: letsencrypt-prod
  solver:
    enabled: true
    ingressClass: nginx

certmanager:
  # Whether to use cert-manager for certificate management
  # Only effective when webhook=true
  # If webhook=true and certmanager.enabled=false, you need to manually create certificate secret
  enabled: true
  # API version of the cert-manager CRDs
  apiVersion: "cert-manager.io/v1"

priorityClassName: ""
nodeSelector: {}
tolerateAllTaints: false
tolerations: []
affinity: {}

podSecurityContext: {}
#  fsGroup: 2000

securityContext: {}
#  capabilities:
#    drop:
#    - ALL
#  readOnlyRootFilesystem: true
#  runAsNonRoot: true
#  runAsUser: 1000

# Feature gates for alpha/experimental features
featureGates:
  # Enable generating Redis configuration using an init container instead of a regular container
  GenerateConfigInInitContainer: false

manager:
  # config values for the operator manager
  config:
    kubeClientTimeout: 60s
    # -- If value > 0, it will override the default value in the operator
    kubeClientQPS: 0.0
```
</details>
<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
