### PR TITLE
docs: add nodeConfVolume to cluster example

### DIFF
--- a/docs/content/en/docs/Getting Started/Cluster/_index.md
+++ b/docs/content/en/docs/Getting Started/Cluster/_index.md
@@ -105,6 +105,13 @@ spec:
         resources:
           requests:
             storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
 ```
 
 The yaml manifest can easily get applied by using `kubectl`.


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Update the RedisCluster example manifest to explicitly enable nodeConfVolume and include nodeConfVolumeClaimTemplate so /node-conf is mounted and writable.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1168 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**
No code changes; docs-only update to prevent the example manifest from failing on non‑root Redis pods.