### PR TITLE
fix: set REDIS_MAX_MEMORY when maxMemoryPercentOfLimit is used

### DIFF
--- a/api/common/v1beta2/common_types.go
+++ b/api/common/v1beta2/common_types.go
@@ -151,7 +151,8 @@ type RedisExporter struct {
 // RedisConfig defines the external configuration of Redis
 // +k8s:deepcopy-gen=true
 type RedisConfig struct {
-	// MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.
+	// MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+	// When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=100
 	MaxMemoryPercentOfLimit *int     `json:"maxMemoryPercentOfLimit,omitempty"`

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -98,7 +98,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.leader.serviceType | string | `"ClusterIP"` |  |
 | redisCluster.leader.tolerations | list | `[]` |  |
 | redisCluster.leader.topologySpreadConstraints | list | `[]` |  |
-| redisCluster.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.     Default is 0 (disabled). |
+| redisCluster.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.    Default is 0 (disabled). |
 | redisCluster.minReadySeconds | int | `0` |  |
 | redisCluster.name | string | `""` |  |
 | redisCluster.persistenceEnabled | bool | `true` |  |

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -26,7 +26,8 @@ redisCluster:
   #    When set to true, the operator will delete the statefulset and recreate it. 
   #    Default is false.
   recreateStatefulSetOnUpdateInvalid: false
-  # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory. 
+  # -- MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+  #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
   persistentVolumeClaimRetentionPolicy: {}

--- a/charts/redis-operator/crds/crds.yaml
+++ b/charts/redis-operator/crds/crds.yaml
@@ -2255,8 +2255,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer
@@ -6504,8 +6505,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer
@@ -8091,8 +8093,9 @@ spec:
                           type: string
                         type: array
                       maxMemoryPercentOfLimit:
-                        description: MaxMemoryPercentOfLimit is the percentage of
-                          redis container memory limit to be used as maxmemory.
+                        description: |-
+                          MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                          When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                         maximum: 100
                         minimum: 1
                         type: integer
@@ -9770,8 +9773,9 @@ spec:
                           type: string
                         type: array
                       maxMemoryPercentOfLimit:
-                        description: MaxMemoryPercentOfLimit is the percentage of
-                          redis container memory limit to be used as maxmemory.
+                        description: |-
+                          MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                          When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                         maximum: 100
                         minimum: 1
                         type: integer
@@ -15543,8 +15547,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -84,7 +84,7 @@ helm delete <my-release> --namespace <namespace>
 | redisReplication.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisReplication.imagePullSecrets | list | `[]` |  |
 | redisReplication.livenessProbe | object | `{}` |  |
-| redisReplication.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.    Default is 0 (disabled). |
+| redisReplication.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.    Default is 0 (disabled). |
 | redisReplication.minReadySeconds | int | `0` |  |
 | redisReplication.name | string | `""` |  |
 | redisReplication.persistentVolumeClaimRetentionPolicy | object | `{}` |  |

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -24,7 +24,8 @@ redisReplication:
   # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
   # When set to true, the operator will delete the statefulset and recreate it. Default is false.
   recreateStatefulSetOnUpdateInvalid: false
-  # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.
+  # -- MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+  #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
   persistentVolumeClaimRetentionPolicy: {}

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -78,7 +78,7 @@ helm delete <my-release> --namespace <namespace>
 | redisStandalone.image | string | `"quay.io/opstree/redis"` |  |
 | redisStandalone.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisStandalone.imagePullSecrets | list | `[]` |  |
-| redisStandalone.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.     Default is 0 (disabled). |
+| redisStandalone.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.    Default is 0 (disabled). |
 | redisStandalone.minReadySeconds | int | `0` |  |
 | redisStandalone.name | string | `""` |  |
 | redisStandalone.persistentVolumeClaimRetentionPolicy | object | `{}` |  |

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -23,7 +23,8 @@ redisStandalone:
   # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
   # When set to true, the operator will delete the statefulset and recreate it. Default is false.
   recreateStatefulSetOnUpdateInvalid: false
-  # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory. 
+  # -- MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+  #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
   persistentVolumeClaimRetentionPolicy: {}

--- a/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redis.yaml
@@ -2256,8 +2256,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -1107,8 +1107,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer
@@ -2694,8 +2695,9 @@ spec:
                           type: string
                         type: array
                       maxMemoryPercentOfLimit:
-                        description: MaxMemoryPercentOfLimit is the percentage of
-                          redis container memory limit to be used as maxmemory.
+                        description: |-
+                          MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                          When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                         maximum: 100
                         minimum: 1
                         type: integer
@@ -4373,8 +4375,9 @@ spec:
                           type: string
                         type: array
                       maxMemoryPercentOfLimit:
-                        description: MaxMemoryPercentOfLimit is the percentage of
-                          redis container memory limit to be used as maxmemory.
+                        description: |-
+                          MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                          When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                         maximum: 100
                         minimum: 1
                         type: integer

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisreplications.yaml
@@ -2278,8 +2278,9 @@ spec:
                       type: string
                     type: array
                   maxMemoryPercentOfLimit:
-                    description: MaxMemoryPercentOfLimit is the percentage of redis
-                      container memory limit to be used as maxmemory.
+                    description: |-
+                      MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.
+                      When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable.
                     maximum: 100
                     minimum: 1
                     type: integer

--- a/docs/content/en/docs/CRD Reference/API Reference/_index.md
+++ b/docs/content/en/docs/CRD Reference/API Reference/_index.md
@@ -253,7 +253,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `maxMemoryPercentOfLimit` _integer_ | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory. |  | Maximum: 100 <br />Minimum: 1 <br /> |
+| `maxMemoryPercentOfLimit` _integer_ | MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.<br />When set with a memory limit, the operator also exports the computed value via the REDIS_MAX_MEMORY environment variable. |  | Maximum: 100 <br />Minimum: 1 <br /> |
 | `dynamicConfig` _string array_ |  |  |  |
 | `additionalRedisConfig` _string_ |  |  |  |
 

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -451,6 +451,8 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 				containerParams.EnvVars,
 				containerParams.Port,
 				clusterVersion,
+				containerParams.Resources,
+				containerParams.MaxMemoryPercentOfLimit,
 			),
 			ReadinessProbe: getProbeInfo(containerParams.ReadinessProbe, sentinelCntr, enableTLS, enableAuth),
 			LivenessProbe:  getProbeInfo(containerParams.LivenessProbe, sentinelCntr, enableTLS, enableAuth),
@@ -590,16 +592,6 @@ func generateInitContainerDef(role, name string, initcontainerParams initContain
 			ptr.Deref(containerParams.EnvVars, []corev1.EnvVar{}),
 			ptr.Deref(containerParams.AdditionalEnvVariable, []corev1.EnvVar{})...,
 		)
-		if containerParams.Resources != nil && containerParams.MaxMemoryPercentOfLimit != nil {
-			memLimit := containerParams.Resources.Limits.Memory().Value()
-			if memLimit != 0 {
-				maxMem := int(float64(memLimit) * float64(*containerParams.MaxMemoryPercentOfLimit) / 100)
-				envVars = append(envVars, corev1.EnvVar{
-					Name:  consts.ENV_KEY_REDIS_MAX_MEMORY,
-					Value: fmt.Sprintf("%d", maxMem),
-				})
-			}
-		}
 
 		VolumeMounts := []corev1.VolumeMount{
 			generateConfigVolumeMount(common.VolumeNameConfig),
@@ -625,6 +617,8 @@ func generateInitContainerDef(role, name string, initcontainerParams initContain
 				&envVars,
 				containerParams.Port,
 				clusterVersion,
+				containerParams.Resources,
+				containerParams.MaxMemoryPercentOfLimit,
 			),
 			VolumeMounts: VolumeMounts,
 		}
@@ -873,6 +867,7 @@ func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS, enableAuth bool) *co
 func getEnvironmentVariables(role string, enabledPassword *bool, secretName *string,
 	secretKey *string, persistenceEnabled *bool, tlsConfig *commonapi.TLSConfig,
 	aclConfig *commonapi.ACLConfig, envVar *[]corev1.EnvVar, port *int, clusterVersion *string,
+	resources *corev1.ResourceRequirements, maxMemoryPercentOfLimit *int,
 ) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{Name: "SERVER_MODE", Value: role},
