### PR TITLE
fix: Correct sidecars format from object to array

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -119,14 +119,7 @@ helm delete <my-release> --namespace <namespace>
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `""` | Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the redis-cluster |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| sidecars.env | object | `{}` |  |
-| sidecars.image | string | `""` |  |
-| sidecars.imagePullPolicy | string | `"IfNotPresent"` |  |
-| sidecars.name | string | `""` |  |
-| sidecars.resources.limits.cpu | string | `"100m"` |  |
-| sidecars.resources.limits.memory | string | `"128Mi"` |  |
-| sidecars.resources.requests.cpu | string | `"50m"` |  |
-| sidecars.resources.requests.memory | string | `"64Mi"` |  |
+| sidecars | list | `[]` |  |
 | storageSpec.nodeConfVolume | bool | `true` |  |
 | storageSpec.nodeConfVolumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storageSpec.nodeConfVolumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"` |  |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -47,24 +47,6 @@ readinessProbe:
 {{- end }}
 {{- end -}}
 
-{{/* Generate sidecar properties */}}
-{{- define "sidecar.properties" -}}
-{{- with .Values.sidecars }}
-name: {{ .name }}
-image: {{ .image }}
-{{- if .imagePullPolicy }}
-imagePullPolicy: {{ .imagePullPolicy }}
-{{- end }}
-{{- if .resources }}
-resources:
-  {{ toYaml .resources | nindent 2 }}
-{{- end }}
-{{- if .env }}
-env:
-{{ toYaml .env | nindent 2 }}
-{{- end }}
-{{- end }}
-{{- end -}}
 
 {{/* Generate init container properties */}}
 {{- define "initContainer.properties" -}}

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -99,8 +99,8 @@ spec:
     persistentVolumeClaim: {{ .Values.acl.persistentVolumeClaim | quote }}
     {{- end }}
   {{- end }}
