### PR TITLE
fix: Propagate manager QPS setting to generated client config

### DIFF
--- a/internal/k8sutils/client.go
+++ b/internal/k8sutils/client.go
@@ -9,11 +9,17 @@ import (
 type K8sConfigProvider = func() (*rest.Config, error)
 
 // GenerateK8sClient create client for kubernetes
-func GenerateK8sClient(configProvider K8sConfigProvider) (kubernetes.Interface, error) {
+func GenerateK8sClient(configProvider K8sConfigProvider, qps float32) (kubernetes.Interface, error) {
 	config, err := configProvider()
 	if err != nil {
 		return nil, err
 	}
+
+	if qps > 0 {
+		config.QPS = qps
+		config.Burst = int(qps * 2)
+	}
+
 	return kubernetes.NewForConfig(config)
 }
 


### PR DESCRIPTION
This PR propagates the manager’s configured Kubernetes client QPS setting into the generated kubernetes.Interface client created via k8sutils.GenerateK8sClient. The client factory now accepts a qps parameter and, when set (>0), applies config.QPS and a matching config.Burst (Burst = int(QPS * 2)) before instantiating the client.

This ensures the manager and the internally created Kubernetes client follow the same rate-limiting configuration. As this wasn’t the case, the generated kubernetes.Interface client fell back to default settings and started making trouble (unexpected throttling / API request behavior).

**Type of change**
Bug fix (non-breaking change which fixes an issue)

**Additional Context**
No functional behavior changes when QPS is not configured (or set to 0); default client-go settings remain in effect.