### PR TITLE
fix: Chart should cast redisCluster.maxMemoryPercentOfLimit to int

### DIFF
--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -30,7 +30,7 @@ spec:
     {{- end }}
   
   {{- if .Values.redisCluster.maxMemoryPercentOfLimit }}
-  {{- if gt .Values.redisCluster.maxMemoryPercentOfLimit 0 }}
+  {{- if gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0 }}
   redisConfig:
     maxMemoryPercentOfLimit: {{ .Values.redisCluster.maxMemoryPercentOfLimit }}
   {{- end }}


### PR DESCRIPTION
**Description**

Some versions of helm will interpret inline numbers as float64. This can cause a type error when the float64-typed value for redisCluster.maxMemoryPercentOfLimit is compared against this inline integer 0 value.

The recommended fix is just to cast the input to an int when doing the comparison.


<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1584


* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**
