### PR TITLE
fix: pass sentinel config env vars for embedded sentinel in RedisReplication

### DIFF
--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -91,6 +91,15 @@ func GenerateConfig() error {
 				cfg.Append("cluster-announce-hostname", fqdnName)
 			}
 		}
+	} else if clusterMode == "replication" {
+		if util.CoalesceEnv1("ANNOUNCE_HOSTNAME", "no") == "yes" {
+			fqdnName, err := fqdn.FqdnHostname()
+			if err != nil {
+				log.Printf("Warning: Failed to get FQDN: %v", err)
+			} else {
+				cfg.Append("replica-announce-ip", fqdnName)
+			}
+		}
 	} else {
 		fmt.Println("Setting up redis in standalone mode")
 	}

--- a/internal/controller/redisreplication/redisreplication_sentinel.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel.go
@@ -93,6 +93,11 @@ func buildSentinelContainer(rr *rrvb2.RedisReplication) corev1.Container {
 func buildSentinelEnv(rr *rrvb2.RedisReplication) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{Name: "QUORUM", Value: fmt.Sprintf("%d", rr.Spec.Sentinel.Size/2+1)},
+		{Name: "DOWN_AFTER_MILLISECONDS", Value: rr.Spec.Sentinel.DownAfterMilliseconds},
+		{Name: "FAILOVER_TIMEOUT", Value: rr.Spec.Sentinel.FailoverTimeout},
+		{Name: "PARALLEL_SYNCS", Value: rr.Spec.Sentinel.ParallelSyncs},
+		{Name: "RESOLVE_HOSTNAMES", Value: rr.Spec.Sentinel.ResolveHostnames},
+		{Name: "ANNOUNCE_HOSTNAMES", Value: rr.Spec.Sentinel.AnnounceHostnames},
 	}
 	if rr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
 		envs = append(envs, corev1.EnvVar{

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,7 +149,16 @@ func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) contain
 	if cr.Spec.RedisConfig != nil {
 		containerProp.MaxMemoryPercentOfLimit = cr.Spec.RedisConfig.MaxMemoryPercentOfLimit
 	}
-	if cr.Spec.EnvVars != nil {
+	if cr.Spec.Sentinel != nil && cr.Spec.Sentinel.AnnounceHostnames == "yes" {
+		announceEnv := corev1.EnvVar{Name: "ANNOUNCE_HOSTNAME", Value: "yes"}
+		if cr.Spec.EnvVars != nil {
+			envs := append(*cr.Spec.EnvVars, announceEnv)
+			containerProp.EnvVars = &envs
+		} else {
+			envs := []corev1.EnvVar{announceEnv}
+			containerProp.EnvVars = &envs
+		}
+	} else if cr.Spec.EnvVars != nil {
 		containerProp.EnvVars = cr.Spec.EnvVars
 	}
 	if cr.Spec.Storage != nil {


### PR DESCRIPTION
  **Description**

  The embedded Sentinel in RedisReplication does not pass through several SentinelConfig
  fields as environment variables, unlike the standalone RedisSentinel controller. This means
  `downAfterMilliseconds`, `failoverTimeout`, `parallelSyncs`, `resolveHostnames`, and
  `announceHostnames` are all ignored for embedded Sentinel deployments despite being
  defined in the CRD.
  Additionally, when `announceHostnames` is enabled, Redis replication pods need to set
  `replica-announce-ip` to their FQDN so that Sentinel tracks stable DNS names instead
  of ephemeral pod IPs. Without this, pod restarts cause Sentinel to cache stale IPs,
  leading to split-brain scenarios and failed failovers.
  This PR:
  1. Passes all SentinelConfig env vars in `buildSentinelEnv` for embedded Sentinel
  2. Sets `ANNOUNCE_HOSTNAME=yes` env var on Redis containers when announceHostnames is enabled
  3. Configures `replica-announce-ip` to the pod FQDN in the Redis bootstrap config


  **Type of change**

  * Bug fix (non-breaking change which fixes an issue)
  
  **Checklist**

  - [x] Tests have been added/modified and all tests pass.
  - [x] Functionality/bugs have been confirmed to be unchanged or fixed.
  - [x] I have performed a self-review of my own code.
  - [ ] Documentation has been updated or added where necessary.

  **Additional Context**

  In production, every pod restart in a RedisReplication cluster causes Sentinel to lose
  track of replicas because it caches pod IPs that change on restart. This leads to
  split-brain (all pods becoming master) and hours-long full resyncs. Enabling
  `resolveHostnames`/`announceHostnames` via the CRD has no effect because the embedded
  Sentinel ignores these fields.