### PR TITLE
feat: Add namespace-scoped RBAC support for redis-operator

### DIFF
--- a/.github/workflows/call-test-charts.yaml
+++ b/.github/workflows/call-test-charts.yaml
@@ -30,6 +30,10 @@ jobs:
         run: |
           sudo snap install yq
 
+      - name: Assert redis-operator RBAC scope templating
+        run: |
+          ./tests/helm/rbac-scope-test.sh
+
       - name: Install and test Redis Related Helm charts
         run: |
           kubectl cluster-info --context kind-kind

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -111,7 +111,8 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
-| rbac.enabled | bool | `true` |  |
+| rbac.enabled | bool | `true` | Enable RBAC resources creation |
+| rbac.scope | string | `"cluster"` | RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding |
 | redisOperator.automountServiceAccountToken | bool | `true` |  |
 | redisOperator.env | list | `[]` |  |
 | redisOperator.extraArgs | list | `[]` |  |

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -112,7 +112,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
 | rbac.enabled | bool | `true` | Enable RBAC resources creation |
-| rbac.scope | string | `"cluster"` | RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding |
+| rbac.scope | string | `"cluster"` | RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding. "cluster" lets the operator manage Redis resources across all namespaces (default behavior). "namespace" restricts the operator to its own release namespace; set redisOperator.watchNamespace accordingly and ensure the CRDs are installed separately (CRDs are cluster-scoped). |
 | redisOperator.automountServiceAccountToken | bool | `true` |  |
 | redisOperator.env | list | `[]` |  |
 | redisOperator.extraArgs | list | `[]` |  |

--- a/charts/redis-operator/templates/_helpers.tpl
+++ b/charts/redis-operator/templates/_helpers.tpl
@@ -41,3 +41,15 @@ Validate webhook and cert-manager configuration
 {{- fail "certmanager.enabled should not be true when webhook is disabled" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate and normalize the RBAC scope.
+Returns "cluster" (the default when unset) or "namespace".
+*/}}
+{{- define "redis-operator.rbacScope" -}}
+{{- $scope := .Values.rbac.scope | default "cluster" -}}
+{{- if and (ne $scope "cluster") (ne $scope "namespace") -}}
+{{- fail (printf "rbac.scope must be either \"cluster\" or \"namespace\", got %q" $scope) -}}
+{{- end -}}
+{{- $scope -}}
+{{- end -}}

