### PR TITLE
fix!: Fix ACL SAVE when using ACL from PVC

### DIFF
--- a/api/common/v1beta2/common_types.go
+++ b/api/common/v1beta2/common_types.go
@@ -288,7 +288,8 @@ type ACLConfig struct {
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
 	// PersistentVolumeClaim-based ACL configuration
 	// Specify the PVC name to mount ACL file from persistent storage
-	// The operator will automatically mount /etc/redis/user.acl from the PVC
+	// The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+	// This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
 	PersistentVolumeClaim *string `json:"persistentVolumeClaim,omitempty"`
 }
 

--- a/charts/redis-operator/crds/crds.yaml
+++ b/charts/redis-operator/crds/crds.yaml
@@ -117,7 +117,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-
@@ -5544,7 +5545,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-
@@ -13393,7 +13395,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-

--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -118,7 +118,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -146,7 +146,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -124,7 +124,8 @@ spec:
                     description: |-
                       PersistentVolumeClaim-based ACL configuration
                       Specify the PVC name to mount ACL file from persistent storage
-                      The operator will automatically mount /etc/redis/user.acl from the PVC
+                      The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl
+                      This feature requires the GenerateConfigInInitContainer feature gate to be enabled.
                     type: string
                   secret:
                     description: |-

--- a/docs/content/en/docs/CRD Reference/API Reference/_index.md
+++ b/docs/content/en/docs/CRD Reference/API Reference/_index.md
@@ -43,7 +43,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretvolumesource-v1-core)_ | Secret-based ACL configuration.<br />Adapts a Secret into a volume containing ACL rules.<br />The contents of the target Secret's Data field will be presented in a volume<br />as files using the keys in the Data field as the file names.<br />Secret volumes support ownership management and SELinux relabeling. |  |  |
-| `persistentVolumeClaim` _string_ | PersistentVolumeClaim-based ACL configuration<br />Specify the PVC name to mount ACL file from persistent storage<br />The operator will automatically mount /etc/redis/user.acl from the PVC |  |  |
+| `persistentVolumeClaim` _string_ | PersistentVolumeClaim-based ACL configuration<br />Specify the PVC name to mount ACL file from persistent storage<br />The operator mounts the PVC at /data/redis so Redis can read and update /data/redis/user.acl<br />This feature requires the GenerateConfigInInitContainer feature gate to be enabled. |  |  |
 
 
 #### AdditionalVolume

--- a/example/v1beta2/acl-pvc/cluster.yaml
+++ b/example/v1beta2/acl-pvc/cluster.yaml
@@ -10,7 +10,7 @@ spec:
     image: quay.io/opstree/redis:latest
     imagePullPolicy: IfNotPresent
   # ACL configuration from PVC
-  # The operator will mount /etc/redis/user.acl from the PVC
+  # The operator mounts the PVC at /data/redis, so Redis reads /data/redis/user.acl
   # Make sure the PVC contains a file named "user.acl" with Redis ACL rules
   acl:
     persistentVolumeClaim: "redis-acl-pvc"

--- a/example/v1beta2/acl-pvc/replication.yaml
+++ b/example/v1beta2/acl-pvc/replication.yaml
@@ -10,7 +10,7 @@ spec:
     image: quay.io/opstree/redis:latest
     imagePullPolicy: IfNotPresent
   # ACL configuration from PVC
-  # The operator will mount /etc/redis/user.acl from the PVC
+  # The operator mounts the PVC at /data/redis, so Redis reads /data/redis/user.acl
   # Make sure the PVC contains a file named "user.acl" with Redis ACL rules
   acl:
     persistentVolumeClaim: "redis-acl-pvc"

--- a/example/v1beta2/acl-pvc/standalone.yaml
+++ b/example/v1beta2/acl-pvc/standalone.yaml
@@ -9,7 +9,7 @@ spec:
     image: quay.io/opstree/redis:latest
     imagePullPolicy: IfNotPresent
   # ACL configuration from PVC
