### PR TITLE
refactor(utils): Remove command-line password usage

### DIFF
--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -96,6 +96,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | certificate.secretName | string | `"webhook-server-cert"` |  |
 | certmanager.apiVersion | string | `"cert-manager.io/v1"` |  |
 | certmanager.enabled | bool | `false` |  |
+| featureGates.AvoidCommandLinePassword | bool | `false` |  |
 | featureGates.GenerateConfigInInitContainer | bool | `false` |  |
 | issuer.create | bool | `true` |  |
 | issuer.email | string | `"shubham.gupta@opstree.com"` |  |

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -127,6 +127,8 @@ securityContext: {}
 
 # Feature gates for alpha/experimental features
 featureGates:
+  # Never execute redis-cli -a <password>, even if authentication cannot succeed without it
+  AvoidCommandLinePassword: false
   # Enable generating Redis configuration using an init container instead of a regular container
   GenerateConfigInInitContainer: false
 

--- a/docs/content/en/docs/Advance Configuration/Feature Gates/_index.md
+++ b/docs/content/en/docs/Advance Configuration/Feature Gates/_index.md
@@ -17,9 +17,33 @@ Feature gates can be configured in the Helm chart values:
 featureGates:
   # Enable generating Redis configuration using an init container instead of a regular container
   GenerateConfigInInitContainer: false
