### PR TITLE
docs: fix example redisSecret indentation

### DIFF
--- a/example/v1beta2/acl_config/cluster.yaml
+++ b/example/v1beta2/acl_config/cluster.yaml
@@ -20,11 +20,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   acl:
     secret:
       secretName: acl-secret

--- a/example/v1beta2/acl_config/replication.yaml
+++ b/example/v1beta2/acl_config/replication.yaml
@@ -20,11 +20,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   acl:
     secret:
       secretName: acl-secret

--- a/example/v1beta2/acl_config/standalone.yaml
+++ b/example/v1beta2/acl_config/standalone.yaml
@@ -16,11 +16,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   acl:
     secret:
       secretName: acl-secret

--- a/example/v1beta2/backup_restore/restore/redis-cluster.yaml
+++ b/example/v1beta2/backup_restore/restore/redis-cluster.yaml
@@ -20,11 +20,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   initContainer:
     enabled: true
     image: quay.io/opstree/redis-operator-restore:latest

--- a/example/v1beta2/env_vars/redis-cluster.yaml
+++ b/example/v1beta2/env_vars/redis-cluster.yaml
@@ -25,11 +25,11 @@ spec:
       value: "custom_value_1"
     - name: CUSTOM_ENV_VAR_2
       value: "custom_value_2"
-      # redisSecret:
-      #   name: redis-secret
-      #   key: password
-      # imagePullSecrets:
-      #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   storage:
     volumeClaimTemplate:
       spec:

--- a/example/v1beta2/env_vars/redis-replication.yaml
+++ b/example/v1beta2/env_vars/redis-replication.yaml
@@ -23,8 +23,8 @@ spec:
     redisSecret:
       name: redis-secret
       key: password
-      # imagePullSecrets:
-      #   - name: regcred
+    # imagePullSecrets:
+    #   - name: regcred
   env:
     - name: CUSTOM_ENV_VAR_1
       value: "custom_value_1"

--- a/example/v1beta2/env_vars/redis-standalone.yaml
+++ b/example/v1beta2/env_vars/redis-standalone.yaml
@@ -19,11 +19,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/redis-cluster.yaml
+++ b/example/v1beta2/redis-cluster.yaml
@@ -20,11 +20,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/redis-replication.yaml
+++ b/example/v1beta2/redis-replication.yaml
@@ -20,11 +20,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-#    redisSecret:
-#      name: redis-secret
-#      key: password
-      # imagePullSecrets:
-      #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/redis-standalone.yaml
+++ b/example/v1beta2/redis-standalone.yaml
@@ -19,11 +19,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/sidecar_features/sidecar.yaml
+++ b/example/v1beta2/sidecar_features/sidecar.yaml
@@ -16,11 +16,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/topology_spread_constraints/redis-cluster.yaml
+++ b/example/v1beta2/topology_spread_constraints/redis-cluster.yaml
@@ -22,9 +22,9 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
   redisLeader:
     topologySpreadConstraints:
       - maxSkew: 1

--- a/example/v1beta2/volume_mount/redis-cluster.yaml
+++ b/example/v1beta2/volume_mount/redis-cluster.yaml
@@ -23,8 +23,8 @@ spec:
     redisSecret:
       name: redis-secret
       key: password
-      # imagePullSecrets:
-      #   - name: regcred
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/volume_mount/redis-replication.yaml
+++ b/example/v1beta2/volume_mount/redis-replication.yaml
@@ -17,11 +17,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest

--- a/example/v1beta2/volume_mount/redis-standalone.yaml
+++ b/example/v1beta2/volume_mount/redis-standalone.yaml
@@ -16,11 +16,11 @@ spec:
       limits:
         cpu: 101m
         memory: 128Mi
-        # redisSecret:
-        #   name: redis-secret
-        #   key: password
-        # imagePullSecrets:
-        #   - name: regcred
+    # redisSecret:
+    #   name: redis-secret
+    #   key: password
+    # imagePullSecrets:
+    #   - name: regcred
   redisExporter:
     enabled: false
     image: quay.io/opstree/redis-exporter:latest


### PR DESCRIPTION
**Description**

Fix indentation of commented `redisSecret` and `imagePullSecrets` blocks in example manifests so they are valid when uncommented. These were previously nested under `resources.limits`, which makes the YAML invalid if enabled.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Docs/examples only.
