### PR TITLE
fix: correct namespaces RBAC resource

### DIFF
--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -80,7 +80,7 @@ rules:
   - configmaps
   - events
   - persistentvolumeclaims
-  - namespace
+  - namespaces
   verbs:
   - create
   - delete


### PR DESCRIPTION
**Description**

Fix a Helm RBAC typo by changing the ClusterRole resource from `namespace` to `namespaces`, which is the correct Kubernetes RBAC resource name. This makes the rule effective and aligns the chart with config/rbac/role.yaml.


**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

No behavior change beyond making the RBAC rule actually match the Kubernetes resource name.
