### PR TITLE
feat(chart): add support for customizable annotations for redis, redis-cluster, sentinel, replication

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -51,6 +51,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.key | string | `"tls.key"` |  |
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
+| annotations | object | `{}` |  |
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
 | externalConfig.enabled | bool | `false` |  |
@@ -65,7 +66,6 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
-| podAnnotations | object | `{}` | Pod annotations to be applied to all Redis pods |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | priorityClassName | string | `""` |  |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -13,6 +13,13 @@ app.kubernetes.io/component: middleware
 {{- end }}
 {{- end -}}
 
+{{/* Define common annotations */}}
+{{- define "common.annotations" -}}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations }}
+{{- end }}
+{{- end -}}
+
 {{/* Helper for Redis Cluster (leader & follower) */}}
 {{- define "redis.role" -}}
 {{- if .affinity }}

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ .Values.redisCluster.name | default .Release.Name }}
   labels: {{- include "common.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.podAnnotations }}
-    {{ toYaml .Values.podAnnotations | nindent 4 }}
-    {{- end }}
+    {{- include "common.annotations" . | nindent 4 }}
     {{ if .Values.redisCluster.recreateStatefulSetOnUpdateInvalid }}
     redis.opstreelabs.in/recreate-statefulset: "true"
     {{ end }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -134,6 +134,10 @@ labels: {}
 #   foo: bar
 #   test: echo
 
+annotations: {}
+#   annotation-key: "annotation-value"
+#   prometheus.io/scrape: "true"
+
 
 externalConfig:
   enabled: false
@@ -233,12 +237,6 @@ storageSpec:
 podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
-
-# -- Pod annotations to be applied to all Redis pods
-podAnnotations: {}
-  # annotation-key: "annotation-value"
-  # prometheus.io/scrape: "true"
-  # prometheus.io/port: "6379"
 
 # serviceAccountName: redis-sa
 

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -50,6 +50,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
 | externalConfig.enabled | bool | `false` |  |
@@ -64,7 +65,6 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
-| podAnnotations | object | `{}` | Pod annotations to be applied to all Redis pods |
 | nodeSelector | object | `{}` |  |
 | pdb.enabled | bool | `false` |  |
 | pdb.maxUnavailable | string | `nil` |  |

--- a/charts/redis-replication/templates/_helpers.tpl
+++ b/charts/redis-replication/templates/_helpers.tpl
@@ -13,6 +13,13 @@ app.kubernetes.io/component: middleware
 {{- end }}
 {{- end -}}
 
+{{/* Define common annotations */}}
+{{- define "common.annotations" -}}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations }}
+{{- end }}
+{{- end -}}
+
 {{/* Generate init container properties */}}
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ .Values.redisReplication.name | default .Release.Name }}
   labels: {{- include "common.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.podAnnotations }}
-    {{ toYaml .Values.podAnnotations | nindent 4 }}
-    {{- end }}
+    {{- include "common.annotations" . | nindent 4 }}
     {{ if .Values.redisReplication.recreateStatefulSetOnUpdateInvalid }}
     redis.opstreelabs.in/recreate-statefulset: "true"
     {{ end }}

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -51,6 +51,10 @@ labels: {}
 #   foo: bar
 #   test: echo
 
+annotations: {}
+#   annotation-key: "annotation-value"
+#   prometheus.io/scrape: "true"
+
 externalConfig:
   enabled: false
   data: |
@@ -175,12 +179,6 @@ topologySpreadConstraints: []
   #       app: redis-replication
 
 serviceAccountName: ""
-
-# -- Pod annotations to be applied to all Redis pods
-podAnnotations: {}
-  # annotation-key: "annotation-value"
-  # prometheus.io/scrape: "true"
-  # prometheus.io/port: "6379"
 
 TLS:
   ca: ca.crt

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -49,6 +49,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.key | string | `"tls.key"` |  |
 | TLS.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
 | externalConfig.enabled | bool | `false` |  |
@@ -63,7 +64,6 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
-| podAnnotations | object | `{}` | Pod annotations to be applied to all sentinel pods |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.initialDelaySeconds | int | `1` |  |
 | livenessProbe.periodSeconds | int | `10` |  |

--- a/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/redis-sentinel/templates/_helpers.tpl
@@ -13,6 +13,13 @@ app.kubernetes.io/component: middleware
 {{- end }}
 {{- end -}}
 
+{{/* Define common annotations */}}
+{{- define "common.annotations" -}}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations }}
+{{- end }}
+{{- end -}}
+
 {{/* Generate init container properties */}}
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ .Values.redisSentinel.name | default .Release.Name }}
   labels: {{- include "common.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.podAnnotations }}
-    {{ toYaml .Values.podAnnotations | nindent 4 }}
-    {{- end }}
+    {{- include "common.annotations" . | nindent 4 }}
     {{ if .Values.redisSentinel.recreateStatefulSetOnUpdateInvalid }}
     redis.opstreelabs.in/recreate-statefulset: "true"
     {{ end }}

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -35,6 +35,10 @@ labels: {}
 #   foo: bar
 #   test: echo
 
+annotations: {}
+#   annotation-key: "annotation-value"
+#   prometheus.io/scrape: "true"
+
 redisSentinelConfig:
   redisReplicationName: "redis-replication"
   redisReplicationPassword:
@@ -163,12 +167,6 @@ topologySpreadConstraints: []
   #       app: redis-sentinel
 
 serviceAccountName: ""
-
-# -- Pod annotations to be applied to all sentinel pods
-podAnnotations: {}
-  # annotation-key: "annotation-value"
-  # prometheus.io/scrape: "true"
-  # prometheus.io/port: "6379"
 
 TLS:
   ca: ca.crt

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -49,6 +49,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
 | externalConfig.enabled | bool | `false` |  |
@@ -63,7 +64,6 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
-| podAnnotations | object | `{}` | Pod annotations to be applied to all Redis pods |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -13,6 +13,13 @@ app.kubernetes.io/component: middleware
 {{- end }}
 {{- end -}}
 
+{{/* Define common annotations */}}
+{{- define "common.annotations" -}}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations }}
+{{- end }}
+{{- end -}}
+
 {{/* Generate init container properties */}}
 {{- define "initContainer.properties" -}}
 {{- with .Values.initContainer }}

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -5,9 +5,7 @@ metadata:
   name:  {{ .Values.redisStandalone.name | default .Release.Name }}
   labels: {{- include "common.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.podAnnotations }}
-    {{ toYaml .Values.podAnnotations | nindent 4 }}
-    {{- end }}
+    {{- include "common.annotations" . | nindent 4 }}
     {{ if .Values.redisStandalone.recreateStatefulSetOnUpdateInvalid }}
     redis.opstreelabs.in/recreate-statefulset: "true"
     {{ end }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -35,6 +35,10 @@ labels: {}
 #   foo: bar
 #   test: echo
 
+annotations: {}
+#   annotation-key: "annotation-value"
+#   prometheus.io/scrape: "true"
+
 externalConfig:
   enabled: false
   data: |
@@ -158,12 +162,6 @@ topologySpreadConstraints: []
   #       app: redis
 
 serviceAccountName: ""
-
-# -- Pod annotations to be applied to all Redis pods
-podAnnotations: {}
-  # annotation-key: "annotation-value"
-  # prometheus.io/scrape: "true"
-  # prometheus.io/port: "6379"
 
 TLS:
   ca: ca.crt


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**


- Introduced new Helm chart template parameters to allow custom annotations
  to be added to Redis and Sentinel pods.
- This enhancement enables more flexible deployment configurations and
  can help with integrations requiring specific pod-level metadata.


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1588

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
