### PR TITLE
feat: add preStop lifecycle hook for replication mode

### DIFF
--- a/api/redisreplication/v1beta2/redisreplication_types_helper.go
+++ b/api/redisreplication/v1beta2/redisreplication_types_helper.go
@@ -18,6 +18,14 @@ func (cr *RedisReplication) SentinelHLService() string {
 	return cr.Name + "-s-hl"
 }
 
+// SentinelMasterName returns the master group name monitored by the embedded
+// Sentinel. The embedded Sentinel always monitors a single group named
+// "mymaster" (see internal/agent/bootstrap/sentinel/config.go, which falls back
+// to "mymaster" because the embedded Sentinel env never sets MASTER_GROUP_NAME).
+func (cr *RedisReplication) SentinelMasterName() string {
+	return "mymaster"
+}
+
 func (cr *RedisReplication) MasterService() string {
 	return cr.Name + "-master"
 }
@@ -29,7 +37,7 @@ func (cr *RedisReplication) GetConnectionInfo(dnsDomain string) *ConnectionInfo 
 		return &ConnectionInfo{
 			Host:       fmt.Sprintf("%s.%s.svc.%s", cr.SentinelHLService(), cr.Namespace, dnsDomain),
 			Port:       26379,
-			MasterName: "mymaster",
+			MasterName: cr.SentinelMasterName(),
 		}
 	}
 	return &ConnectionInfo{

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -208,6 +208,16 @@ func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) contain
 	if cr.Spec.ACL != nil {
 		containerProp.ACLConfig = cr.Spec.ACL
 	}
+	// Only wire up the Sentinel failover preStop hook when an embedded Sentinel
+	// is actually managing this replication. The service name and master group
+	// are sourced from the CR so they match the deployed Sentinel topology, and
+	// the demotion wait is bounded by the grace period so it cannot run past it.
+	if cr.EnableSentinel() {
+		containerProp.SentinelService = cr.SentinelHLService()
+		containerProp.SentinelMasterName = cr.SentinelMasterName()
+		containerProp.SentinelPort = 26379
+		containerProp.PreStopWaitSeconds = replicationPreStopWaitSeconds(cr.Spec.TerminationGracePeriodSeconds)
+	}
 	return containerProp
 }
 

--- a/internal/k8sutils/redis-replication_test.go
+++ b/internal/k8sutils/redis-replication_test.go
@@ -234,6 +234,46 @@ func Test_generateRedisReplicationContainerParams(t *testing.T) {
 	assert.EqualValues(t, expected, actual, "Expected %+v, got %+v", expected, actual)
 }
 
