### PR TITLE
fix: label rendering for non-string values.

### DIFF
--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -9,9 +9,7 @@ app.kubernetes.io/instance: {{ .Values.redisCluster.name | default .Release.Name
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/component: middleware
 {{- if .Values.labels }}
-{{- range $labelkey, $labelvalue := .Values.labels }}
-{{ $labelkey}}: {{ $labelvalue }}
-{{- end }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end -}}
 

--- a/charts/redis-replication/templates/_helpers.tpl
+++ b/charts/redis-replication/templates/_helpers.tpl
@@ -9,9 +9,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/component: middleware
 {{- if .Values.labels }}
-{{- range $labelkey, $labelvalue := .Values.labels }}
-{{ $labelkey}}: {{ $labelvalue }}
-{{- end }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end -}}
 

--- a/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/redis-sentinel/templates/_helpers.tpl
@@ -9,9 +9,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/component: middleware
 {{- if .Values.labels }}
-{{- range $labelkey, $labelvalue := .Values.labels }}
-{{ $labelkey}}: {{ $labelvalue }}
-{{- end }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end -}}
 

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -9,9 +9,7 @@ app.kubernetes.io/instance: {{ .Values.redisStandalone.name | default .Release.N
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/component: middleware
 {{- if .Values.labels }}
-{{- range $labelkey, $labelvalue := .Values.labels }}
-{{ $labelkey}}: {{ $labelvalue }}
-{{- end }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
**Description**

I've fixed label rendering for non-string values.  
For now, we cannot set boolean or number only string label values to Pod labels.

Current:

```sh
$ helm template redis-cluster ot-helm/redis-cluster --set-string 'labels.test1=test,labels.test2=true,labels.test3=1' | head -20
---
# Source: redis-cluster/templates/redis-cluster.yaml
apiVersion: redis.redis.opstreelabs.in/v1beta2
kind: RedisCluster
metadata:
  name: redis-cluster
  labels:
    app.kubernetes.io/name: redis-cluster
    helm.sh/chart: redis-cluster-0.17.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: redis-cluster
    app.kubernetes.io/version: 0.17.1
    app.kubernetes.io/component: middleware
    test1: test
    test2: true
    test3: 1
  annotations:

spec:
  clusterSize: 3
```

Changed:

```sh
$ helm template redis-cluster ./charts/redis-cluster --set-string 'labels.test1=test,labels.test2=true,labels.test3=1' | head -20
---
# Source: redis-cluster/templates/redis-cluster.yaml
apiVersion: redis.redis.opstreelabs.in/v1beta2
kind: RedisCluster
metadata:
  name: redis-cluster
  labels:
    app.kubernetes.io/name: redis-cluster
    helm.sh/chart: redis-cluster-0.17.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: redis-cluster
    app.kubernetes.io/version: 0.17.1
    app.kubernetes.io/component: middleware
    test1: test
    test2: "true"
    test3: "1"
  annotations:

spec:
  clusterSize: 3
```

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.