+  # Never execute redis-cli -a <password>, even if authentication cannot succeed without it
+  AvoidCommandLinePassword: false
 ```
 
 ## Available Feature Gates
+
+### AvoidCommandLinePassword
+
+When enabled, Redis Operator will never execute `redis-cli -a <password>`, which can leak passwords. The Operator sets the
+`REDISCLI_AUTH` variable on all Redis pods, so the password does not need to be provided on the command line and it is normally
+safe to turn this on unless you are simultaneously upgrading the operator. This is an alpha feature and may change in future releases.
+
+However, if you upgrade from a version that does not add `REDISCLI_AUTH` to the pods (a behavior introduced in the same version that
+added `AvoidCommandLinePassword`), simultaneously enabling `AvoidCommandLinePassword` will make Redis Operator unable to manage
+your current pods, since `-a <password>` is still needed on them. Hence, to guarantee that the Redis password will never be included
+on a command line, you must either risk an operator downtime or upgrade in two steps:
+
+1. Upgrade to a version that adds `REDISCLI_AUTH` to the pods (which was introduced at the same time as `AvoidCommandLinePassword`).
+2. Turn on `AvoidCommandLinePassword`.
+
+**Default**: `false`
+
+**Usage**:
+```yaml
+featureGates:
+  AvoidCommandLinePassword: true
+```
 
 ### GenerateConfigInInitContainer
 

--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -97,8 +97,9 @@ func addFlags(cmd *cobra.Command, opts *managerOptions) {
 	cmd.Flags().BoolVar(&opts.enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().BoolVar(&opts.enableWebhooks, "enable-webhooks", envs.IsWebhookEnabled(), "Enable webhooks")
 	cmd.Flags().IntVar(&opts.maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Max concurrent reconciles")
-	cmd.Flags().StringVar(&opts.featureGatesString, "feature-gates", envs.GetFeatureGates(), "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n  GenerateConfigInInitContainer=true|false: enables using init container for config generation")
+	cmd.Flags().StringVar(&opts.featureGatesString, "feature-gates", envs.GetFeatureGates(), "A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:"+
+		"\n  GenerateConfigInInitContainer=true|false: enables using init container for config generation"+
+		"\n  AvoidCommandLinePassword=true|false: prevents using -a <password> in redis-cli commands")
 	cmd.Flags().Duration(
 		operator.KubeClientTimeoutMGRFlag,
 		60*time.Second,

--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -101,7 +101,8 @@ func addFlags(cmd *cobra.Command, opts *managerOptions) {
 	cmd.Flags().BoolVar(&opts.enableWebhooks, "enable-webhooks", envs.IsWebhookEnabled(), "Enable webhooks")
 	cmd.Flags().IntVar(&opts.maxConcurrentReconciles, "max-concurrent-reconciles", 3, "Maximum number of concurrent reconciles per controller. Reconciles for distinct objects run in parallel (controller-runtime still serializes per object), so a single slow or stuck reconcile cannot starve other Redis resources across namespaces.")
 	cmd.Flags().StringVar(&opts.featureGatesString, "feature-gates", envs.GetFeatureGates(), "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n  GenerateConfigInInitContainer=true|false: enables using init container for config generation")
+		"Options are:\n  GenerateConfigInInitContainer=true|false: enables using init container for config generation"+
+		"\n  AvoidCommandLinePassword=true|false: prevents using -a <password> in redis-cli commands")
 	cmd.Flags().Duration(
 		operator.KubeClientTimeoutMGRFlag,
 		60*time.Second,

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -9,12 +9,14 @@ const (
 	// GenerateConfigInInitContainer enables generating Redis configuration using an init container
 	// instead of a regular container
 	GenerateConfigInInitContainer featuregate.Feature = "GenerateConfigInInitContainer"
+	AvoidCommandLinePassword      featuregate.Feature = "AvoidCommandLinePassword"
 )
 
 // DefaultRedisOperatorFeatureGates consists of all known Redis operator feature gates.
 // To add a new feature, define a key for it above and add it here.
 var DefaultRedisOperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	GenerateConfigInInitContainer: {Default: false, PreRelease: featuregate.Alpha},
+	AvoidCommandLinePassword:      {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // MutableFeatureGate is a feature gate that can be dynamically set

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -249,15 +249,11 @@ func ReshardRedisCluster(ctx context.Context, client kubernetes.Interface, cr *r
 	}
 	cmd = []string{"redis-cli", "--cluster", "reshard"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, transferPOD))
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "error in getting redis password")
-			return
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, transferNodeName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, transferNodeName)...)
 
@@ -373,7 +369,7 @@ func RebalanceRedisClusterEmptyMasters(ctx context.Context, client kubernetes.In
 		return
 	}
 
-	// cmd = redis-cli --cluster rebalance <redis>:<port> --cluster-use-empty-masters -a <pass>
+	// cmd = redis-cli --cluster rebalance <redis>:<port> --cluster-use-empty-masters
 	var cmd []string
 	pod := RedisDetails{
 		PodName:   cr.Name + "-leader-1",
@@ -382,14 +378,11 @@ func RebalanceRedisClusterEmptyMasters(ctx context.Context, client kubernetes.In
 	cmd = []string{"redis-cli", "--cluster", "rebalance"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, pod))
 	cmd = append(cmd, "--cluster-use-empty-masters")
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
@@ -419,7 +412,7 @@ func CheckIfEmptyMasters(ctx context.Context, client kubernetes.Interface, cr *r
 
 // Rebalance Redis Cluster Would Rebalance the Redis Cluster without using the empty masters
 func RebalanceRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) {
-	// cmd = redis-cli --cluster rebalance <redis>:<port> -a <pass>
+	// cmd = redis-cli --cluster rebalance <redis>:<port>
 	var cmd []string
 	pod := RedisDetails{
 		PodName:   cr.Name + "-leader-1",
@@ -427,14 +420,11 @@ func RebalanceRedisCluster(ctx context.Context, client kubernetes.Interface, cr 
 	}
 	cmd = []string{"redis-cli", "--cluster", "rebalance"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, pod))
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
@@ -470,14 +460,11 @@ func AddRedisNodeToCluster(ctx context.Context, client kubernetes.Interface, cr 
 	}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, newPod))
 	cmd = append(cmd, getEndpoint(ctx, client, cr, existingPod))
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
@@ -522,14 +509,11 @@ func RemoveRedisFollowerNodesFromCluster(ctx context.Context, client kubernetes.
 
 	cmd = []string{"redis-cli"}
 
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
 	lastLeaderPodNodeID := getRedisNodeID(ctx, client, cr, lastLeaderPod)
@@ -555,14 +539,11 @@ func RemoveRedisNodeFromCluster(ctx context.Context, client kubernetes.Interface
 	cmd := []string{"redis-cli", "--cluster", "del-node"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, existingPod))
 	cmd = append(cmd, getRedisNodeID(ctx, client, cr, removePod))
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 	executeCommand(ctx, client, cr, cmd, cr.Name+"-leader-0")
 }
@@ -596,7 +577,7 @@ func verifyLeaderPodInfo(ctx context.Context, redisClient *redis.Client, podName
 
 func ClusterFailover(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, shardIdx int32) error {
 	slavePodName := cr.Name + "-leader-" + strconv.Itoa(int(shardIdx))
-	// cmd = redis-cli cluster failover  -a <pass>
+	// cmd = redis-cli cluster failover
 	var cmd []string
 	pod := RedisDetails{
 		PodName:   slavePodName,
@@ -609,14 +590,11 @@ func ClusterFailover(ctx context.Context, client kubernetes.Interface, cr *rcvb2
 	}
 	host, port := endpoint[:lastColon], endpoint[lastColon+1:]
 	cmd = []string{"redis-cli", "-h", host, "-p", port}
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, slavePodName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, slavePodName)...)
 	cmd = append(cmd, "cluster", "failover")

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -347,18 +347,16 @@ func FixRedisCluster(ctx context.Context, client kubernetes.Interface, cr *rcvb2
 	}
 	cmd := []string{"redis-cli", "--cluster", "fix"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, pod))
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error in getting redis password")
-		}
-		cmd = append(cmd, "-a")
-		cmd = append(cmd, pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+		return err
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, "--cluster-yes")
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
-	_, err := executeCommand1(ctx, client, cr, cmd, cr.Name+"-leader-0")
+	_, err = executeCommand1(ctx, client, cr, cmd, cr.Name+"-leader-0")
 	return err
 }
 

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -16,6 +16,7 @@ import (
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/features"
 	retry "github.com/avast/retry-go"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/samber/lo"
@@ -118,6 +119,66 @@ func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.Red
 // executeSingleLeaderAddSlots so the command assembly and batching logic
 // can be unit tested without a live pod exec.
 type podExecFunc func(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string)
+
+// checkRedisCLIAuthInEnv returns true if we can use the pod's REDISCLI_AUTH variable instead of sending redis-cli -a <password>.
+// It checks only variables specified via env[].valueFrom since this is what the operator sets; it does not look at envFrom.
+func checkRedisCLIAuthInEnv(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName, secretName, secretKey string) (bool, error) {
+	redisPod, err := client.CoreV1().Pods(cr.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error checking Redis pod's REDISCLI_AUTH variable", "namespace", cr.Namespace, "podName", podName)
+		return false, err
+	}
+
+	for _, tr := range redisPod.Spec.Containers {
+		if tr.Name == cr.Name+"-leader" {
+			for _, e := range tr.Env {
+				if e.Name != "REDISCLI_AUTH" {
+					continue
+				}
+
+				if e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
+					continue
+				}
+
+				if e.ValueFrom.SecretKeyRef.Name != secretName || e.ValueFrom.SecretKeyRef.Key != secretKey {
+					return false, nil
+				}
+
+				return true, nil
+			}
+
+			log.FromContext(ctx).V(1).Info("Leader container not configured with REDISCLI_AUTH", "podName", podName)
+			return false, nil
+		}
+	}
+
+	log.FromContext(ctx).V(1).Info("Leader container not found in pod", "podName", podName)
+	return false, nil
+}
+
+func getRedisClusterAuthArgs(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName string) ([]string, error) {
+	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
+		passwordInEnv, err := checkRedisCLIAuthInEnv(ctx, client, cr, podName, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
+		if err != nil {
+			return []string{}, fmt.Errorf("error checking pod authentication config: %w", err)
+		}
+
+		if !passwordInEnv {
+			if features.Enabled(features.AvoidCommandLinePassword) {
+				return []string{}, errors.New("refusing to use command-line authentication because AvoidCommandLinePassword is set")
+			}
+
+			pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
+			if err != nil {
+				return []string{}, fmt.Errorf("error getting Redis password: %w", err)
+			}
+
+			return []string{"-a", pass}, nil
+		}
+	}
+
+	return []string{}, nil
+}
 
 // executeSingleLeaderAddSlots assigns all 16384 hash slots to the single
 // leader node. On Redis 7+ it uses CLUSTER ADDSLOTSRANGE 0 16383 (a single
@@ -368,13 +429,12 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 		executeSingleLeaderAddSlots(ctx, client, cr, executeCommand)
 	default:
 		cmd := CreateMultipleLeaderRedisCommand(ctx, client, cr)
-		if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-			pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-			if err != nil {
-				log.FromContext(ctx).Error(err, "Error in getting redis password")
-			}
-			cmd.AddFlag("-a")
-			cmd.AddFlag(pass)
+		authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+		}
+		for _, arg := range authArgs {
+			cmd.AddFlag(arg)
 		}
 		cmd.AddFlag(getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 		executeCommand(ctx, client, cr, cmd.Args(), cr.Name+"-leader-0")
@@ -401,14 +461,11 @@ func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interf
 	cmd = append(cmd, getEndpoint(ctx, client, cr, followerPod))
 	cmd = append(cmd, getEndpoint(ctx, client, cr, leaderPod))
 	cmd = append(cmd, "--cluster-slave")
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Failed to retrieve Redis password", "Secret", *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name)
-		} else {
-			cmd = append(cmd, "-a", pass)
-		}
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, leaderPod.PodName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, leaderPod.PodName)...)
 	return cmd
 }
@@ -613,13 +670,11 @@ func checkClusterHealth(ctx context.Context, client kubernetes.Interface, cr *rc
 	logger := log.FromContext(ctx)
 
 	cmd := []string{"redis-cli", "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", *cr.Spec.Port)}
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			return fmt.Errorf("error getting redis password: %w", err)
-		}
-		cmd = append(cmd, "-a", pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, podName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, podName)...)
 
 	out, err := executeCommand1(ctx, client, cr, cmd, podName)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -187,18 +187,18 @@ func getRedisClusterAuthArgs(ctx context.Context, client kubernetes.Interface, c
 func executeSingleLeaderAddSlots(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, execute podExecFunc) {
 	logger := log.FromContext(ctx)
 
-	var flags []string
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			logger.Error(err, "Error in getting redis password")
-		} else {
-			flags = append(flags, "-a", pass)
-		}
-	}
-	flags = append(flags, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
-
 	podName := cr.Name + "-leader-0"
+
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, podName)
+	if err != nil {
+		// Bail out instead of assigning slots unauthenticated: doing so would
+		// either fail outright or, worse, corrupt the new cluster's topology.
+		logger.Error(err, "Failed to get password authentication arguments")
+		return
+	}
+	var flags []string
+	flags = append(flags, authArgs...)
+	flags = append(flags, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
 	// Redis 7+ supports ADDSLOTSRANGE which takes a start-end pair instead
 	// of listing every slot number individually — avoids the URL length issue entirely.
@@ -431,7 +431,10 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 		cmd := CreateMultipleLeaderRedisCommand(ctx, client, cr)
 		authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
 		if err != nil {
+			// Bail out instead of creating the cluster unauthenticated: that
+			// would either fail or build a cluster the operator cannot manage.
 			log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+			return
 		}
 		for _, arg := range authArgs {
 			cmd.AddFlag(arg)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -801,11 +801,24 @@ const defaultExecCommandTimeout = 5 * time.Minute
 // reconciler opens against redis pods, so an unreachable pod cannot stall a reconcile.
 const defaultRedisClientTimeout = 5 * time.Second
 
+// wrapRedisCLIAuthSanitize wraps a redis-cli argv in a shell shim that strips
+// CR/LF from the container's REDISCLI_AUTH before redis-cli reads it (see
+// redisCLIAuthSanitizer for why). The original argv is forwarded via "$@" so
+// no re-quoting is needed and the password still never appears on the command
+// line. Non-redis-cli commands are passed through untouched.
+func wrapRedisCLIAuthSanitize(cmd []string) []string {
+	if len(cmd) == 0 || cmd[0] != "redis-cli" {
+		return cmd
+	}
+	return append([]string{"sh", "-c", redisCLIAuthSanitizer + `; exec "$@"`, "sh"}, cmd...)
+}
+
 func executeCommand1(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) (stdout string, stderr error) {
 	var (
 		execOut bytes.Buffer
 		execErr bytes.Buffer
 	)
+	cmd = wrapRedisCLIAuthSanitize(cmd)
 	config, err := GenerateK8sConfig()()
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Could not find pod to execute")

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -17,6 +17,7 @@ import (
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/features"
 	retry "github.com/avast/retry-go"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/samber/lo"
@@ -119,6 +120,66 @@ func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.Red
 // executeSingleLeaderAddSlots so the command assembly and batching logic
 // can be unit tested without a live pod exec.
 type podExecFunc func(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string)
+
+// checkRedisCLIAuthInEnv returns true if we can use the pod's REDISCLI_AUTH variable instead of sending redis-cli -a <password>.
+// It checks only variables specified via env[].valueFrom since this is what the operator sets; it does not look at envFrom.
+func checkRedisCLIAuthInEnv(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName, secretName, secretKey string) (bool, error) {
+	redisPod, err := client.CoreV1().Pods(cr.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error checking Redis pod's REDISCLI_AUTH variable", "namespace", cr.Namespace, "podName", podName)
+		return false, err
+	}
+
+	for _, tr := range redisPod.Spec.Containers {
+		if tr.Name == cr.Name+"-leader" {
+			for _, e := range tr.Env {
+				if e.Name != "REDISCLI_AUTH" {
+					continue
+				}
+
+				if e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
+					continue
+				}
+
+				if e.ValueFrom.SecretKeyRef.Name != secretName || e.ValueFrom.SecretKeyRef.Key != secretKey {
+					return false, nil
+				}
+
+				return true, nil
+			}
+
+			log.FromContext(ctx).V(1).Info("Leader container not configured with REDISCLI_AUTH", "podName", podName)
+			return false, nil
+		}
+	}
+
+	log.FromContext(ctx).V(1).Info("Leader container not found in pod", "podName", podName)
+	return false, nil
+}
+
+func getRedisClusterAuthArgs(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName string) ([]string, error) {
+	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
+		passwordInEnv, err := checkRedisCLIAuthInEnv(ctx, client, cr, podName, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
+		if err != nil {
+			return []string{}, fmt.Errorf("error checking pod authentication config: %w", err)
+		}
+
+		if !passwordInEnv {
+			if features.Enabled(features.AvoidCommandLinePassword) {
+				return []string{}, errors.New("refusing to use command-line authentication because AvoidCommandLinePassword is set")
+			}
+
+			pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
+			if err != nil {
+				return []string{}, fmt.Errorf("error getting Redis password: %w", err)
+			}
+
+			return []string{"-a", pass}, nil
+		}
+	}
+
+	return []string{}, nil
+}
 
 // executeSingleLeaderAddSlots assigns all 16384 hash slots to the single
 // leader node. On Redis 7+ it uses CLUSTER ADDSLOTSRANGE 0 16383 (a single
@@ -369,13 +430,12 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 		executeSingleLeaderAddSlots(ctx, client, cr, executeCommand)
 	default:
 		cmd := CreateMultipleLeaderRedisCommand(ctx, client, cr)
-		if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-			pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-			if err != nil {
-				log.FromContext(ctx).Error(err, "Error in getting redis password")
-			}
-			cmd.AddFlag("-a")
-			cmd.AddFlag(pass)
+		authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+		}
+		for _, arg := range authArgs {
+			cmd.AddFlag(arg)
 		}
 		cmd.AddFlag(getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 		executeCommand(ctx, client, cr, cmd.Args(), cr.Name+"-leader-0")
@@ -402,14 +462,11 @@ func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interf
 	cmd = append(cmd, getEndpoint(ctx, client, cr, followerPod))
 	cmd = append(cmd, getEndpoint(ctx, client, cr, leaderPod))
 	cmd = append(cmd, "--cluster-slave")
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Failed to retrieve Redis password", "Secret", *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name)
-		} else {
-			cmd = append(cmd, "-a", pass)
-		}
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, leaderPod.PodName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, leaderPod.PodName)...)
 	return cmd
 }
@@ -614,13 +671,11 @@ func checkClusterHealth(ctx context.Context, client kubernetes.Interface, cr *rc
 	logger := log.FromContext(ctx)
 
 	cmd := []string{"redis-cli", "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", *cr.Spec.Port)}
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			return fmt.Errorf("error getting redis password: %w", err)
-		}
-		cmd = append(cmd, "-a", pass)
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, podName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
+	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, podName)...)
 
 	out, err := executeCommand1(ctx, client, cr, cmd, podName)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -670,16 +670,40 @@ func RedisClusterStatusHealth(ctx context.Context, client kubernetes.Interface, 
 }
 
 // checkClusterHealth performs a single cluster health check against a specific pod
+// clusterCheckConnectTimeoutSeconds bounds how long redis-cli waits when dialing
+// a cluster peer during the health check.
+//
+// redis-cli has no default connect timeout, so `--cluster check` blocks
+// indefinitely on any node whose recorded address is stale -- which is exactly
+// the state left behind when pods come back on new IPs (a StatefulSet recreate,
+// an eviction, a node drain). Because the health check runs 3 attempts against
+// each leader, a stuck dial can pin a single reconcile for far longer than the
+// exec timeout budget, so the reconcile never reaches RepairDisconnectedNodes,
+// which is what would issue the CLUSTER MEET that corrects those addresses. The
+// cluster then stays out of Ready indefinitely instead of self-healing.
+//
+// Bounding the dial makes the probe fail in seconds and report the cluster as
+// unhealthy, letting the repair path run on the next reconcile.
+const clusterCheckConnectTimeoutSeconds = 5
+
+// clusterCheckCommand builds the `redis-cli --cluster check` argv, bounding the
+// peer dial with clusterCheckConnectTimeoutSeconds so an unreachable node cannot
+// block the reconcile.
+func clusterCheckCommand(port int, authArgs, tlsArgs []string) []string {
+	cmd := []string{"redis-cli", "-t", strconv.Itoa(clusterCheckConnectTimeoutSeconds), "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", port)}
+	cmd = append(cmd, authArgs...)
+	cmd = append(cmd, tlsArgs...)
+	return cmd
+}
+
 func checkClusterHealth(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName string) error {
 	logger := log.FromContext(ctx)
 
-	cmd := []string{"redis-cli", "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", *cr.Spec.Port)}
 	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, podName)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
 	}
-	cmd = append(cmd, authArgs...)
-	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, podName)...)
+	cmd := clusterCheckCommand(*cr.Spec.Port, authArgs, getRedisTLSArgs(cr.Spec.TLS, podName))
 
 	out, err := executeCommand1(ctx, client, cr, cmd, podName)
 	if err != nil {

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -188,18 +188,18 @@ func getRedisClusterAuthArgs(ctx context.Context, client kubernetes.Interface, c
 func executeSingleLeaderAddSlots(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, execute podExecFunc) {
 	logger := log.FromContext(ctx)
 
-	var flags []string
-	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
-		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
-		if err != nil {
-			logger.Error(err, "Error in getting redis password")
-		} else {
-			flags = append(flags, "-a", pass)
-		}
-	}
-	flags = append(flags, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
-
 	podName := cr.Name + "-leader-0"
+
+	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, podName)
+	if err != nil {
+		// Bail out instead of assigning slots unauthenticated: doing so would
+		// either fail outright or, worse, corrupt the new cluster's topology.
+		logger.Error(err, "Failed to get password authentication arguments")
+		return
+	}
+	var flags []string
+	flags = append(flags, authArgs...)
+	flags = append(flags, getRedisTLSArgs(cr.Spec.TLS, cr.Name+"-leader-0")...)
 
 	// Redis 7+ supports ADDSLOTSRANGE which takes a start-end pair instead
 	// of listing every slot number individually — avoids the URL length issue entirely.
@@ -432,7 +432,10 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 		cmd := CreateMultipleLeaderRedisCommand(ctx, client, cr)
 		authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
 		if err != nil {
+			// Bail out instead of creating the cluster unauthenticated: that
+			// would either fail or build a cluster the operator cannot manage.
 			log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+			return
 		}
 		for _, arg := range authArgs {
 			cmd.AddFlag(arg)

--- a/internal/k8sutils/redis_auth_args_test.go
+++ b/internal/k8sutils/redis_auth_args_test.go
@@ -1,0 +1,150 @@
+package k8sutils
+
+import (
+	"context"
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/features"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	authTestNamespace  = "default"
+	authTestClusterCR  = "test-cluster"
+	authTestLeaderPod  = "test-cluster-leader-0"
+	authTestSecretName = "redis-secret"
+	authTestSecretKey  = "password"
+	authTestPassword   = "s3cr3t"
+)
+
+// newAuthTestCluster builds a minimal RedisCluster referencing an existing
+// password secret, which is the only case in which authentication args matter.
+func newAuthTestCluster(withSecret bool) *rcvb2.RedisCluster {
+	cr := &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authTestClusterCR,
+			Namespace: authTestNamespace,
+		},
+	}
+	if withSecret {
+		cr.Spec.KubernetesConfig.ExistingPasswordSecret = &common.ExistingPasswordSecret{
+			Name: ptr.To(authTestSecretName),
+			Key:  ptr.To(authTestSecretKey),
+		}
+	}
+	return cr
+}
+
+// leaderPod returns a leader pod whose redis container optionally carries the
+// REDISCLI_AUTH env var sourced from the given secret name/key.
+func leaderPod(withRedisCLIAuth bool, secretName, secretKey string) *corev1.Pod {
+	container := corev1.Container{Name: authTestClusterCR + "-leader"}
+	if withRedisCLIAuth {
+		container.Env = []corev1.EnvVar{
+			{
+				Name: "REDISCLI_AUTH",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+						Key:                  secretKey,
+					},
+				},
+			},
+		}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: authTestLeaderPod, Namespace: authTestNamespace},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
+	}
+}
+
+func authTestSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: authTestSecretName, Namespace: authTestNamespace},
+		Data:       map[string][]byte{authTestSecretKey: []byte(authTestPassword)},
+	}
+}
+
+// setAvoidCommandLinePassword toggles the feature gate for the duration of a
+// test and restores its previous value afterwards.
+func setAvoidCommandLinePassword(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := features.Enabled(features.AvoidCommandLinePassword)
+	require.NoError(t, features.MutableFeatureGate.SetFromMap(map[string]bool{
+		string(features.AvoidCommandLinePassword): enabled,
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, features.MutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.AvoidCommandLinePassword): previous,
+		}))
+	})
+}
+
+func TestGetRedisClusterAuthArgs(t *testing.T) {
+	t.Run("no existing password secret returns no args", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		args, err := getRedisClusterAuthArgs(context.Background(), client, newAuthTestCluster(false), authTestLeaderPod)
+		require.NoError(t, err)
+		assert.Empty(t, args)
+	})
+
+	t.Run("REDISCLI_AUTH present and matching returns no -a", func(t *testing.T) {
+		client := fake.NewSimpleClientset(authTestSecret(), leaderPod(true, authTestSecretName, authTestSecretKey))
+		args, err := getRedisClusterAuthArgs(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod)
+		require.NoError(t, err)
+		assert.Empty(t, args)
+	})
+
+	t.Run("REDISCLI_AUTH absent with gate off returns -a <password>", func(t *testing.T) {
+		setAvoidCommandLinePassword(t, false)
+		client := fake.NewSimpleClientset(authTestSecret(), leaderPod(false, "", ""))
+		args, err := getRedisClusterAuthArgs(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"-a", authTestPassword}, args)
+	})
+
+	t.Run("REDISCLI_AUTH absent with gate on returns error", func(t *testing.T) {
+		setAvoidCommandLinePassword(t, true)
+		client := fake.NewSimpleClientset(authTestSecret(), leaderPod(false, "", ""))
+		args, err := getRedisClusterAuthArgs(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod)
+		require.Error(t, err)
+		assert.Empty(t, args)
+	})
+}
+
+func TestCheckRedisCLIAuthInEnv(t *testing.T) {
+	t.Run("matching REDISCLI_AUTH", func(t *testing.T) {
+		client := fake.NewSimpleClientset(leaderPod(true, authTestSecretName, authTestSecretKey))
+		ok, err := checkRedisCLIAuthInEnv(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod, authTestSecretName, authTestSecretKey)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("REDISCLI_AUTH sourced from a different secret", func(t *testing.T) {
+		client := fake.NewSimpleClientset(leaderPod(true, "other-secret", authTestSecretKey))
+		ok, err := checkRedisCLIAuthInEnv(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod, authTestSecretName, authTestSecretKey)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("leader container without REDISCLI_AUTH", func(t *testing.T) {
+		client := fake.NewSimpleClientset(leaderPod(false, "", ""))
+		ok, err := checkRedisCLIAuthInEnv(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod, authTestSecretName, authTestSecretKey)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("pod does not exist returns error", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		ok, err := checkRedisCLIAuthInEnv(context.Background(), client, newAuthTestCluster(true), authTestLeaderPod, authTestSecretName, authTestSecretKey)
+		require.Error(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/internal/k8sutils/redis_auth_args_test.go
+++ b/internal/k8sutils/redis_auth_args_test.go
@@ -148,3 +148,33 @@ func TestCheckRedisCLIAuthInEnv(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestWrapRedisCLIAuthSanitize(t *testing.T) {
+	t.Run("redis-cli argv is wrapped and forwarded via $@", func(t *testing.T) {
+		in := []string{"redis-cli", "--cluster", "check", "127.0.0.1:6379"}
+		out := wrapRedisCLIAuthSanitize(in)
+		// sh -c '<sanitize>; exec "$@"' sh redis-cli --cluster check 127.0.0.1:6379
+		require.Len(t, out, 4+len(in))
+		assert.Equal(t, []string{"sh", "-c"}, out[:2])
+		assert.Contains(t, out[2], `tr -d '\r\n'`)
+		assert.Contains(t, out[2], `exec "$@"`)
+		assert.Equal(t, "sh", out[3])
+		assert.Equal(t, in, out[4:])
+	})
+
+	t.Run("sanitizer leaves REDISCLI_AUTH unset when absent", func(t *testing.T) {
+		// The guard must not export an empty REDISCLI_AUTH: redis-cli would
+		// then send AUTH with an empty password on password-less deployments.
+		out := wrapRedisCLIAuthSanitize([]string{"redis-cli", "ping"})
+		assert.Contains(t, out[2], `if [ -n "${REDISCLI_AUTH:-}" ]`)
+	})
+
+	t.Run("non-redis-cli argv passes through untouched", func(t *testing.T) {
+		in := []string{"cat", "/etc/redis/redis.conf"}
+		assert.Equal(t, in, wrapRedisCLIAuthSanitize(in))
+	})
+
+	t.Run("empty argv passes through", func(t *testing.T) {
+		assert.Empty(t, wrapRedisCLIAuthSanitize(nil))
+	})
+}

--- a/internal/k8sutils/redis_auth_args_test.go
+++ b/internal/k8sutils/redis_auth_args_test.go
@@ -149,6 +149,27 @@ func TestCheckRedisCLIAuthInEnv(t *testing.T) {
 	})
 }
 
+func TestClusterCheckCommand(t *testing.T) {
+	t.Run("bounds the peer dial with a connect timeout", func(t *testing.T) {
+		cmd := clusterCheckCommand(6379, nil, nil)
+		// redis-cli has no default connect timeout, so without -t the check
+		// blocks forever on nodes whose recorded IP is stale and the reconcile
+		// never reaches the repair path. The flag must precede --cluster.
+		require.Equal(t, []string{
+			"redis-cli", "-t", "5", "--cluster", "check", "127.0.0.1:6379",
+		}, cmd)
+		assert.Positive(t, clusterCheckConnectTimeoutSeconds)
+	})
+
+	t.Run("auth and tls args are appended after the check target", func(t *testing.T) {
+		cmd := clusterCheckCommand(6380, []string{"-a", "sekret"}, []string{"--tls", "--insecure"})
+		require.Equal(t, []string{
+			"redis-cli", "-t", "5", "--cluster", "check", "127.0.0.1:6380",
+			"-a", "sekret", "--tls", "--insecure",
+		}, cmd)
+	})
+}
+
 func TestWrapRedisCLIAuthSanitize(t *testing.T) {
 	t.Run("redis-cli argv is wrapped and forwarded via $@", func(t *testing.T) {
 		in := []string{"redis-cli", "--cluster", "check", "127.0.0.1:6379"}

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -500,6 +500,16 @@ func TestExecuteSingleLeaderAddSlots(t *testing.T) {
 			var objects []runtime.Object
 			if tt.redisCluster.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
 				objects = mock_utils.CreateFakeObjectWithSecret("redis-password-secret", "default", "password")
+				// The leader pod must exist so the operator can check whether
+				// REDISCLI_AUTH is already set before deciding to pass -a on the
+				// command line. This pod has no REDISCLI_AUTH, so the -a fallback
+				// applies and the password flag is still emitted.
+				objects = append(objects, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster-leader-0", Namespace: "default"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "redis-cluster-leader"}},
+					},
+				})
 			}
 			client := k8sClientFake.NewSimpleClientset(objects...)
 

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -466,7 +466,6 @@ func createPVCTemplate(volumeName string, stsMeta metav1.ObjectMeta, storageSpec
 func generateContainerDef(name string, containerParams containerParameters, clusterMode, nodeConfVolume, enableMetrics bool, externalConfig, clusterVersion *string, mountpath []corev1.VolumeMount, sidecars []commonapi.Sidecar) []corev1.Container {
 	sentinelCntr := containerParams.Role == "sentinel"
 	enableTLS := containerParams.TLSConfig != nil
-	enableAuth := containerParams.EnabledPassword != nil && *containerParams.EnabledPassword
 	containerDefinition := []corev1.Container{
 		{
 			Name:            name,
@@ -487,8 +486,8 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 				containerParams.Resources,
 				containerParams.MaxMemoryPercentOfLimit,
 			),
-			ReadinessProbe: getProbeInfo(containerParams.ReadinessProbe, sentinelCntr, enableTLS, enableAuth),
-			LivenessProbe:  getProbeInfo(containerParams.LivenessProbe, sentinelCntr, enableTLS, enableAuth),
+			ReadinessProbe: getProbeInfo(containerParams.ReadinessProbe, sentinelCntr, enableTLS),
+			LivenessProbe:  getProbeInfo(containerParams.LivenessProbe, sentinelCntr, enableTLS),
 			VolumeMounts:   getVolumeMount(name, containerParams.PersistenceEnabled, clusterMode, nodeConfVolume, externalConfig, mountpath, containerParams.TLSConfig, containerParams.ACLConfig),
 		},
 	}
@@ -948,7 +947,7 @@ func getVolumeMount(name string, persistenceEnabled *bool, clusterMode bool, nod
 // getProbeInfo generate probe for Redis StatefulSet
 // The `ping` command will exit successfully even if the node is loading,
 // so we need to verify that the Redis `ping` command returns "PONG".
-func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS, enableAuth bool) *corev1.Probe {
+func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS bool) *corev1.Probe {
 	if probe == nil {
 		probe = &corev1.Probe{}
 	}

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -515,7 +515,6 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 
 	preStopCfg := PreStopConfig{
 		Role:               containerParams.Role,
-		EnableAuth:         enableAuth,
 		EnableTLS:          enableTLS,
 		SentinelService:    containerParams.SentinelService,
 		SentinelMasterName: containerParams.SentinelMasterName,
@@ -581,9 +580,8 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 
 // PreStopConfig holds the inputs needed to render a container preStop hook.
 type PreStopConfig struct {
-	Role       string
-	EnableAuth bool
-	EnableTLS  bool
+	Role      string
+	EnableTLS bool
 	// SentinelService, SentinelMasterName and SentinelPort describe the
 	// Sentinel that manages failover for the "replication" role. They must be
 	// sourced from the actual (embedded) Sentinel config rather than derived in
@@ -603,12 +601,15 @@ type PreStopConfig struct {
 // "cluster" triggers a CLUSTER FAILOVER to the best slave; "replication"
 // triggers a Sentinel failover, but only when a Sentinel service is configured.
 // All other roles (and Sentinel-less replication) return an empty string.
+//
+// Authentication is taken from the REDISCLI_AUTH environment variable that the
+// operator sets on the pod, so the password is never passed on the command line.
 func GeneratePreStopCommand(cfg PreStopConfig) string {
-	authArgs, tlsArgs := GenerateAuthAndTLSArgs(cfg.EnableAuth, cfg.EnableTLS)
+	tlsArgs := GenerateTLSArgs(cfg.EnableTLS)
 
 	switch cfg.Role {
 	case "cluster":
-		return generateClusterPreStop(authArgs, tlsArgs)
+		return generateClusterPreStop(tlsArgs)
 	case "replication":
 		// Without a Sentinel managing failover there is nothing to fail over
 		// to; installing the hook would make every master termination block on
@@ -616,7 +617,7 @@ func GeneratePreStopCommand(cfg PreStopConfig) string {
 		if cfg.SentinelService == "" {
 			return ""
 		}
-		return generateReplicationPreStop(authArgs, tlsArgs, cfg)
+		return generateReplicationPreStop(tlsArgs, cfg)
 	default:
 		return ""
 	}
@@ -638,28 +639,25 @@ func replicationPreStopWaitSeconds(gracePeriodSeconds *int64) int {
 	return int(max(grace-headroomSeconds, 1))
 }
 
-// GenerateAuthAndTLSArgs constructs authentication and TLS arguments for redis-cli.
-func GenerateAuthAndTLSArgs(enableAuth, enableTLS bool) (string, string) {
-	authArgs := ""
+// GenerateTLSArgs constructs TLS arguments for redis-cli. Authentication is
+// supplied via the REDISCLI_AUTH environment variable, never on the command line.
+func GenerateTLSArgs(enableTLS bool) string {
 	tlsArgs := ""
 
-	if enableAuth {
-		authArgs = " -a \"${REDIS_PASSWORD}\""
-	}
 	if enableTLS {
 		tlsArgs = " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"
 	}
-	return authArgs, tlsArgs
+	return tlsArgs
 }
 
 // generateClusterPreStop generates the preStop script for Redis cluster mode.
 // It identifies the master node and triggers a failover to the best available slave before shutdown.
-func generateClusterPreStop(authArgs, tlsArgs string) string {
+func generateClusterPreStop(tlsArgs string) string {
 	return fmt.Sprintf(`#!/bin/sh
-ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '/role:master/ {print "master"}')
+ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '/role:master/ {print "master"}')
 
 if [ "$ROLE" = "master" ]; then
-    BEST_SLAVE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '
+    BEST_SLAVE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '
         BEGIN { maxOffset = -1; bestSlave = "" }
         /slave[0-9]+:ip/ {
             split($2, a, ",");
@@ -676,9 +674,9 @@ if [ "$ROLE" = "master" ]; then
     ')
 
     if [ -n "$BEST_SLAVE" ]; then
-        redis-cli -h "$BEST_SLAVE" -p ${REDIS_PORT} %s %s cluster failover
+        redis-cli -h "$BEST_SLAVE" -p ${REDIS_PORT} %s cluster failover
     fi
-fi`, authArgs, tlsArgs, authArgs, tlsArgs, authArgs, tlsArgs)
+fi`, tlsArgs, tlsArgs, tlsArgs)
 }
 
 // generateReplicationPreStop generates the preStop script for Redis replication mode.
@@ -689,26 +687,26 @@ fi`, authArgs, tlsArgs, authArgs, tlsArgs, authArgs, tlsArgs)
 // (embedded) Sentinel configuration rather than derived in shell, so they stay
 // correct regardless of the resource name or topology. The demotion wait is
 // bounded by cfg.WaitSeconds so the hook returns before the grace period expires.
-func generateReplicationPreStop(authArgs, tlsArgs string, cfg PreStopConfig) string {
+func generateReplicationPreStop(tlsArgs string, cfg PreStopConfig) string {
 	sentinelPort := cfg.SentinelPort
 	if sentinelPort == 0 {
 		sentinelPort = 26379
 	}
 	waitSeconds := max(cfg.WaitSeconds, 1)
 	return fmt.Sprintf(`#!/bin/sh
-ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '/role:master/ {print "master"}')
+ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '/role:master/ {print "master"}')
 
 if [ "$ROLE" = "master" ]; then
     redis-cli -h "%s" -p %d SENTINEL FAILOVER %s
 
     for i in $(seq 1 %d); do
-        NEW_ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '/role:slave/ {print "slave"}')
+        NEW_ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '/role:slave/ {print "slave"}')
         if [ "$NEW_ROLE" = "slave" ]; then
             break
         fi
         sleep 1
     done
-fi`, authArgs, tlsArgs, cfg.SentinelService, sentinelPort, cfg.SentinelMasterName, waitSeconds, authArgs, tlsArgs)
+fi`, tlsArgs, cfg.SentinelService, sentinelPort, cfg.SentinelMasterName, waitSeconds, tlsArgs)
 }
 
 func generateInitContainerDef(role, name string, initcontainerParams initContainerParameters, externalConfig *string, mountpath []corev1.VolumeMount, containerParams containerParameters, clusterVersion *string) []corev1.Container {
@@ -964,9 +962,6 @@ func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS, enableAuth bool) *co
 		} else {
 			redisHealthCheck = append(redisHealthCheck, "-p", "${REDIS_PORT}")
 		}
-		if enableAuth {
-			redisHealthCheck = append(redisHealthCheck, "-a", "${REDIS_PASSWORD}")
-		}
 		if enableTLS {
 			redisHealthCheck = append(redisHealthCheck, "--tls", "--cert", "${REDIS_TLS_CERT}", "--key", "${REDIS_TLS_CERT_KEY}", "${REDIS_TLS_CA_CERT:+--cacert}", "${REDIS_TLS_CA_CERT}")
 		}