-  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
-  sidecars: {{ include "sidecar.properties" . | nindent 4 }}
+  {{- if .Values.sidecars }}
+  sidecars: {{ toYaml .Values.sidecars | nindent 4 }}
   {{- end }}
   {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
   initContainer: {{ include "initContainer.properties" . | nindent 4 }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -157,20 +157,24 @@ redisExporter:
     #   value: "value1"
   securityContext: {}
 
-sidecars:
-  name: ""
-  image: ""
-  imagePullPolicy: "IfNotPresent"
-  resources:
-    limits:
-      cpu: "100m"
-      memory: "128Mi"
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-  env: {}
-    # - name: MY_ENV_VAR
-    #   value: "my-env-var-value"
+sidecars: []
+  # - name: "sidecar-example"
+  #   image: "busybox:latest"
+  #   imagePullPolicy: "IfNotPresent"
+  #   resources:
+  #     limits:
+  #       cpu: "100m"
+  #       memory: "128Mi"
+  #     requests:
+  #       cpu: "50m"
+  #       memory: "64Mi"
+  #   env: []
+  #   # - name: MY_ENV_VAR
+  #   #   value: "my-env-var-value"
+  #   command: []
+  #   # - "/bin/sh"
+  #   # - "-c"
+  #   # - "sleep 3600"
 
 initContainer:
   enabled: false

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -99,14 +99,7 @@ helm delete <my-release> --namespace <namespace>
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `""` | Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the redis-replication |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| sidecars.env | list | `[]` |  |
-| sidecars.image | string | `""` |  |
-| sidecars.imagePullPolicy | string | `"IfNotPresent"` |  |
-| sidecars.name | string | `""` |  |
-| sidecars.resources.limits.cpu | string | `"100m"` |  |
-| sidecars.resources.limits.memory | string | `"128Mi"` |  |
-| sidecars.resources.requests.cpu | string | `"50m"` |  |
-| sidecars.resources.requests.memory | string | `"64Mi"` |  |
+| sidecars | list | `[]` |  |
 | storageSpec.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/redis-replication/templates/_helpers.tpl
+++ b/charts/redis-replication/templates/_helpers.tpl
@@ -41,22 +41,3 @@ args:
 {{- end }}
 {{- end }}
 {{- end -}}
-
-{{/* Generate sidecar properties */}}
-{{- define "sidecar.properties" -}}
-{{- with .Values.sidecars }}
-name: {{ .name }}
-image: {{ .image }}
-{{- if .imagePullPolicy }}
-imagePullPolicy: {{ .imagePullPolicy }}
-{{- end }}
-{{- if .resources }}
-resources:
-  {{ toYaml .resources | nindent 2 }}
-{{- end }}
-{{- if .env }}
-env:
-{{ toYaml .env | nindent 2 }}
-{{- end }}
-{{- end }}
-{{- end -}}

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -96,8 +96,8 @@ spec:
   {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
   initContainer: {{ include "initContainer.properties" . | nindent 4 }}
   {{- end }}
-  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
-  sidecars: {{ include "sidecar.properties" . | nindent 4 }}
+  {{- if .Values.sidecars }}
+  sidecars: {{ toYaml .Values.sidecars | nindent 4 }}
   {{- end }}
   {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
   serviceAccountName: "{{ .Values.serviceAccountName }}"

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -93,20 +93,24 @@ initContainer:
   command: []
   args: []
 
-sidecars:
-  name: ""
-  image: ""
-  imagePullPolicy: "IfNotPresent"
-  resources:
-    limits:
-      cpu: "100m"
-      memory: "128Mi"
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-  env: []
-    # - name: MY_ENV_VAR
-    #   value: "my-env-var-value"
+sidecars: []
+  # - name: "sidecar-example"
+  #   image: "busybox:latest"
+  #   imagePullPolicy: "IfNotPresent"
+  #   resources:
+  #     limits:
+  #       cpu: "100m"
+  #       memory: "128Mi"
+  #     requests:
+  #       cpu: "50m"
+  #       memory: "64Mi"
+  #   env: []
+  #   # - name: MY_ENV_VAR
+  #   #   value: "my-env-var-value"
+  #   command: []
+  #   # - "/bin/sh"
+  #   # - "-c"
+  #   # - "sleep 3600"
 
 priorityClassName: ""
 

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -118,12 +118,5 @@ helm delete <my-release> --namespace <namespace>
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `""` | Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the redis-sentinel |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| sidecars.env | list | `[]` |  |
-| sidecars.image | string | `""` |  |
-| sidecars.imagePullPolicy | string | `"IfNotPresent"` |  |
-| sidecars.name | string | `""` |  |
-| sidecars.resources.limits.cpu | string | `"100m"` |  |
-| sidecars.resources.limits.memory | string | `"128Mi"` |  |
-| sidecars.resources.requests.cpu | string | `"50m"` |  |
-| sidecars.resources.requests.memory | string | `"64Mi"` |  |
+| sidecars | list | `[]` |  |
 | tolerations | list | `[]` |  |

--- a/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/redis-sentinel/templates/_helpers.tpl
@@ -41,22 +41,3 @@ args:
 {{- end }}
 {{- end }}
 {{- end -}}
-
-{{/* Generate sidecar properties */}}
-{{- define "sidecar.properties" -}}
-{{- with .Values.sidecars }}
-name: {{ .name }}
-image: {{ .image }}
-{{- if .imagePullPolicy }}
-imagePullPolicy: {{ .imagePullPolicy }}
-{{- end }}
-{{- if .resources }}
-resources:
-  {{ toYaml .resources | nindent 2 }}
-{{- end }}
-{{- if .env }}
-env:
-{{ toYaml .env | nindent 2 }}
-{{- end }}
-{{- end }}
-{{- end -}}

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -109,8 +109,8 @@ spec:
   {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
   initContainer: {{ include "initContainer.properties" . | nindent 4 }}
   {{- end }}
-  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
-  sidecars: {{ include "sidecar.properties" . | nindent 4 }}
+  {{- if .Values.sidecars }}
+  sidecars: {{ toYaml .Values.sidecars | nindent 4 }}
   {{- end }}
   {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
   serviceAccountName: "{{ .Values.serviceAccountName }}"

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -104,20 +104,24 @@ initContainer:
   command: []
   args: []
 
-sidecars:
-  name: ""
-  image: ""
-  imagePullPolicy: "IfNotPresent"
-  resources:
-    limits:
-      cpu: "100m"
-      memory: "128Mi"
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-  env: []
-    # - name: MY_ENV_VAR
-    #   value: "my-env-var-value"
+sidecars: []
+  # - name: "sidecar-example"
+  #   image: "busybox:latest"
+  #   imagePullPolicy: "IfNotPresent"
+  #   resources:
+  #     limits:
+  #       cpu: "100m"
+  #       memory: "128Mi"
+  #     requests:
+  #       cpu: "50m"
+  #       memory: "64Mi"
+  #   env: []
+  #   # - name: MY_ENV_VAR
+  #   #   value: "my-env-var-value"
+  #   command: []
+  #   # - "/bin/sh"
+  #   # - "-c"
+  #   # - "sleep 3600"
 
 priorityClassName: ""
 

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -94,14 +94,7 @@ helm delete <my-release> --namespace <namespace>
 | serviceMonitor.interval | string | `"30s"` |  |
 | serviceMonitor.namespace | string | `""` | Namespace where servicemonitor resource will be created, if empty it will be created in the same namespace as the redis |
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| sidecars.env | list | `[]` |  |
-| sidecars.image | string | `""` |  |
-| sidecars.imagePullPolicy | string | `"IfNotPresent"` |  |
-| sidecars.name | string | `""` |  |
-| sidecars.resources.limits.cpu | string | `"100m"` |  |
-| sidecars.resources.limits.memory | string | `"128Mi"` |  |
-| sidecars.resources.requests.cpu | string | `"50m"` |  |
-| sidecars.resources.requests.memory | string | `"64Mi"` |  |
+| sidecars | list | `[]` |  |
 | storageSpec.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -41,22 +41,3 @@ args:
 {{- end }}
 {{- end }}
 {{- end -}}
-
-{{/* Generate sidecar properties */}}
-{{- define "sidecar.properties" -}}
-{{- with .Values.sidecars }}
-name: {{ .name }}
-image: {{ .image }}
-{{- if .imagePullPolicy }}
-imagePullPolicy: {{ .imagePullPolicy }}
-{{- end }}
-{{- if .resources }}
-resources:
-  {{ toYaml .resources | nindent 2 }}
-{{- end }}
-{{- if .env }}
-env:
-{{ toYaml .env | nindent 2 }}
-{{- end }}
-{{- end }}
-{{- end -}}

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -95,8 +95,8 @@ spec:
   {{- if and .Values.initContainer .Values.initContainer.enabled (ne .Values.initContainer.image "") }}
   initContainer: {{ include "initContainer.properties" . | nindent 4 }}
   {{- end }}
-  {{- if and .Values.sidecars (ne .Values.sidecars.name "") (ne .Values.sidecars.image "") }}
-  sidecars: {{ include "sidecar.properties" . | nindent 4 }}
+  {{- if .Values.sidecars }}
+  sidecars: {{ toYaml .Values.sidecars | nindent 4 }}
   {{- end }}
   {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
   serviceAccountName: "{{ .Values.serviceAccountName }}"

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -89,20 +89,24 @@ initContainer:
   command: []
   args: []
 
-sidecars:
-  name: ""
-  image: ""
-  imagePullPolicy: "IfNotPresent"
-  resources:
-    limits:
-      cpu: "100m"
-      memory: "128Mi"
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-  env: []
-    # - name: MY_ENV_VAR
-    #   value: "my-env-var-value"
+sidecars: []
+  # - name: "sidecar-example"
+  #   image: "busybox:latest"
+  #   imagePullPolicy: "IfNotPresent"
+  #   resources:
+  #     limits:
+  #       cpu: "100m"
+  #       memory: "128Mi"
+  #     requests:
+  #       cpu: "50m"
+  #       memory: "64Mi"
+  #   env: []
+  #   # - name: MY_ENV_VAR
+  #   #   value: "my-env-var-value"
+  #   command: []
+  #   # - "/bin/sh"
+  #   # - "-c"
+  #   # - "sleep 3600"
 
 priorityClassName: ""
 


### PR DESCRIPTION
  The sidecars field in Helm charts was incorrectly configured as object
  format, but CRD expects array format. This caused Kubernetes API to
  reject generated CRs, making the feature unusable.

  Changes:
  - Convert sidecars from object to array in all chart values.yaml files
  - Simplify templates to use toYaml directly
  - Remove unused sidecar.properties helper

  This is a bug fix as the object format never worked with the CRD.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1600 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
