### PR TITLE
fix: aggregate operator ClusterRole into admin

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,3 +18,15 @@ resources:
 # default, aiding admins in cluster management. Those roles are
 # not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: manager-role
+    patch: |
+      - op: add
+        path: /metadata/labels
+        value:
+          rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,8 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: manager-role
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - nonResourceURLs:
   - '*'


### PR DESCRIPTION
**Description**

Add the aggregate-to-admin label to the operator ClusterRole so it is included in the built-in admin role via RBAC aggregation.

Fixes #1664

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

No behavior changes to controller logic; this only affects RBAC aggregation.