@@ -1058,6 +1053,16 @@ func getEnvironmentVariables(role string, enabledPassword *bool, secretName *str
 	if enabledPassword != nil && *enabledPassword {
 		envVars = append(envVars, corev1.EnvVar{
 			Name: "REDIS_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: *secretName,
+					},
+					Key: *secretKey,
+				},
+			},
+		}, corev1.EnvVar{
+			Name: "REDISCLI_AUTH",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -577,6 +577,17 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 	return containerDefinition
 }
 
+// redisCLIAuthSanitizer strips CR/LF from REDISCLI_AUTH before redis-cli reads
+// it. Password secrets frequently carry a trailing newline (echo | base64,
+// kubectl create secret --from-file), and every other consumer of the password
+// sees it trimmed: getRedisPassword applies strings.TrimSpace and requirepass
+// is read from a line-based config file. REDISCLI_AUTH is sourced raw from the
+// secretKeyRef, so without this the server holds the trimmed password while
+// redis-cli sends the untrimmed one and every AUTH fails with WRONGPASS.
+// The -n guard keeps the variable unset on password-less deployments, where
+// exporting an empty value would make redis-cli send AUTH with an empty password.
+const redisCLIAuthSanitizer = `if [ -n "${REDISCLI_AUTH:-}" ]; then REDISCLI_AUTH="$(printf %s "$REDISCLI_AUTH" | tr -d '\r\n')"; export REDISCLI_AUTH; fi`
+
 // PreStopConfig holds the inputs needed to render a container preStop hook.
 type PreStopConfig struct {
 	Role      string
@@ -653,6 +664,7 @@ func GenerateTLSArgs(enableTLS bool) string {
 // It identifies the master node and triggers a failover to the best available slave before shutdown.
 func generateClusterPreStop(tlsArgs string) string {
 	return fmt.Sprintf(`#!/bin/sh
+%s
 ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '/role:master/ {print "master"}')
 
 if [ "$ROLE" = "master" ]; then
@@ -675,7 +687,7 @@ if [ "$ROLE" = "master" ]; then
     if [ -n "$BEST_SLAVE" ]; then
         redis-cli -h "$BEST_SLAVE" -p ${REDIS_PORT} %s cluster failover
     fi
-fi`, tlsArgs, tlsArgs, tlsArgs)
+fi`, redisCLIAuthSanitizer, tlsArgs, tlsArgs, tlsArgs)
 }
 
 // generateReplicationPreStop generates the preStop script for Redis replication mode.
@@ -693,6 +705,7 @@ func generateReplicationPreStop(tlsArgs string, cfg PreStopConfig) string {
 	}
 	waitSeconds := max(cfg.WaitSeconds, 1)
 	return fmt.Sprintf(`#!/bin/sh
+%s
 ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s info replication | awk -F: '/role:master/ {print "master"}')
 
 if [ "$ROLE" = "master" ]; then
@@ -705,7 +718,7 @@ if [ "$ROLE" = "master" ]; then
         fi
         sleep 1
     done
-fi`, tlsArgs, cfg.SentinelService, sentinelPort, cfg.SentinelMasterName, waitSeconds, tlsArgs)
+fi`, redisCLIAuthSanitizer, tlsArgs, cfg.SentinelService, sentinelPort, cfg.SentinelMasterName, waitSeconds, tlsArgs)
 }
 
 func generateInitContainerDef(role, name string, initcontainerParams initContainerParameters, externalConfig *string, mountpath []corev1.VolumeMount, containerParams containerParameters, clusterVersion *string) []corev1.Container {
@@ -968,7 +981,7 @@ func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS bool) *corev1.Probe {
 
 		redisHealthCheckSubshell := strings.Join(redisHealthCheck, " ")
 
-		healthCheckScript := "RESP=\"$(" + redisHealthCheckSubshell + ")\"\n" + "[ \"$RESP\" = \"PONG\" ]"
+		healthCheckScript := redisCLIAuthSanitizer + "\n" + "RESP=\"$(" + redisHealthCheckSubshell + ")\"\n" + "[ \"$RESP\" = \"PONG\" ]"
 
 		// `-e` causes the shell to exit immediately if a (nontested) command fails
 		probe.ProbeHandler = corev1.ProbeHandler{

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -23,24 +23,19 @@ import (
 
 func TestGenerateAuthAndTLSArgs(t *testing.T) {
 	tests := []struct {
-		name         string
-		enableAuth   bool
-		enableTLS    bool
-		expectedAuth string
-		expectedTLS  string
+		name        string
+		enableTLS   bool
+		expectedTLS string
 	}{
-		{"NoAuthNoTLS", false, false, "", ""},
-		{"AuthOnly", true, false, " -a \"${REDIS_PASSWORD}\"", ""},
-		{"TLSOnly", false, true, "", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
-		{"AuthAndTLS", true, true, " -a \"${REDIS_PASSWORD}\"", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
+		{"NoAuthNoTLS", false, ""},
+		{"AuthOnly", false, ""},
+		{"TLSOnly", true, " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
+		{"AuthAndTLS", true, " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			authArgs, tlsArgs := GenerateAuthAndTLSArgs(tt.enableAuth, tt.enableTLS)
-			if authArgs != tt.expectedAuth {
-				t.Errorf("expected auth args %q, got %q", tt.expectedAuth, authArgs)
-			}
+			tlsArgs := GenerateTLSArgs(tt.enableTLS)
 			if tlsArgs != tt.expectedTLS {
 				t.Errorf("expected TLS args %q, got %q", tt.expectedTLS, tlsArgs)
 			}
@@ -107,7 +102,6 @@ func TestStorageHasVolumeClaimTemplate(t *testing.T) {
 func TestGeneratePreStopCommand(t *testing.T) {
 	sentinelCfg := PreStopConfig{
 		Role:               "replication",
-		EnableAuth:         true,
 		EnableTLS:          true,
 		SentinelService:    "my-replication-s-hl",
 		SentinelMasterName: "mymaster",
@@ -120,11 +114,11 @@ func TestGeneratePreStopCommand(t *testing.T) {
 		cfg         PreStopConfig
 		expectEmpty bool
 	}{
-		{"ClusterRole", PreStopConfig{Role: "cluster", EnableAuth: true, EnableTLS: true}, false},
+		{"ClusterRole", PreStopConfig{Role: "cluster", EnableTLS: true}, false},
 		{"ReplicationWithSentinel", sentinelCfg, false},
 		// Embedded Sentinel disabled => no service => no hook, so master
 		// terminations of non-Sentinel replication never block on a missing svc.
-		{"ReplicationWithoutSentinel", PreStopConfig{Role: "replication", EnableAuth: true, EnableTLS: true}, true},
+		{"ReplicationWithoutSentinel", PreStopConfig{Role: "replication", EnableTLS: true}, true},
 		{"SentinelRole", PreStopConfig{Role: "sentinel"}, true},
 		{"StandaloneRole", PreStopConfig{Role: "standalone"}, true},
 		{"UnknownRole", PreStopConfig{Role: "unknown"}, true},
@@ -172,7 +166,6 @@ func TestGenerateContainerDefAddsMaxMemoryEnv(t *testing.T) {
 func TestGenerateReplicationPreStopContent(t *testing.T) {
 	cfg := PreStopConfig{
 		Role:               "replication",
-		EnableAuth:         true,
 		EnableTLS:          false,
 		SentinelService:    "my-replication-s-hl",
 		SentinelMasterName: "customMaster",
@@ -1678,6 +1671,14 @@ func TestGetEnvironmentVariables(t *testing.T) {
 						Key: "test-key",
 					},
 				}},
+				{Name: "REDISCLI_AUTH", ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+						Key: "test-key",
+					},
+				}},
 				{Name: "SERVER_MODE", Value: "sentinel"},
 				{Name: "SETUP_MODE", Value: "sentinel"},
 				{Name: "TEST_ENV", Value: "test-value"},
@@ -1746,6 +1747,14 @@ func TestGetEnvironmentVariables(t *testing.T) {
 						Key: "test-key",
 					},
 				}},
+				{Name: "REDISCLI_AUTH", ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+						Key: "test-key",
+					},
+				}},
 				{Name: "SERVER_MODE", Value: "cluster"},
 				{Name: "SETUP_MODE", Value: "cluster"},
 				{Name: "TEST_ENV", Value: "test-value"},
@@ -1771,6 +1780,14 @@ func TestGetEnvironmentVariables(t *testing.T) {
 				{Name: "PERSISTENCE_ENABLED", Value: "true"},
 				{Name: "REDIS_ADDR", Value: "redis://localhost:6379"},
 				{Name: "REDIS_PASSWORD", ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+						Key: "test-key",
+					},
+				}},
+				{Name: "REDISCLI_AUTH", ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"strconv"
+	"strings"
 	"testing"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
@@ -129,6 +130,12 @@ func TestGeneratePreStopCommand(t *testing.T) {
 			result := GeneratePreStopCommand(tt.cfg)
 			if (result == "") != tt.expectEmpty {
 				t.Errorf("expected empty: %v, got: %q", tt.expectEmpty, result)
+			}
+			// Every generated hook must sanitize REDISCLI_AUTH before the
+			// first redis-cli call: secrets commonly carry a trailing newline
+			// that the server-side password never has (see redisCLIAuthSanitizer).
+			if result != "" && !strings.Contains(result, redisCLIAuthSanitizer) {
+				t.Errorf("preStop script missing REDISCLI_AUTH sanitizer:\n%s", result)
 			}
 		})
 	}
@@ -976,7 +983,7 @@ func TestGenerateContainerDef(t *testing.T) {
 	probe := corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"sh", "-ec", "RESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
+				Command: []string{"sh", "-ec", redisCLIAuthSanitizer + "\nRESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
 			},
 		},
 	}
@@ -1890,14 +1897,14 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 	probe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"sh", "-ec", "RESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
+				Command: []string{"sh", "-ec", redisCLIAuthSanitizer + "\nRESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
 			},
 		},
 	}
 	probeWithTLS := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"sh", "-ec", "RESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} --tls --cert ${REDIS_TLS_CERT} --key ${REDIS_TLS_CERT_KEY} ${REDIS_TLS_CA_CERT:+--cacert} ${REDIS_TLS_CA_CERT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
+				Command: []string{"sh", "-ec", redisCLIAuthSanitizer + "\nRESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} --tls --cert ${REDIS_TLS_CERT} --key ${REDIS_TLS_CERT_KEY} ${REDIS_TLS_CA_CERT:+--cacert} ${REDIS_TLS_CA_CERT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
 			},
 		},
 	}

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
@@ -54,6 +54,44 @@ spec:
         - assert:
             file: secret.yaml
 
+    - name: Assert command-line-password-free authentication
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              #!/bin/bash
+              set -e
+
+              # The AvoidCommandLinePassword work makes the operator inject
+              # REDISCLI_AUTH into the redis containers and stop passing
+              # -a <password> on redis-cli command lines. Verify both halves
+              # against a password-protected (and TLS-enabled) cluster.
+
+              # 1. REDISCLI_AUTH must be present on the leader and follower pods.
+              #    containers[0] is the redis container; the exporter is separate.
+              for role in leader follower; do
+                STS="redis-cluster-v1beta2-${role}"
+                NAMES=$(kubectl get statefulset "${STS}" -n ${NAMESPACE} \
+                  -o jsonpath='{.spec.template.spec.containers[0].env[*].name}')
+                echo "${STS} env names: ${NAMES}"
+                echo "${NAMES}" | tr ' ' '\n' | grep -qx REDISCLI_AUTH \
+                  || { echo "REDISCLI_AUTH missing on ${STS}"; exit 1; }
+              done
+
+              # 2. redis-cli must authenticate via REDISCLI_AUTH alone: a PING
+              #    with no -a <password> must still succeed. It would return a
+              #    NOAUTH error if the env var were not being honoured. TLS flags
+              #    are transport-only and do not provide authentication.
+              PONG=$(kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-leader-0 \
+                -c redis-cluster-v1beta2-leader -- \
+                redis-cli --tls --cacert /tls/ca.crt ping)
+              echo "bare PING -> ${PONG}"
+              [ "${PONG}" = "PONG" ] || { echo "expected PONG without -a"; exit 1; }
+
+              echo "command-line-password-free authentication verified"
+            check:
+              (contains($stdout, 'command-line-password-free authentication verified')): true
+
     - name: Assert config
       try:
         - script:


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR configures Kubernetes pods with environment variables that `redis-cli` uses for authentication, and removes command-line authentication from everywhere that `redis-cli` is executed by the operator.  This removal of command-line auth is controlled by a feature flag.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1513

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
