### PR TITLE
feat: update redis helm charts to support already implemented properties

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.17.3
-appVersion: "0.17.3"
+version: 0.17.4
+appVersion: "0.17.4"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -82,6 +82,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.follower.securityContext | object | `{}` |  |
 | redisCluster.follower.serviceType | string | `"ClusterIP"` |  |
 | redisCluster.follower.tolerations | list | `[]` |  |
+| redisCluster.follower.topologySpreadConstraints | list | `[]` |  |
 | redisCluster.image | string | `"quay.io/opstree/redis"` |  |
 | redisCluster.imagePullPolicy | string | `"IfNotPresent"` |  |
 | redisCluster.imagePullSecrets | object | `{}` |  |
@@ -96,10 +97,12 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.leader.securityContext | object | `{}` |  |
 | redisCluster.leader.serviceType | string | `"ClusterIP"` |  |
 | redisCluster.leader.tolerations | list | `[]` |  |
+| redisCluster.leader.topologySpreadConstraints | list | `[]` |  |
 | redisCluster.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.     Default is 0 (disabled). |
 | redisCluster.minReadySeconds | int | `0` |  |
 | redisCluster.name | string | `""` |  |
 | redisCluster.persistenceEnabled | bool | `true` |  |
+| redisCluster.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redisCluster.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates.    When set to true, the operator will delete the statefulset and recreate it.     Default is false. |
 | redisCluster.redisSecret.secretKey | string | `""` |  |
 | redisCluster.redisSecret.secretName | string | `""` |  |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -33,6 +33,10 @@ pdb:
 nodeSelector:
   {{- toYaml .nodeSelector | nindent 2 }}
 {{- end }}
+{{- if .topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml .topologySpreadConstraints | nindent 2 }}
+{{- end }}
 {{- if .securityContext }}
 securityContext:
   {{- toYaml .securityContext | nindent 2 }}

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -71,6 +71,9 @@ spec:
     {{- if .Values.redisCluster.minReadySeconds }}
     minReadySeconds: {{ .Values.redisCluster.minReadySeconds}}
     {{- end }}
+    {{- if .Values.redisCluster.persistentVolumeClaimRetentionPolicy }}
+    persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.redisCluster.persistentVolumeClaimRetentionPolicy | nindent 6 }}
+    {{- end }}
 
   {{- if .Values.storageSpec }}
   storage: {{ toYaml .Values.storageSpec | nindent 4 }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -29,6 +29,9 @@ redisCluster:
   # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory. 
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  persistentVolumeClaimRetentionPolicy: {}
+    # whenDeleted: Delete
+    # whenScaled: Retain
   # -- Enable pod anti-affinity between leader and follower pods by adding the appropriate label.
   #    Notice that this requires the operator to have its mutating webhook enabled,
   #    otherwise it will only add an annotation to the RedisCluster CR. 
@@ -55,6 +58,14 @@ redisCluster:
     nodeSelector: null
       # memory: medium
     securityContext: {}
+    topologySpreadConstraints: []
+      # - maxSkew: 1
+      #   topologyKey: kubernetes.io/hostname
+      #   whenUnsatisfiable: DoNotSchedule
+      #   labelSelector:
+      #     matchLabels:
+      #       role: leader
+      #       clusterId: redis-cluster
     pdb:
       enabled: false
       maxUnavailable: 1
@@ -93,6 +104,14 @@ redisCluster:
     nodeSelector: null
       # memory: medium
     securityContext: {}
+    topologySpreadConstraints: []
+      # - maxSkew: 1
+      #   topologyKey: kubernetes.io/hostname
+      #   whenUnsatisfiable: DoNotSchedule
+      #   labelSelector:
+      #     matchLabels:
+      #       role: follower
+      #       clusterId: redis-cluster
     pdb:
       enabled: false
       maxUnavailable: 1

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.12
-appVersion: "0.16.12"
+version: 0.16.13
+appVersion: "0.16.13"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -87,6 +87,7 @@ helm delete <my-release> --namespace <namespace>
 | redisReplication.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.    Default is 0 (disabled). |
 | redisReplication.minReadySeconds | int | `0` |  |
 | redisReplication.name | string | `""` |  |
+| redisReplication.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redisReplication.readinessProbe | object | `{}` |  |
 | redisReplication.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
 | redisReplication.redisSecret.secretKey | string | `""` |  |
@@ -105,3 +106,4 @@ helm delete <my-release> --namespace <namespace>
 | storageSpec.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -30,6 +30,9 @@ spec:
     {{- if .Values.redisReplication.minReadySeconds }}
     minReadySeconds: {{ .Values.redisReplication.minReadySeconds}}
     {{- end }}
+    {{- if .Values.redisReplication.persistentVolumeClaimRetentionPolicy }}
+    persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.redisReplication.persistentVolumeClaimRetentionPolicy | nindent 6 }}
+    {{- end }}
   {{- if .Values.redisReplication.livenessProbe }}
   livenessProbe: {{ toYaml .Values.redisReplication.livenessProbe | nindent 4 }}
   {{- end }}
