### PR TITLE
docs: fix minor typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 For development and testing of operator on local system, we need to set up a [Minikube](https://minikube.sigs.k8s.io/docs/start/) or local Kubernetes cluster.
 
-Minikube is a single node Kubernetes cluster that generally gets used for the development and testing on Kubernetes. For creating a Minkube cluster we need to simply run:
+Minikube is a single node Kubernetes cluster that generally gets used for the development and testing on Kubernetes. For creating a Minikube cluster we need to simply run:
 
 ```shell
 $ minikube start --vm-driver virtualbox

--- a/docs/content/en/docs/CRD Reference/API Reference/_index.md
+++ b/docs/content/en/docs/CRD Reference/API Reference/_index.md
@@ -661,7 +661,7 @@ _Appears in:_
 
 
 
-Storage is the inteface to add pvc and pv support in redis
+Storage is the interface to add pvc and pv support in redis
 
 
 
@@ -697,5 +697,4 @@ _Appears in:_
 | `cert` _string_ |  |  |  |
 | `key` _string_ |  |  |  |
 | `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretvolumesource-v1-core)_ | Reference to secret which contains the certificates |  |  |
-
 

--- a/docs/content/en/docs/Contribute/_index.md
+++ b/docs/content/en/docs/Contribute/_index.md
@@ -21,7 +21,7 @@ description: >
 
 For development and testing of operator on local system, we need to set up a [Minikube](https://minikube.sigs.k8s.io/docs/start/) or local Kubernetes cluster.
 
-Minikube is a single node Kubernetes cluster that generally gets used for the development and testing on Kubernetes. For creating a Minkube cluster we need to simply run:
+Minikube is a single node Kubernetes cluster that generally gets used for the development and testing on Kubernetes. For creating a Minikube cluster we need to simply run:
 
 ```shell
 $ minikube start --vm-driver virtualbox


### PR DESCRIPTION
**Description**

Fix a few small documentation typos:
- “Minkube” → “Minikube” (CONTRIBUTING + Contribute docs)
- “inteface” → “interface” (CRD Reference)

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Docs-only change.
