### PR TITLE
feat: add livenessProbe and readinessProbe configuration

### DIFF
--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.11
-appVersion: "0.16.11"
+version: 0.16.12
+appVersion: "0.16.12"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -83,9 +83,11 @@ helm delete <my-release> --namespace <namespace>
 | redisReplication.image | string | `"quay.io/opstree/redis"` |  |
 | redisReplication.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisReplication.imagePullSecrets | list | `[]` |  |
+| redisReplication.livenessProbe | object | `{}` |  |
 | redisReplication.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.    Default is 0 (disabled). |
 | redisReplication.minReadySeconds | int | `0` |  |
 | redisReplication.name | string | `""` |  |
+| redisReplication.readinessProbe | object | `{}` |  |
 | redisReplication.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
 | redisReplication.redisSecret.secretKey | string | `""` |  |
 | redisReplication.redisSecret.secretName | string | `""` |  |

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -30,6 +30,12 @@ spec:
     {{- if .Values.redisReplication.minReadySeconds }}
     minReadySeconds: {{ .Values.redisReplication.minReadySeconds}}
     {{- end }}
+  {{- if .Values.redisReplication.livenessProbe }}
+  livenessProbe: {{ toYaml .Values.redisReplication.livenessProbe | nindent 4 }}
+  {{- end }}
+  {{- if .Values.redisReplication.readinessProbe }}
+  readinessProbe: {{ toYaml .Values.redisReplication.readinessProbe | nindent 4 }}
+  {{- end }}
 
   redisExporter:
     enabled: {{ .Values.redisExporter.enabled }}

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -27,6 +27,18 @@ redisReplication:
   # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  livenessProbe: {}
+    # timeoutSeconds: 5
+    # periodSeconds: 15
+    # successThreshold: 1
+    # failureThreshold: 5
+    # initialDelaySeconds: 15
+  readinessProbe: {}
+    # timeoutSeconds: 5
+    # periodSeconds: 15
+    # successThreshold: 1
+    # failureThreshold: 5
+    # initialDelaySeconds: 15
 
 # Overwite name for resources
 # name: ""


### PR DESCRIPTION
## Summary

Adds `livenessProbe` and `readinessProbe` configuration options to the redis-replication Helm chart, aligning it with the redis-cluster chart which already has this functionality.

## Motivation

Currently, the redis-replication chart does not expose probe configuration, forcing users to either:
- Use default probe settings (which may not be optimal for all workloads)
- Manually patch the `RedisReplication` CRD after deployment

This is inconsistent with the redis-cluster chart, which already supports probe customization.

## Changes

- ✅ Added `livenessProbe` and `readinessProbe` fields to `values.yaml`
- ✅ Updated `redis-replication.yaml` template to render probe configs
- ✅ Bumped chart version from `0.16.11` to `0.16.12`
- ✅ Regenerated `README.md` with helm-docs

## Example Usage

```yaml
redisReplication:
  livenessProbe:
    timeoutSeconds: 5
    periodSeconds: 15
    failureThreshold: 5
    initialDelaySeconds: 15
  readinessProbe:
    timeoutSeconds: 5
    periodSeconds: 15
    failureThreshold: 5
    initialDelaySeconds: 15
```

## Testing

Tested in production with the following configuration and confirmed:
- ✅ Probes are correctly applied to pods
- ✅ Default behavior unchanged (when probes not specified)
- ✅ Rolling updates work correctly
- ✅ No PVC or data loss during updates

## Related Issue

Closes: https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1577