### PR TITLE
fix: respect persistenceEnabled for initContainer

### DIFF
--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -103,7 +103,7 @@ func generateRedisClusterInitContainerParams(cr *rcvb2.RedisCluster) initContain
 			initcontainerProp.AdditionalVolume = cr.Spec.Storage.VolumeMount.Volume
 			initcontainerProp.AdditionalMountPath = cr.Spec.Storage.VolumeMount.MountPath
 		}
-		if cr.Spec.Storage != nil {
+		if cr.Spec.Storage != nil && cr.Spec.PersistenceEnabled != nil && *cr.Spec.PersistenceEnabled {
 			initcontainerProp.PersistenceEnabled = &trueProperty
 		}
 	}

--- a/internal/k8sutils/redis-cluster_test.go
+++ b/internal/k8sutils/redis-cluster_test.go
@@ -524,3 +524,24 @@ func Test_generateRedisClusterInitContainerParams(t *testing.T) {
 	actual := generateRedisClusterInitContainerParams(input)
 	assert.EqualValues(t, expected, actual, "Expected %+v, got %+v", expected, actual)
 }
+
+func Test_generateRedisClusterInitContainerParams_PersistenceDisabled(t *testing.T) {
+	enabled := true
+	persistenceEnabled := false
+
+	input := &rcvb2.RedisCluster{
+		Spec: rcvb2.RedisClusterSpec{
+			PersistenceEnabled: &persistenceEnabled,
+			Storage:            &rcvb2.ClusterStorage{},
+			InitContainer: &common.InitContainer{
+				Enabled: &enabled,
+				Image:   "busybox:latest",
+			},
+		},
+	}
+
+	actual := generateRedisClusterInitContainerParams(input)
+	if actual.PersistenceEnabled != nil {
+		t.Fatalf("Expected PersistenceEnabled to be nil when persistence is disabled, got %v", *actual.PersistenceEnabled)
+	}
+}


### PR DESCRIPTION
**Description**

Respect spec.persistenceEnabled when wiring initContainer persistence so the init container doesn’t try to mount PVCs when persistence is disabled. Adds a unit test for the disabled‑persistence case.

Fixes #1540

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Tests:
`env GOCACHE=/tmp/go-build go test ./internal/k8sutils`
