### PR TITLE
fix: service account name for matching references on operator chart

### DIFF
--- a/charts/redis-operator/templates/service-account.yaml
+++ b/charts/redis-operator/templates/service-account.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ .Values.redisOperator.name }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name : {{ .Values.redisOperator.name }}


### PR DESCRIPTION
This is a minor fix that I encountered today when changing `.Values.redisOperator.name`, and the operator pod disappeared.

