### PR TITLE
fix!: update mutating webhook configuration name to include release name prefix

### DIFF
--- a/charts/redis-operator/templates/mutating-webhook-configuration.yaml
+++ b/charts/redis-operator/templates/mutating-webhook-configuration.yaml
@@ -23,7 +23,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: {{ .Release.Name }}-mutating-webhook-configuration
   {{- if .Values.certmanager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.certificate.name }}

--- a/upgrade/migartion-v0.23.0-to-v0.24.0.md
+++ b/upgrade/migartion-v0.23.0-to-v0.24.0.md
@@ -1,0 +1,24 @@
+# Webhook Configuration Migration Guide
+
+## Overview
+
+Webhook configurations now include the release name prefix to prevent naming conflicts with other operators.
+
+**Only required if you have webhooks enabled (`redisOperator.webhook=true`).**
+
+## Migration Steps
+
+### Helm Installations
+
+```bash
+# 1. Delete old webhook configuration
+kubectl delete mutatingwebhookconfiguration mutating-webhook-configuration
+
+# 2. Upgrade
+helm upgrade redis-operator ot-helm/redis-operator \
+  --namespace <namespace> \
+  --set redisOperator.webhook=true
+
+# 3. Verify
+kubectl get mutatingwebhookconfiguration | grep redis-operator
+```


### PR DESCRIPTION
**Description**

The mutating webhook configuration name has been updated to include the release name prefix.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1649

**Type of change**

<!-- Please delete options that are not relevant. -->
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