@@ -884,6 +879,16 @@ func getEnvironmentVariables(role string, enabledPassword *bool, secretName *str
 			Name:  "REDIS_MAJOR_VERSION",
 			Value: *clusterVersion,
 		})
+	}
+
+	if resources != nil && resources.Limits != nil && maxMemoryPercentOfLimit != nil && *maxMemoryPercentOfLimit > 0 {
+		if memLimit := resources.Limits.Memory().Value(); memLimit > 0 {
+			maxMem := int(float64(memLimit) * float64(*maxMemoryPercentOfLimit) / 100)
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  consts.ENV_KEY_REDIS_MAX_MEMORY,
+				Value: strconv.FormatInt(int64(maxMem), 10),
+			})
+		}
 	}
 
 	var redisHost string

--- a/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/chainsaw-test.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: max-memory-env-redis-standalone
+spec:
+  timeouts:
+    apply: 30s
+    assert: 5m
+    exec: 1m
+  steps:
+    - name: Deploy Redis Standalone
+      try:
+        - apply:
+            file: standalone.yaml
+        - assert:
+            file: ready-standalone.yaml
+
+    - name: Verify REDIS_MAX_MEMORY env variable
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-standalone-max-memory-0 -- env 2>&1
+            check:
+              (contains($stdout, 'REDIS_MAX_MEMORY=83886080')): true
+
+    - name: Verify redis maxmemory config
+      try:
+        - script:
+            timeout: 30s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-standalone-max-memory-0 --
+              redis-cli -p 6379 CONFIG GET maxmemory 2>&1
+            check:
+              (contains($stdout, '83886080')): true

--- a/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/ready-standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/ready-standalone.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-standalone-max-memory
+  labels:
+    app: redis-standalone-max-memory
+    redis_setup_type: standalone
+    role: standalone
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/standalone.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: redis-standalone-max-memory
+spec:
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi
+  redisConfig:
+    maxMemoryPercentOfLimit: 80
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
**Description**

Fix the REDIS_MAX_MEMORY setup when the maxMemoryPercentOfLimit is specified. It was only injected on the init container, now it is set for the redis containers.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1641

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