+func Test_generateRedisReplicationContainerParams_SentinelPreStop(t *testing.T) {
+	base := func() *rrvb2.RedisReplication {
+		return &rrvb2.RedisReplication{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-replication"},
+			Spec: rrvb2.RedisReplicationSpec{
+				Size: ptr.To(int32(3)),
+			},
+		}
+	}
+
+	t.Run("sentinel disabled leaves preStop fields empty", func(t *testing.T) {
+		got := generateRedisReplicationContainerParams(base())
+		assert.Empty(t, got.SentinelService)
+		assert.Empty(t, got.SentinelMasterName)
+		assert.Zero(t, got.SentinelPort)
+		assert.Zero(t, got.PreStopWaitSeconds)
+	})
+
+	t.Run("embedded sentinel wires preStop from CR config", func(t *testing.T) {
+		cr := base()
+		cr.Spec.Sentinel = &rrvb2.Sentinel{Size: 3}
+		cr.Spec.TerminationGracePeriodSeconds = ptr.To(int64(60))
+
+		got := generateRedisReplicationContainerParams(cr)
+		assert.Equal(t, "my-replication-s-hl", got.SentinelService)
+		assert.Equal(t, "mymaster", got.SentinelMasterName)
+		assert.Equal(t, 26379, got.SentinelPort)
+		// grace(60) - headroom(10) => 50s wait, leaving headroom before SIGKILL.
+		assert.Equal(t, 50, got.PreStopWaitSeconds)
+	})
+
+	t.Run("embedded sentinel with size 0 stays disabled", func(t *testing.T) {
+		cr := base()
+		cr.Spec.Sentinel = &rrvb2.Sentinel{Size: 0}
+
+		got := generateRedisReplicationContainerParams(cr)
+		assert.Empty(t, got.SentinelService)
+	})
+}
+
 func Test_generateRedisReplicationInitContainerParams(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "testdata", "redis-replication.yaml")
 	expected := initContainerParameters{

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -571,6 +571,8 @@ func GeneratePreStopCommand(role string, enableAuth, enableTLS bool) string {
 	switch role {
 	case "cluster":
 		return generateClusterPreStop(authArgs, tlsArgs)
+	case "replication":
+		return generateReplicationPreStop(authArgs, tlsArgs)
 	default:
 		return ""
 	}
@@ -617,6 +619,29 @@ if [ "$ROLE" = "master" ]; then
         redis-cli -h "$BEST_SLAVE" -p ${REDIS_PORT} %s %s cluster failover
     fi
 fi`, authArgs, tlsArgs, authArgs, tlsArgs, authArgs, tlsArgs)
+}
+
+// generateReplicationPreStop generates the preStop script for Redis replication mode.
+// It checks if this pod is the master, and if so, triggers a Sentinel failover
+// before allowing the pod to terminate, preventing unnecessary downtime.
+func generateReplicationPreStop(authArgs, tlsArgs string) string {
+	return fmt.Sprintf(`#!/bin/sh
+ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s --no-auth-warning info replication | awk -F: '/role:master/ {print "master"}')
+
+if [ "$ROLE" = "master" ]; then
+    CR_NAME=$(echo $HOSTNAME | sed 's/-[0-9]*$//')
+    SENTINEL_SVC="${CR_NAME}-s-hl"
+
+    redis-cli -h "$SENTINEL_SVC" -p 26379 SENTINEL FAILOVER mymaster
+
+    for i in $(seq 1 30); do
+        NEW_ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s --no-auth-warning info replication | awk -F: '/role:slave/ {print "slave"}')
+        if [ "$NEW_ROLE" = "slave" ]; then
+            break
+        fi
+        sleep 1
+    done
+fi`, authArgs, tlsArgs, authArgs, tlsArgs)
 }
 
 func generateInitContainerDef(role, name string, initcontainerParams initContainerParameters, externalConfig *string, mountpath []corev1.VolumeMount, containerParams containerParameters, clusterVersion *string) []corev1.Container {

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -150,6 +150,13 @@ type containerParameters struct {
 	EnvVars                      *[]corev1.EnvVar
 	Port                         *int
 	HostPort                     *int
+	// Sentinel-driven preStop settings. These are only populated for the
+	// "replication" role when an embedded Sentinel is enabled. When
+	// SentinelService is empty the replication preStop hook is not installed.
+	SentinelService    string
+	SentinelMasterName string
+	SentinelPort       int
+	PreStopWaitSeconds int
 }
 
 type initContainerParameters struct {
@@ -506,7 +513,16 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 		containerDefinition[0].VolumeMounts = append(containerDefinition[0].VolumeMounts, generateConfigVolumeMount(common.VolumeNameConfig))
 	}
 
-	if preStopCmd := GeneratePreStopCommand(containerParams.Role, enableAuth, enableTLS); preStopCmd != "" {
+	preStopCfg := PreStopConfig{
+		Role:               containerParams.Role,
+		EnableAuth:         enableAuth,
+		EnableTLS:          enableTLS,
+		SentinelService:    containerParams.SentinelService,
+		SentinelMasterName: containerParams.SentinelMasterName,
+		SentinelPort:       containerParams.SentinelPort,
+		WaitSeconds:        containerParams.PreStopWaitSeconds,
+	}
+	if preStopCmd := GeneratePreStopCommand(preStopCfg); preStopCmd != "" {
 		containerDefinition[0].Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
@@ -563,19 +579,63 @@ func generateContainerDef(name string, containerParams containerParameters, clus
 	return containerDefinition
 }
 
-// GeneratePreStopCommand generates the preStop script based on the Redis role.
-// Only "cluster" role is supported for now; other roles return an empty string.
-func GeneratePreStopCommand(role string, enableAuth, enableTLS bool) string {
-	authArgs, tlsArgs := GenerateAuthAndTLSArgs(enableAuth, enableTLS)
+// PreStopConfig holds the inputs needed to render a container preStop hook.
+type PreStopConfig struct {
+	Role       string
+	EnableAuth bool
+	EnableTLS  bool
+	// SentinelService, SentinelMasterName and SentinelPort describe the
+	// Sentinel that manages failover for the "replication" role. They must be
+	// sourced from the actual (embedded) Sentinel config rather than derived in
+	// shell. When SentinelService is empty the replication hook is disabled, so
+	// non-Sentinel replication deployments never get a hook that would block on
+	// a non-existent service.
+	SentinelService    string
+	SentinelMasterName string
+	SentinelPort       int
+	// WaitSeconds bounds how long the replication hook waits for the local node
+	// to be demoted to a slave. It is kept below terminationGracePeriodSeconds
+	// so the hook returns before the kubelet sends SIGKILL.
+	WaitSeconds int
+}
 
-	switch role {
+// GeneratePreStopCommand generates the preStop script based on the Redis role.
+// "cluster" triggers a CLUSTER FAILOVER to the best slave; "replication"
+// triggers a Sentinel failover, but only when a Sentinel service is configured.
+// All other roles (and Sentinel-less replication) return an empty string.
+func GeneratePreStopCommand(cfg PreStopConfig) string {
+	authArgs, tlsArgs := GenerateAuthAndTLSArgs(cfg.EnableAuth, cfg.EnableTLS)
+
+	switch cfg.Role {
 	case "cluster":
 		return generateClusterPreStop(authArgs, tlsArgs)
 	case "replication":
-		return generateReplicationPreStop(authArgs, tlsArgs)
+		// Without a Sentinel managing failover there is nothing to fail over
+		// to; installing the hook would make every master termination block on
+		// a redis-cli call to a service that does not exist.
+		if cfg.SentinelService == "" {
+			return ""
+		}
+		return generateReplicationPreStop(authArgs, tlsArgs, cfg)
 	default:
 		return ""
 	}
+}
+
+// replicationPreStopWaitSeconds bounds the demotion wait so the preStop hook
+// returns with headroom before terminationGracePeriodSeconds elapses, leaving
+// the kubelet time to deliver SIGTERM and let Redis shut down cleanly instead
+// of being SIGKILLed mid-failover.
+func replicationPreStopWaitSeconds(gracePeriodSeconds *int64) int {
+	const (
+		defaultGracePeriodSeconds = 30
+		headroomSeconds           = 10
+	)
+	grace := int64(defaultGracePeriodSeconds)
+	if gracePeriodSeconds != nil && *gracePeriodSeconds > 0 {
+		grace = *gracePeriodSeconds
+	}
+	return int(max(grace-headroomSeconds, 1))
 }
 
 // GenerateAuthAndTLSArgs constructs authentication and TLS arguments for redis-cli.
@@ -622,26 +682,33 @@ fi`, authArgs, tlsArgs, authArgs, tlsArgs, authArgs, tlsArgs)
 }
 
 // generateReplicationPreStop generates the preStop script for Redis replication mode.