-  # The operator will mount /etc/redis/user.acl from the PVC
+  # The operator mounts the PVC at /data/redis, so Redis reads /data/redis/user.acl
   # Make sure the PVC contains a file named "user.acl" with Redis ACL rules
   acl:
     persistentVolumeClaim: "redis-acl-pvc"

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -41,6 +41,8 @@ func GenerateConfig() error {
 		nodeport           = util.CoalesceEnv1("NODEPORT", "false")
 		tlsMode            = util.CoalesceEnv1("TLS_MODE", "false")
 		clusterMode        = util.CoalesceEnv1("SETUP_MODE", "standalone")
+		aclMode            = util.CoalesceEnv1("ACL_MODE", "")
+		aclFilePath        = util.CoalesceEnv1("ACL_FILE_PATH", "/etc/redis/user.acl")
 	)
 
 	if val, ok := util.CoalesceEnv("REDIS_PASSWORD", ""); ok && val != "" {
@@ -112,8 +114,9 @@ func GenerateConfig() error {
 		fmt.Println("Running without TLS mode")
 	}
 
-	if aclMode := util.CoalesceEnv1("ACL_MODE", ""); aclMode == "true" {
-		cfg.Append("aclfile", "/etc/redis/user.acl")
+	if aclMode == "true" {
+		fmt.Println("ACL_MODE is true, modifying ACL file path to", aclFilePath)
+		cfg.Append("aclfile", aclFilePath)
 	} else {
 		fmt.Println("ACL_MODE is not true, skipping ACL file modification")
 	}

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -88,8 +88,11 @@ func GenerateConfig() error {
 
 	// acl_setup
 	{
-		if aclMode, ok := util.CoalesceEnv("ACL_MODE", ""); ok && aclMode == "true" {
-			cfg.Append("aclfile", "/etc/redis/user.acl")
+		aclMode, _ := util.CoalesceEnv("ACL_MODE", "")
+		aclFilePath, _ := util.CoalesceEnv("ACL_FILE_PATH", "/etc/redis/user.acl")
+		if aclMode == "true" {
+			fmt.Println("ACL_MODE is true, modifying ACL file path to", aclFilePath)
+			cfg.Append("aclfile", aclFilePath)
 		} else {
 			fmt.Println("ACL_MODE is not true, skipping ACL file modification")
 		}

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -800,15 +800,18 @@ func getVolumeMount(name string, persistenceEnabled *bool, clusterMode bool, nod
 	}
 
 	if aclConfig != nil {
-		volumeName := "acl-secret"
 		if aclConfig.PersistentVolumeClaim != nil {
-			volumeName = "acl-pvc"
+			VolumeMounts = append(VolumeMounts, corev1.VolumeMount{
+				Name:      "acl-pvc",
+				MountPath: "/data/redis",
+			})
+		} else {
+			VolumeMounts = append(VolumeMounts, corev1.VolumeMount{
+				Name:      "acl-secret",
+				MountPath: "/etc/redis/user.acl",
+				SubPath:   "user.acl",
+			})
 		}
-		VolumeMounts = append(VolumeMounts, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: "/etc/redis/user.acl",
-			SubPath:   "user.acl",
-		})
 	}
 
 	if externalConfig != nil {
@@ -916,6 +919,14 @@ func getEnvironmentVariables(role string, enabledPassword *bool, secretName *str
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "ACL_MODE",
 			Value: "true",
+		})
+		aclFilePath := "/etc/redis/user.acl"
+		if aclConfig.PersistentVolumeClaim != nil {
+			aclFilePath = "/data/redis/user.acl"
+		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "ACL_FILE_PATH",
+			Value: aclFilePath,
 		})
 	}
 

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/chainsaw-test.yaml
@@ -96,7 +96,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} --container redis-cluster-acl-pvc-leader redis-cluster-acl-pvc-leader-0 --
-              cat /etc/redis/user.acl 2>&1
+              cat /data/redis/user.acl 2>&1
             check:
               (contains($stdout, 'user pvcuser')): true
               (contains($stdout, 'user readonly')): true
@@ -113,7 +113,32 @@ spec:
               (contains($stdout, 'pvcuser')): true
               (contains($stdout, 'readonly')): true
 
-    # Step 11: Test cluster operations with ACL
+    # Step 11: Test ACL SAVE persists to PVC
+    - name: Verify ACL SAVE writes to PVC
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} --container redis-cluster-acl-pvc-leader redis-cluster-acl-pvc-leader-0 --
+              redis-cli -c -p 6379 --user admin --pass admin@secure456 ACL SETUSER saveduser on ~* &* +@all >saved@secure789 2>&1
+            check:
+              (contains($stdout, 'OK')): true
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} --container redis-cluster-acl-pvc-leader redis-cluster-acl-pvc-leader-0 --
+              redis-cli -c -p 6379 --user admin --pass admin@secure456 ACL SAVE 2>&1
+            check:
+              (contains($stdout, 'OK')): true
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} --container redis-cluster-acl-pvc-leader redis-cluster-acl-pvc-leader-0 --
+              cat /data/redis/user.acl 2>&1
+            check:
+              (contains($stdout, 'user saveduser')): true
+
+    # Step 12: Test cluster operations with ACL
     - name: Test cluster info with ACL user
       try:
         - script:
@@ -124,13 +149,13 @@ spec:
             check:
               (contains($stdout, 'cluster_state:ok')): true
 
-    # Step 12: Verify PVC data persistence
+    # Step 13: Verify PVC data persistence
     - name: Verify ACL PVC volume mount
       try:
         - script:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} --container redis-cluster-acl-pvc-leader redis-cluster-acl-pvc-leader-0 --
-              cat /proc/mounts | grep '/etc/redis/user.acl' 2>&1
+              cat /proc/mounts | grep '/data/redis' 2>&1
             check:
-              (contains($stdout, '/etc/redis/user.acl')): true
+              (contains($stdout, '/data/redis')): true

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
@@ -76,7 +76,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-0 --
-              cat /etc/redis/user.acl 2>&1
+              cat /data/redis/user.acl 2>&1
             check:
               (contains($stdout, 'user repluser')): true
 
@@ -87,7 +87,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-1 --
-              cat /etc/redis/user.acl 2>&1
+              cat /data/redis/user.acl 2>&1
             check:
               (contains($stdout, 'user repluser')): true
 

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/chainsaw-test.yaml
@@ -78,7 +78,7 @@ spec:
             timeout: 30s
             content: >
               kubectl exec --namespace ${NAMESPACE} redis-standalone-acl-pvc-0 --
-              cat /etc/redis/user.acl 2>&1
+              cat /data/redis/user.acl 2>&1
             check:
               (contains($stdout, 'user standaloneuser')): true
 


### PR DESCRIPTION

**Description**

Redis always rewrites ACLs (and redis.conf, RDB, AOF) via the same pattern: write a temp file alongside the target, fsync, then rename(2) over the original.  
Because user.acl is mounted via subPath, Kubernetes turns that single file into its own bind mount.  
Bind mounts behave like a mini mount point, and Linux forbids rename(2) on a mount target—exactly what Redis tries to do during ACL SAVE (it writes tempfile + rename).  
The kernel therefore returns EBUSY, which surfaces as “Resource busy”.

The PR is fixing this behavior, by mounting the PVC as directory under the /data/redis.


**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
