### PR TITLE
fix: do not create empty PVC when storage has only volumeMount

### DIFF
--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -189,7 +189,7 @@ func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) contain
 	if cr.Spec.LivenessProbe != nil {
 		containerProp.LivenessProbe = cr.Spec.LivenessProbe
 	}
-	if cr.Spec.Storage != nil {
+	if storageHasVolumeClaimTemplate(cr.Spec.Storage) {
 		containerProp.PersistenceEnabled = &trueProperty
 	}
 	if cr.Spec.TLS != nil {
@@ -225,7 +225,7 @@ func generateRedisReplicationInitContainerParams(cr *rrvb2.RedisReplication) ini
 			initcontainerProp.AdditionalVolume = cr.Spec.Storage.VolumeMount.Volume
 			initcontainerProp.AdditionalMountPath = cr.Spec.Storage.VolumeMount.MountPath
 		}
-		if cr.Spec.Storage != nil {
+		if storageHasVolumeClaimTemplate(cr.Spec.Storage) {
 			initcontainerProp.PersistenceEnabled = &trueProperty
 		}
 	}

--- a/internal/k8sutils/redis-standalone.go
+++ b/internal/k8sutils/redis-standalone.go
@@ -197,7 +197,7 @@ func generateRedisStandaloneContainerParams(cr *rvb2.Redis) containerParameters 
 	if cr.Spec.LivenessProbe != nil {
 		containerProp.LivenessProbe = cr.Spec.LivenessProbe
 	}
-	if cr.Spec.Storage != nil {
+	if storageHasVolumeClaimTemplate(cr.Spec.Storage) {
 		containerProp.PersistenceEnabled = &trueProperty
 	}
 	if cr.Spec.TLS != nil {
@@ -233,7 +233,7 @@ func generateRedisStandaloneInitContainerParams(cr *rvb2.Redis) initContainerPar
 			initcontainerProp.AdditionalVolume = cr.Spec.Storage.VolumeMount.Volume
 			initcontainerProp.AdditionalMountPath = cr.Spec.Storage.VolumeMount.MountPath
 		}
-		if cr.Spec.Storage != nil {
+		if storageHasVolumeClaimTemplate(cr.Spec.Storage) {
 			initcontainerProp.PersistenceEnabled = &trueProperty
 		}
 	}

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -250,6 +250,17 @@ func syncManagedFields(stored, new *appsv1.StatefulSet) {
 	new.ManagedFields = stored.ManagedFields
 }
 
+// storageHasVolumeClaimTemplate checks if the Storage has a meaningful VolumeClaimTemplate defined
+// (i.e., not just the zero value). This distinguishes between storage configured with only
+// volumeMount (e.g. emptyDir) vs. storage that actually requests a PersistentVolumeClaim.
+func storageHasVolumeClaimTemplate(storage *commonapi.Storage) bool {
+	if storage == nil {
+		return false
+	}
+	vct := storage.VolumeClaimTemplate
+	return len(vct.Spec.AccessModes) > 0 || vct.Spec.Resources.Requests != nil || vct.Spec.StorageClassName != nil || vct.Spec.VolumeName != ""
+}
+
 // hasVolumeClaimTemplates checks if the StatefulSet has VolumeClaimTemplates and if their counts match.
 func hasVolumeClaimTemplates(new, stored *appsv1.StatefulSet) bool {
 	return len(new.Spec.VolumeClaimTemplates) >= 1 && len(new.Spec.VolumeClaimTemplates) == len(stored.Spec.VolumeClaimTemplates)


### PR DESCRIPTION
**Description**

When `spec.storage` contains only `volumeMount` entries (e.g. `emptyDir`) without `volumeClaimTemplate`, the operator incorrectly set `PersistenceEnabled=true`, causing an empty `volumeClaimTemplates` entry in the resulting StatefulSet. This led to unnecessary (and possibly broken) PVC provisioning.

**Root cause:** `PersistenceEnabled` was set based solely on `cr.Spec.Storage != nil`, without checking whether `volumeClaimTemplate` is actually populated. Since the `Storage` struct is non-nil whenever any storage is configured (including volumeMount-only with emptyDir), the operator always treated it as a request for a PersistentVolumeClaim.

**Changes:**
- Added `storageHasVolumeClaimTemplate()` helper in `statefulset.go` that checks whether `VolumeClaimTemplate` has meaningful content (`AccessModes`, `Resources.Requests`, `StorageClassName`, or `VolumeName`)
- Redis standalone and replication: replaced `cr.Spec.Storage != nil` with `storageHasVolumeClaimTemplate()` for both container and init container params
- Redis cluster init container: aligned the check with the existing container params logic (`PersistenceEnabled != nil && *PersistenceEnabled`)
- Added unit tests for `storageHasVolumeClaimTemplate`

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Users who have `volumeClaimTemplate` properly configured are not affected — behavior is unchanged for them. The fix only removes the incorrect empty PVC creation for volumeMount-only storage configurations.