### PR TITLE
docs: add examples index and architecture diagram

### DIFF
--- a/docs/content/en/docs/Architecture/_index.md
+++ b/docs/content/en/docs/Architecture/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Architecture"
+linkTitle: "Architecture"
+weight: 2
+date: 2026-02-16T00:00:00Z
+description: >
+  High-level architecture and reconciliation flow for Redis Operator.
+---
+
+This page provides a high-level view of how Redis Operator turns a CR into Kubernetes resources.
+
+```mermaid
+flowchart TB
+  CR["Redis / RedisCluster / RedisSentinel CR"] --> Controller["Controller / Reconciler"]
+  Controller --> STS["StatefulSet"]
+  Controller --> SVC["Service"]
+  Controller --> PVC["PVCs"]
+  Controller --> CM["ConfigMaps / Secrets"]
+  Controller --> PDB["PodDisruptionBudget"]
+  STS --> Exporter["redis-exporter (optional)"]
+```
+
+## Reconciliation flow
+
+- You apply or update a Redis custom resource.
+- The controller reconciles desired state into Kubernetes primitives.
+- StatefulSets manage Redis pods and their storage.
+- Services and PDBs provide networking and disruption protection.
+- ConfigMaps and Secrets provide configuration and credentials.

--- a/docs/content/en/docs/Overview/_index.md
+++ b/docs/content/en/docs/Overview/_index.md
@@ -38,6 +38,8 @@ Here the features which are supported by this operator:
 
 ## Architecture
 
+For a high-level system overview and reconciliation flow, see the [Architecture]({{< relref "../Architecture/_index.md" >}}) page.
+
 ![redis_operator_architecture](../../../images/redis-operator-architecture.png)
 
 ## Code of Conduct

--- a/example/v1beta2/README.md
+++ b/example/v1beta2/README.md
@@ -1,0 +1,45 @@
+# Examples (v1beta2)
+
+This directory contains ready-to-apply manifests for common Redis Operator scenarios.
+
+## Core setups
+
+- `redis-standalone.yaml`: Minimal Redis standalone instance.
+- `redis-replication.yaml`: Redis replication setup.
+- `redis-sentinel.yaml`: Redis Sentinel setup.
+- `redis-cluster.yaml`: Redis Cluster setup.
+
+## Configuration and tuning
+
+- `additional_config/`: Additional Redis configuration via `redisConfig`.
+- `advance_config/`: Advanced Redis configuration options.
+- `env_vars/`: Inject environment variables into Redis containers.
+- `probes/`: Custom readiness and liveness probes.
+- `sidecar_features/`: Sidecar containers and related settings.
+- `volume_mount/`: Additional volume mounts.
+
+## Scheduling and placement
+
+- `affinity/`: Pod affinity and anti-affinity rules.
+- `node-selector/`: Node selector settings.
+- `tolerations/`: Pod tolerations.
+- `topology_spread_constraints/`: Topology spread constraints.
+- `redis-cluster-deploy/`: Role-based anti-affinity example for cluster deployment.
+
+## Security
+
+- `password_protected/`: Password-protected Redis.
+- `tls_enabled/`: TLS-enabled Redis.
+- `acl_config/`: ACL configuration for Redis users.
+- `acl-pvc/`: ACL configuration stored on PVC.
+- `private_registry/`: Pull images from a private registry.
+
+## Operations and lifecycle
+
+- `backup_restore/`: Backup and restore workflows.
+- `disruption_budget/`: PodDisruptionBudget configuration.
+- `external_service/`: External service exposure options.
+- `pvc_retention_policy/`: PVC retention policy settings.
+- `recreate-statefulset/`: StatefulSet recreate strategy.
+- `redis_monitoring/`: Monitoring and exporter configuration.
+- `upgrade-strategy/`: Upgrade strategy examples.


### PR DESCRIPTION
**Description**

Add a v1beta2 examples index and a new Architecture doc page with a Mermaid diagram. Link the Architecture page from Overview.


**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Docs-only change; no runtime code or tests affected.
