### PR TITLE
fix: Add endpoint validation in cluster creation commands

### DIFF
--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -542,8 +542,10 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 			objects = append(objects, secret...)
 
 			client := k8sClientFake.NewSimpleClientset(objects...)
-			cmd := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod)
+			cmd, err := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod)
 
+			// Assert no error occurred
+			assert.NoError(t, err)
 			// Assert the command is as expected using testify
 			assert.Equal(t, tt.expectedCommand, cmd)
 		})


### PR DESCRIPTION
Redis cluster creation was failing silently due to empty endpoint values being added to Redis CLI commands after [PR 1568](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1568) merge. Scope:
- Validate getEndpoint() returns non-empty values before using them
- Return errors from createRedisReplicationCommand when endpoints fail
- Prevents silent failures in cluster bootstrap process

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