@@ -80,6 +83,9 @@ spec:
   {{- end }}
   {{- if .Values.tolerations }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 4 }}
   {{- end }}
   {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
   TLS:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -27,6 +27,9 @@ redisReplication:
   # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  persistentVolumeClaimRetentionPolicy: {}
+    # whenDeleted: Delete
+    # whenScaled: Retain
   livenessProbe: {}
     # timeoutSeconds: 5
     # periodSeconds: 15
@@ -160,6 +163,15 @@ tolerations: []
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: replication
+  #       app: redis-replication
 
 serviceAccountName: ""
 

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-sentinel
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.11
-appVersion: "0.16.11"
+version: 0.16.12
+appVersion: "0.16.12"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -94,6 +94,7 @@ helm delete <my-release> --namespace <namespace>
 | redisSentinel.imagePullSecrets | list | `[]` |  |
 | redisSentinel.minReadySeconds | int | `0` |  |
 | redisSentinel.name | string | `""` |  |
+| redisSentinel.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redisSentinel.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
 | redisSentinel.redisSecret.secretKey | string | `""` |  |
 | redisSentinel.redisSecret.secretName | string | `""` |  |
@@ -120,3 +121,4 @@ helm delete <my-release> --namespace <namespace>
 | serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | sidecars | list | `[]` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -51,6 +51,9 @@ spec:
     {{- if .Values.redisSentinel.minReadySeconds }}
     minReadySeconds: {{ .Values.redisSentinel.minReadySeconds }}
     {{- end }}
+    {{- if .Values.redisSentinel.persistentVolumeClaimRetentionPolicy }}
+    persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.redisSentinel.persistentVolumeClaimRetentionPolicy | nindent 6 }}
+    {{- end }}
 
   redisExporter:
     enabled: {{ .Values.redisExporter.enabled }}
@@ -83,6 +86,9 @@ spec:
   {{- end }}
   {{- if .Values.tolerations }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 4 }}
   {{- end }}
   {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
   TLS:

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -24,6 +24,9 @@ redisSentinel:
   # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
   # When set to true, the operator will delete the statefulset and recreate it. Default is false.
   recreateStatefulSetOnUpdateInvalid: false
+  persistentVolumeClaimRetentionPolicy: {}
+    # whenDeleted: Delete
+    # whenScaled: Retain
 
 # Overwite name for resources
 # name: ""
@@ -149,6 +152,15 @@ tolerations: []
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: sentinel
+  #       app: redis-sentinel
 
 serviceAccountName: ""
 

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: redis
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.8
-appVersion: "0.16.8"
+version: 0.16.9
+appVersion: "0.16.9"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -81,6 +81,7 @@ helm delete <my-release> --namespace <namespace>
 | redisStandalone.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory.     Default is 0 (disabled). |
 | redisStandalone.minReadySeconds | int | `0` |  |
 | redisStandalone.name | string | `""` |  |
+| redisStandalone.persistentVolumeClaimRetentionPolicy | object | `{}` |  |
 | redisStandalone.recreateStatefulSetOnUpdateInvalid | bool | `false` | Some fields of statefulset are immutable, such as volumeClaimTemplates. When set to true, the operator will delete the statefulset and recreate it. Default is false. |
 | redisStandalone.redisSecret.secretKey | string | `""` |  |
 | redisStandalone.redisSecret.secretName | string | `""` |  |
@@ -98,3 +99,4 @@ helm delete <my-release> --namespace <namespace>
 | storageSpec.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -29,6 +29,9 @@ spec:
     {{- if .Values.redisStandalone.minReadySeconds }}
     minReadySeconds: {{ .Values.redisStandalone.minReadySeconds }}
     {{- end }}
+    {{- if .Values.redisStandalone.persistentVolumeClaimRetentionPolicy }}
+    persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.redisStandalone.persistentVolumeClaimRetentionPolicy | nindent 6 }}
+    {{- end }}
 
   redisExporter:
     enabled: {{ .Values.redisExporter.enabled }}
@@ -73,6 +76,9 @@ spec:
   {{- end }}
   {{- if .Values.tolerations }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 4 }}
   {{- end }}
   {{- if and .Values.TLS.ca .Values.TLS.cert .Values.TLS.key .Values.TLS.secret.secretName }}
   TLS:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -26,6 +26,9 @@ redisStandalone:
   # -- MaxMemoryPercentOfLimit is the percentage of redis container memory limit to be used as maxmemory. 
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  persistentVolumeClaimRetentionPolicy: {}
+    # whenDeleted: Delete
+    # whenScaled: Retain
 
 labels: {}
 #   foo: bar
@@ -144,6 +147,14 @@ tolerations: []
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app: redis
 
 serviceAccountName: ""
 


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Update Redis Helm charts to support the already implemented properties:
- persistentVolumeClaimRetentionPolicy
- topologySpreadConstraints

Update the chart versions.

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**

These properties are already implemented in the operator, only the chart is missing the support for them. 