### PR TITLE
fix: Centralize skip-reconcile metrics management and fix RedisCluster metric bug

### DIFF
--- a/internal/controller/common/skip_reconcile.go
+++ b/internal/controller/common/skip_reconcile.go
@@ -7,6 +7,7 @@ import (
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/monitoring"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -18,7 +19,7 @@ const (
 	RedisSentinelSkipReconcileAnnotation    = "redissentinel.opstreelabs.in/skip-reconcile"
 )
 
-func IsSkipReconcile(ctx context.Context, obj metav1.Object) (skip bool) {
+func ShouldSkipReconcile(ctx context.Context, obj metav1.Object) (skip bool) {
 	defer func() {
 		if skip {
 			log.FromContext(ctx).Info("found skip reconcile annotation", "namespace", obj.GetNamespace(), "name", obj.GetName())
@@ -30,7 +31,9 @@ func IsSkipReconcile(ctx context.Context, obj metav1.Object) (skip bool) {
 	}
 	switch obj.(type) {
 	case *rcvb2.RedisCluster:
+		monitoring.RedisClusterSkipReconcile.WithLabelValues(obj.GetNamespace(), obj.GetName()).Set(0)
 		if value, found := annotations[RedisClusterSkipReconcileAnnotation]; found && value == "true" {
+			monitoring.RedisClusterSkipReconcile.WithLabelValues(obj.GetNamespace(), obj.GetName()).Set(1)
 			return true
 		}
 	case *rvb2.Redis:
@@ -38,7 +41,9 @@ func IsSkipReconcile(ctx context.Context, obj metav1.Object) (skip bool) {
 			return true
 		}
 	case *rrvb2.RedisReplication:
+		monitoring.RedisReplicationSkipReconcile.WithLabelValues(obj.GetNamespace(), obj.GetName()).Set(0)
 		if value, found := annotations[RedisReplicationSkipReconcileAnnotation]; found && value == "true" {
+			monitoring.RedisReplicationSkipReconcile.WithLabelValues(obj.GetNamespace(), obj.GetName()).Set(1)
 			return true
 		}
 	case *rsvb2.RedisSentinel:

--- a/internal/controller/redis/redis_controller.go
+++ b/internal/controller/redis/redis_controller.go
@@ -53,7 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		return intctrlutil.Reconciled()
 	}
-	if common.IsSkipReconcile(ctx, instance) {
+	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
 	if err = k8sutils.AddFinalizer(ctx, instance, RedisFinalizer, r.Client); err != nil {

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -69,9 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		return intctrlutil.Reconciled()
 	}
-	monitoring.RedisReplicationSkipReconcile.WithLabelValues(instance.Namespace, instance.Name).Set(0)
-	if common.IsSkipReconcile(ctx, instance) {
-		monitoring.RedisClusterSkipReconcile.WithLabelValues(instance.Namespace, instance.Name).Set(1)
+	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
 	instance.SetDefault()

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -44,9 +44,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return intctrlutil.Reconciled()
 	}
 
-	monitoring.RedisReplicationSkipReconcile.WithLabelValues(instance.Namespace, instance.Name).Set(0)
-	if common.IsSkipReconcile(ctx, instance) {
-		monitoring.RedisReplicationSkipReconcile.WithLabelValues(instance.Namespace, instance.Name).Set(1)
+	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
 

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -48,7 +48,7 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return intctrlutil.Reconciled()
 	}
 
-	if common.IsSkipReconcile(ctx, instance) {
+	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
 


### PR DESCRIPTION
  - Move skip-reconcile metrics logic from controllers to common function
  - Fix incorrect metric usage in RedisCluster controller (was using RedisReplicationSkipReconcile)

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