-// It checks if this pod is the master, and if so, triggers a Sentinel failover
-// before allowing the pod to terminate, preventing unnecessary downtime.
-func generateReplicationPreStop(authArgs, tlsArgs string) string {
+// It checks if this pod is the master, and if so, asks Sentinel to fail over to a
+// replica before allowing the pod to terminate, preventing unnecessary downtime.
+//
+// The Sentinel service, master group name and port are injected from the actual
+// (embedded) Sentinel configuration rather than derived in shell, so they stay
+// correct regardless of the resource name or topology. The demotion wait is
+// bounded by cfg.WaitSeconds so the hook returns before the grace period expires.
+func generateReplicationPreStop(authArgs, tlsArgs string, cfg PreStopConfig) string {
+	sentinelPort := cfg.SentinelPort
+	if sentinelPort == 0 {
+		sentinelPort = 26379
+	}
+	waitSeconds := max(cfg.WaitSeconds, 1)
 	return fmt.Sprintf(`#!/bin/sh
-ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s --no-auth-warning info replication | awk -F: '/role:master/ {print "master"}')
+ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '/role:master/ {print "master"}')
 
 if [ "$ROLE" = "master" ]; then
-    CR_NAME=$(echo $HOSTNAME | sed 's/-[0-9]*$//')
-    SENTINEL_SVC="${CR_NAME}-s-hl"
+    redis-cli -h "%s" -p %d SENTINEL FAILOVER %s
 
-    redis-cli -h "$SENTINEL_SVC" -p 26379 SENTINEL FAILOVER mymaster
-
-    for i in $(seq 1 30); do
-        NEW_ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s --no-auth-warning info replication | awk -F: '/role:slave/ {print "slave"}')
+    for i in $(seq 1 %d); do
+        NEW_ROLE=$(redis-cli -h $(hostname) -p ${REDIS_PORT} %s %s info replication | awk -F: '/role:slave/ {print "slave"}')
         if [ "$NEW_ROLE" = "slave" ]; then
             break
         fi
         sleep 1
     done
-fi`, authArgs, tlsArgs, authArgs, tlsArgs)
+fi`, authArgs, tlsArgs, cfg.SentinelService, sentinelPort, cfg.SentinelMasterName, waitSeconds, authArgs, tlsArgs)
 }
 
 func generateInitContainerDef(role, name string, initcontainerParams initContainerParameters, externalConfig *string, mountpath []corev1.VolumeMount, containerParams containerParameters, clusterVersion *string) []corev1.Container {

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -111,7 +111,7 @@ func TestGeneratePreStopCommand(t *testing.T) {
 		expectEmpty bool
 	}{
 		{"ClusterRole", "cluster", false},
-		{"ReplicationRole", "replication", true},
+		{"ReplicationRole", "replication", false},
 		{"SentinelRole", "sentinel", true},
 		{"StandaloneRole", "standalone", true},
 		{"UnknownRole", "unknown", true},

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -105,21 +105,34 @@ func TestStorageHasVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestGeneratePreStopCommand(t *testing.T) {
+	sentinelCfg := PreStopConfig{
+		Role:               "replication",
+		EnableAuth:         true,
+		EnableTLS:          true,
+		SentinelService:    "my-replication-s-hl",
+		SentinelMasterName: "mymaster",
+		SentinelPort:       26379,
+		WaitSeconds:        20,
+	}
+
 	tests := []struct {
 		name        string
-		role        string
+		cfg         PreStopConfig
 		expectEmpty bool
 	}{
-		{"ClusterRole", "cluster", false},
-		{"ReplicationRole", "replication", false},
-		{"SentinelRole", "sentinel", true},
-		{"StandaloneRole", "standalone", true},
-		{"UnknownRole", "unknown", true},
+		{"ClusterRole", PreStopConfig{Role: "cluster", EnableAuth: true, EnableTLS: true}, false},
+		{"ReplicationWithSentinel", sentinelCfg, false},
+		// Embedded Sentinel disabled => no service => no hook, so master
+		// terminations of non-Sentinel replication never block on a missing svc.
+		{"ReplicationWithoutSentinel", PreStopConfig{Role: "replication", EnableAuth: true, EnableTLS: true}, true},
+		{"SentinelRole", PreStopConfig{Role: "sentinel"}, true},
+		{"StandaloneRole", PreStopConfig{Role: "standalone"}, true},
+		{"UnknownRole", PreStopConfig{Role: "unknown"}, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GeneratePreStopCommand(tt.role, true, true)
+			result := GeneratePreStopCommand(tt.cfg)
 			if (result == "") != tt.expectEmpty {
 				t.Errorf("expected empty: %v, got: %q", tt.expectEmpty, result)
 			}
@@ -154,6 +167,52 @@ func TestGenerateContainerDefAddsMaxMemoryEnv(t *testing.T) {
 	require.Len(t, containers, 1)
 	expectedValue := strconv.FormatInt(memLimit.Value()*int64(percent)/100, 10)
 	assert.Contains(t, containers[0].Env, corev1.EnvVar{Name: consts.ENV_KEY_REDIS_MAX_MEMORY, Value: expectedValue})
+}
+
+func TestGenerateReplicationPreStopContent(t *testing.T) {
+	cfg := PreStopConfig{
+		Role:               "replication",
+		EnableAuth:         true,
+		EnableTLS:          false,
+		SentinelService:    "my-replication-s-hl",
+		SentinelMasterName: "customMaster",
+		SentinelPort:       26379,
+		WaitSeconds:        20,
+	}
+
+	script := GeneratePreStopCommand(cfg)
+	require.NotEmpty(t, script)
+
+	// Failover targets the injected service, port and master group rather than
+	// values derived in shell, so they stay correct across names/topologies.
+	assert.Contains(t, script, `redis-cli -h "my-replication-s-hl" -p 26379 SENTINEL FAILOVER customMaster`)
+	// The demotion wait is bounded by WaitSeconds, not a hardcoded 30.
+	assert.Contains(t, script, "seq 1 20")
+
+	// No shell-side derivation of the service name or master group remains.
+	assert.NotContains(t, script, "CR_NAME")
+	assert.NotContains(t, script, "${CR_NAME}-s-hl")
+	assert.NotContains(t, script, "FAILOVER mymaster")
+	// Aligned with the cluster hook, which does not pass --no-auth-warning.
+	assert.NotContains(t, script, "--no-auth-warning")
+}
+
+func TestReplicationPreStopWaitSeconds(t *testing.T) {
+	tests := []struct {
+		name  string
+		grace *int64
+		want  int
+	}{
+		{"NilGraceUsesDefault", nil, 20},
+		{"ZeroGraceUsesDefault", ptr.To(int64(0)), 20},
+		{"LargerGraceGetsMoreHeadroom", ptr.To(int64(60)), 50},
+		{"SmallGraceClampedToOne", ptr.To(int64(5)), 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, replicationPreStopWaitSeconds(tt.grace))
+		})
+	}
 }
 
 func TestGetVolumeMount(t *testing.T) {


### PR DESCRIPTION
  **Description**

  Replication mode pods currently have no preStop lifecycle hook, unlike cluster mode.
  When a master pod is terminated during a rolling update or node drain, clients experience
  downtime until Sentinel detects the failure and triggers a failover (up to `down-after-milliseconds`).
  This adds a preStop hook for the `replication` role following the same pattern as the existing
  cluster mode hook in `generateClusterPreStop`. The hook:
  1. Checks if the terminating pod is the master via `INFO replication`
  2. Derives the Sentinel headless service from the pod hostname
  3. Triggers `SENTINEL FAILOVER mymaster`
  4. Waits up to 30 seconds for the role to change to slave
  Replica pods skip the hook entirely.


  **Type of change**

  * New feature (non-breaking change which adds functionality)

  **Checklist**

  - [x] Tests have been added/modified and all tests pass.
  - [x] Functionality/bugs have been confirmed to be unchanged or fixed.
  - [x] I have performed a self-review of my own code.
  - [ ] Documentation has been updated or added where necessary.

  **Additional Context**

  In production we observed that every rolling restart of a RedisReplication StatefulSet causes
  client downtime because the master pod is killed without failover. This is particularly
  impactful for large datasets where replica startup takes 30-40 minutes, as Sentinel may
  trigger unnecessary full resyncs while the topology is unstable.