--- a/charts/redis-operator/templates/role-binding.yaml
+++ b/charts/redis-operator/templates/role-binding.yaml
@@ -1,9 +1,16 @@
 {{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 metadata:
   name: {{ .Values.redisOperator.name }}
+{{- if eq .Values.rbac.scope "namespace" }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app.kubernetes.io/name : {{ .Values.redisOperator.name }}
     helm.sh/chart : {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -17,7 +24,11 @@ subjects:
   name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 roleRef:
+{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: {{ .Values.redisOperator.name }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/redis-operator/templates/role-binding.yaml
+++ b/charts/redis-operator/templates/role-binding.yaml
@@ -1,14 +1,15 @@
 {{- if .Values.rbac.enabled }}
+{{- $scope := include "redis-operator.rbacScope" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
+{{- if eq $scope "cluster" }}
 kind: ClusterRoleBinding
 {{- else }}
 kind: RoleBinding
 {{- end }}
 metadata:
   name: {{ .Values.redisOperator.name }}
-{{- if eq .Values.rbac.scope "namespace" }}
+{{- if eq $scope "namespace" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
   labels:
@@ -24,7 +25,7 @@ subjects:
   name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
+{{- if eq $scope "cluster" }}
   kind: ClusterRole
 {{- else }}
   kind: Role

--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -1,9 +1,16 @@
 {{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: {{ .Values.redisOperator.name }}
+{{- if eq .Values.rbac.scope "namespace" }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app.kubernetes.io/name : {{ .Values.redisOperator.name }}
     helm.sh/chart : {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -1,14 +1,15 @@
 {{- if .Values.rbac.enabled }}
+{{- $scope := include "redis-operator.rbacScope" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if or (not .Values.rbac.scope) (eq .Values.rbac.scope "cluster") }}
+{{- if eq $scope "cluster" }}
 kind: ClusterRole
 {{- else }}
 kind: Role
 {{- end }}
 metadata:
   name: {{ .Values.redisOperator.name }}
-{{- if eq .Values.rbac.scope "namespace" }}
+{{- if eq $scope "namespace" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
   labels:
@@ -19,7 +20,9 @@ metadata:
     app.kubernetes.io/version : {{ .Chart.AppVersion }}
     app.kubernetes.io/component: role
     app.kubernetes.io/part-of : {{ .Release.Name }}
+{{- if eq $scope "cluster" }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+{{- end }}
 rules:
 - apiGroups:
   - redis.redis.opstreelabs.in
@@ -40,18 +43,21 @@ rules:
   - patch
   - update
   - watch
+{{- if eq $scope "cluster" }}
+# nonResourceURLs and cluster-scoped resources (CRDs) are only valid on a ClusterRole.
 - nonResourceURLs:
   - '*'
   verbs:
   - get
-- apiGroups: 
+- apiGroups:
   - "apiextensions.k8s.io"
-  resources: 
+  resources:
   - "customresourcedefinitions"
-  verbs: 
+  verbs:
   - "get"
-  - "list" 
+  - "list"
   - "watch"
+{{- end }}
 - apiGroups:
   - redis.redis.opstreelabs.in
   resources:
@@ -88,7 +94,10 @@ rules:
   - configmaps
   - events
   - persistentvolumeclaims
+{{- if eq $scope "cluster" }}
+  # namespaces is a cluster-scoped resource; only grant it on a ClusterRole.
   - namespaces
+{{- end }}
   verbs:
   - create
   - delete

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -65,6 +65,10 @@ replicas: 1
 
 rbac:
   enabled: true
+  # Choose RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding
+  # cluster: Operator can manage Redis resources across all namespaces (default behavior)
+  # namespace: Operator can only manage Redis resources in its own namespace
+  # scope: "cluster"
 serviceAccountName: redis-operator
 
 serviceAccount:

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -64,11 +64,13 @@ resources:
 replicas: 1
 
 rbac:
+  # -- Enable RBAC resources creation
   enabled: true
-  # Choose RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding
-  # cluster: Operator can manage Redis resources across all namespaces (default behavior)
-  # namespace: Operator can only manage Redis resources in its own namespace
-  # scope: "cluster"
+  # -- RBAC scope: "cluster" for ClusterRole/ClusterRoleBinding or "namespace" for Role/RoleBinding.
+  # "cluster" lets the operator manage Redis resources across all namespaces (default behavior).
+  # "namespace" restricts the operator to its own release namespace; set redisOperator.watchNamespace
+  # accordingly and ensure the CRDs are installed separately (CRDs are cluster-scoped).
+  scope: "cluster"
 serviceAccountName: redis-operator
 
 serviceAccount:

--- a/tests/helm/rbac-scope-test.sh
+++ b/tests/helm/rbac-scope-test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Renders the redis-operator Helm chart and asserts that the rbac.scope value
+# produces valid RBAC resources for both the default/cluster scope and the
+# namespace scope. Requires only `helm` (no cluster needed).
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../charts/redis-operator" && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# --- default scope (rbac.scope unset) -> cluster-wide RBAC ---
+default_out="$(helm template ro "$CHART_DIR" --namespace redis-operator \
+  --show-only templates/role.yaml --show-only templates/role-binding.yaml)"
+
+echo "$default_out" | grep -q '^kind: ClusterRole$'        || fail "default scope should render a ClusterRole"
+echo "$default_out" | grep -q '^kind: ClusterRoleBinding$' || fail "default scope should render a ClusterRoleBinding"
+echo "$default_out" | grep -q 'nonResourceURLs'            || fail "default ClusterRole should keep the nonResourceURLs rule"
+echo "$default_out" | grep -q 'aggregate-to-admin'         || fail "default ClusterRole should keep the aggregate-to-admin label"
+echo "$default_out" | grep -q 'customresourcedefinitions'  || fail "default ClusterRole should keep the CRD rule"
+pass "default scope renders ClusterRole/ClusterRoleBinding"
+
+# --- explicit cluster scope behaves like the default ---
+cluster_out="$(helm template ro "$CHART_DIR" --set rbac.scope=cluster \
+  --show-only templates/role.yaml)"
+echo "$cluster_out" | grep -q '^kind: ClusterRole$' || fail "scope=cluster should render a ClusterRole"
+pass "scope=cluster renders ClusterRole"
+
+# --- namespace scope -> namespaced Role/RoleBinding ---
+ns_out="$(helm template ro "$CHART_DIR" --namespace my-redis --set rbac.scope=namespace \
+  --show-only templates/role.yaml --show-only templates/role-binding.yaml)"
+
+echo "$ns_out" | grep -q '^kind: Role$'          || fail "namespace scope should render a Role"
+echo "$ns_out" | grep -q '^kind: RoleBinding$'   || fail "namespace scope should render a RoleBinding"
+echo "$ns_out" | grep -q '^  namespace: my-redis$' || fail "namespaced Role/RoleBinding should set metadata.namespace"
+
+# A namespaced Role is rejected by the API server if it carries any cluster-only construct.
+echo "$ns_out" | grep -q 'nonResourceURLs'           && fail "namespaced Role must not contain nonResourceURLs" || true
+echo "$ns_out" | grep -q 'aggregate-to-admin'        && fail "namespaced Role must not carry the aggregate-to-admin label" || true
+echo "$ns_out" | grep -q 'customresourcedefinitions' && fail "namespaced Role must not grant cluster-scoped CRDs" || true
+echo "$ns_out" | grep -qE '^[[:space:]]*-[[:space:]]*namespaces$' && fail "namespaced Role must not grant the cluster-scoped namespaces resource" || true
+pass "namespace scope renders a clean Role/RoleBinding with no cluster-only rules"
+
+# --- invalid scope is rejected at template time ---
+if helm template ro "$CHART_DIR" --set rbac.scope=invalid >/dev/null 2>&1; then
+  fail "an invalid rbac.scope should make templating fail"
+fi
+pass "invalid scope is rejected"
+
+echo "All RBAC scope assertions passed."


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR introduces a new rbac.scope configuration option in the Helm chart's values.yaml. This option allows users to control the scope of the RBAC resources created for the Redis Operator, supporting both cluster-wide and namespace-specific permissions.
The primary goal is to enable deployments in restricted environments where cluster-level permissions are not available or desired.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1503

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
This change is particularly useful for deployments in multi-tenant clusters or environments with strict security policies that prevent granting cluster-wide permissions. It allows the operator to function with a more limited, namespace-contained set of privileges, adhering to the principle of least privilege.