### PR TITLE
fix: fall back to system trust store when CA cert is absent from TLS …

### DIFF
--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -108,7 +108,11 @@ func GenerateConfig() error {
 	if tlsMode == "true" {
 		cfg.Append("tls-cert-file", util.CoalesceEnv1("REDIS_TLS_CERT", ""))
 		cfg.Append("tls-key-file", util.CoalesceEnv1("REDIS_TLS_CERT_KEY", ""))
-		cfg.Append("tls-ca-cert-file", util.CoalesceEnv1("REDIS_TLS_CA_CERT", ""))
+		if caCert := util.CoalesceEnv1("REDIS_TLS_CA_CERT", ""); caCert != "" {
+			cfg.Append("tls-ca-cert-file", caCert)
+		} else {
+			cfg.Append("tls-ca-cert-file", "/etc/ssl/certs/ca-certificates.crt")
+		}
 		cfg.Append("tls-auth-clients", "optional")
 		cfg.Append("tls-replication", "yes")
 

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -32,7 +32,8 @@ pidfile /var/run/redis.pid
 
 // GenerateConfig generates Redis configuration file
 func GenerateConfig() error {
-	cfg := agentutil.NewConfig("/etc/redis/redis.conf", defaultRedisConfig)
+	confPath := util.CoalesceEnv1("REDIS_CONFIG_FILE", "/etc/redis/redis.conf")
+	cfg := agentutil.NewConfig(confPath, defaultRedisConfig)
 
 	var (
 		persistenceEnabled = util.CoalesceEnv1("PERSISTENCE_ENABLED", "false")
@@ -110,8 +111,6 @@ func GenerateConfig() error {
 		cfg.Append("tls-key-file", util.CoalesceEnv1("REDIS_TLS_CERT_KEY", ""))
 		if caCert := util.CoalesceEnv1("REDIS_TLS_CA_CERT", ""); caCert != "" {
 			cfg.Append("tls-ca-cert-file", caCert)
-		} else {
-			cfg.Append("tls-ca-cert-file", "/etc/ssl/certs/ca-certificates.crt")
 		}
 		cfg.Append("tls-auth-clients", "optional")
 		cfg.Append("tls-replication", "yes")

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -4,7 +4,110 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_TLSCAFallback_EnvLogic(t *testing.T) {
+	// Tests the CA cert selection logic used in GenerateConfig TLS block:
+	// - REDIS_TLS_CA_CERT set   → use that path
+	// - REDIS_TLS_CA_CERT unset → fall back to system trust store
+	tests := []struct {
+		name        string
+		caCertEnv   string
+		expectedCA  string
+	}{
+		{
+			name:       "explicit CA cert env set - uses provided path",
+			caCertEnv:  "/tls/ca.crt",
+			expectedCA: "/tls/ca.crt",
+		},
+		{
+			name:       "CA cert env not set - falls back to system trust store",
+			caCertEnv:  "",
+			expectedCA: "/etc/ssl/certs/ca-certificates.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.caCertEnv != "" {
+				t.Setenv("REDIS_TLS_CA_CERT", tt.caCertEnv)
+			} else {
+				os.Unsetenv("REDIS_TLS_CA_CERT")
+			}
+
+			// Mirror the logic from GenerateConfig TLS block
+			caCert := os.Getenv("REDIS_TLS_CA_CERT")
+			var resolvedCA string
+			if caCert != "" {
+				resolvedCA = caCert
+			} else {
+				resolvedCA = "/etc/ssl/certs/ca-certificates.crt"
+			}
+
+			assert.Equal(t, tt.expectedCA, resolvedCA)
+		})
+	}
+}
+
+func Test_GenerateConfig_TLS_WritesCorrectCALine(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := tmpDir + "/redis.conf"
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		expectInConf string
+	}{
+		{
+			name: "with explicit CA - writes explicit CA path",
+			envVars: map[string]string{
+				"TLS_MODE":           "true",
+				"REDIS_TLS_CERT":     "/tls/tls.crt",
+				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
+				"REDIS_TLS_CA_CERT":  "/tls/ca.crt",
+				"REDIS_CONFIG_FILE":  confPath,
+			},
+			expectInConf: "tls-ca-cert-file /tls/ca.crt",
+		},
+		{
+			name: "without CA - writes system trust store path",
+			envVars: map[string]string{
+				"TLS_MODE":          "true",
+				"REDIS_TLS_CERT":    "/tls/tls.crt",
+				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
+				"REDIS_CONFIG_FILE": confPath,
+			},
+			expectInConf: "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			// Unset CA cert if not in test case
+			if _, ok := tt.envVars["REDIS_TLS_CA_CERT"]; !ok {
+				os.Unsetenv("REDIS_TLS_CA_CERT")
+			}
+
+			// Mirror the CA resolution logic
+			caCert := os.Getenv("REDIS_TLS_CA_CERT")
+			var caLine string
+			if caCert != "" {
+				caLine = "tls-ca-cert-file " + caCert
+			} else {
+				caLine = "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt"
+			}
+
+			require.Equal(t, tt.expectInConf, caLine,
+				"CA cert line in config should match expected value")
+		})
+	}
+}
 
 func Test_updateMyselfIP(t *testing.T) {
 	testData := `7a6b5f4f99496c97f4e32c30c077aa95cab92664 10.244.0.246:0@16379,,tls-port=6379,shard-id=a03445a0d3f6d405af261041e0cb77a8a176f42b slave b66f2fa597eeda567cf05f3701419be9a3b2f50e 0 1756463509000 1 connected

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,102 +10,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_TLSCAFallback_EnvLogic(t *testing.T) {
-	// Tests the CA cert selection logic used in GenerateConfig TLS block:
-	// - REDIS_TLS_CA_CERT set   → use that path
-	// - REDIS_TLS_CA_CERT unset → fall back to system trust store
+func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 	tests := []struct {
-		name        string
-		caCertEnv   string
-		expectedCA  string
+		name           string
+		caCertEnv      string
+		setCACertEnv   bool
+		expectCALine   bool
+		expectedCAPath string
 	}{
 		{
-			name:       "explicit CA cert env set - uses provided path",
-			caCertEnv:  "/tls/ca.crt",
-			expectedCA: "/tls/ca.crt",
+			name:           "explicit CA cert env set - writes provided path",
+			caCertEnv:      "/tls/ca.crt",
+			setCACertEnv:   true,
+			expectCALine:   true,
+			expectedCAPath: "/tls/ca.crt",
 		},
 		{
-			name:       "CA cert env not set - falls back to system trust store",
-			caCertEnv:  "",
-			expectedCA: "/etc/ssl/certs/ca-certificates.crt",
+			name:         "CA cert env not set - omits tls-ca-cert-file",
+			setCACertEnv: false,
+			expectCALine: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.caCertEnv != "" {
+			confPath := filepath.Join(t.TempDir(), "redis.conf")
+
+			t.Setenv("REDIS_CONFIG_FILE", confPath)
+			t.Setenv("TLS_MODE", "true")
+			t.Setenv("REDIS_TLS_CERT", "/tls/tls.crt")
+			t.Setenv("REDIS_TLS_CERT_KEY", "/tls/tls.key")
+			// Keep the run in standalone mode so GenerateConfig does not try to
+			// reach the network / read nodes.conf for cluster bootstrapping.
+			t.Setenv("SETUP_MODE", "standalone")
+			if tt.setCACertEnv {
 				t.Setenv("REDIS_TLS_CA_CERT", tt.caCertEnv)
 			} else {
 				os.Unsetenv("REDIS_TLS_CA_CERT")
 			}
 
-			// Mirror the logic from GenerateConfig TLS block
-			caCert := os.Getenv("REDIS_TLS_CA_CERT")
-			var resolvedCA string
-			if caCert != "" {
-				resolvedCA = caCert
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			// TLS should always be configured when TLS_MODE is true.
+			assert.Contains(t, conf, "tls-cert-file /tls/tls.crt")
+			assert.Contains(t, conf, "tls-key-file /tls/tls.key")
+
+			if tt.expectCALine {
+				assert.Contains(t, conf, "tls-ca-cert-file "+tt.expectedCAPath)
 			} else {
-				resolvedCA = "/etc/ssl/certs/ca-certificates.crt"
+				assert.NotContains(t, conf, "tls-ca-cert-file")
 			}
-
-			assert.Equal(t, tt.expectedCA, resolvedCA)
-		})
-	}
-}
-
-func Test_GenerateConfig_TLS_WritesCorrectCALine(t *testing.T) {
-	tmpDir := t.TempDir()
-	confPath := tmpDir + "/redis.conf"
-
-	tests := []struct {
-		name        string
-		envVars     map[string]string
-		expectInConf string
-	}{
-		{
-			name: "with explicit CA - writes explicit CA path",
-			envVars: map[string]string{
-				"TLS_MODE":           "true",
-				"REDIS_TLS_CERT":     "/tls/tls.crt",
-				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
-				"REDIS_TLS_CA_CERT":  "/tls/ca.crt",
-				"REDIS_CONFIG_FILE":  confPath,
-			},
-			expectInConf: "tls-ca-cert-file /tls/ca.crt",
-		},
-		{
-			name: "without CA - writes system trust store path",
-			envVars: map[string]string{
-				"TLS_MODE":          "true",
-				"REDIS_TLS_CERT":    "/tls/tls.crt",
-				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
-				"REDIS_CONFIG_FILE": confPath,
-			},
-			expectInConf: "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.envVars {
-				t.Setenv(k, v)
-			}
-			// Unset CA cert if not in test case
-			if _, ok := tt.envVars["REDIS_TLS_CA_CERT"]; !ok {
-				os.Unsetenv("REDIS_TLS_CA_CERT")
-			}
-
-			// Mirror the CA resolution logic
-			caCert := os.Getenv("REDIS_TLS_CA_CERT")
-			var caLine string
-			if caCert != "" {
-				caLine = "tls-ca-cert-file " + caCert
-			} else {
-				caLine = "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt"
-			}
-
-			require.Equal(t, tt.expectInConf, caLine,
-				"CA cert line in config should match expected value")
 		})
 	}
 }

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -109,7 +109,11 @@ func GenerateConfig() error {
 			cfg.Append("tls-port", "26379")
 			cfg.Append("tls-cert-file", redisTLSCert)
 			cfg.Append("tls-key-file", redisTLSCertKey)
-			cfg.Append("tls-ca-cert-file", redisTLSCACert)
+			if redisTLSCACert != "" {
+				cfg.Append("tls-ca-cert-file", redisTLSCACert)
+			} else {
+				cfg.Append("tls-ca-cert-file", "/etc/ssl/certs/ca-certificates.crt")
+			}
 			cfg.Append("tls-auth-clients", "optional")
 			// Sentinel should use tls for replication connection.
 			cfg.Append("tls-replication", "yes")

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -28,7 +28,8 @@ sentinel deny-scripts-reconfig yes
 `
 
 func GenerateConfig() error {
-	cfg := agentutil.NewConfig("/etc/redis/sentinel.conf", defaultSentinelConfig)
+	confPath, _ := util.CoalesceEnv("SENTINEL_CONFIG_FILE", "/etc/redis/sentinel.conf")
+	cfg := agentutil.NewConfig(confPath, defaultSentinelConfig)
 
 	// set_sentinel_password
 	{
@@ -111,8 +112,6 @@ func GenerateConfig() error {
 			cfg.Append("tls-key-file", redisTLSCertKey)
 			if redisTLSCACert != "" {
 				cfg.Append("tls-ca-cert-file", redisTLSCACert)
-			} else {
-				cfg.Append("tls-ca-cert-file", "/etc/ssl/certs/ca-certificates.crt")
 			}
 			cfg.Append("tls-auth-clients", "optional")
 			// Sentinel should use tls for replication connection.

--- a/internal/agent/bootstrap/sentinel/config_test.go
+++ b/internal/agent/bootstrap/sentinel/config_test.go
@@ -1,0 +1,104 @@
+package bootstrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SentinelTLSCAFallback_EnvLogic(t *testing.T) {
+	// Tests the CA cert selection logic used in sentinel GenerateConfig TLS block:
+	// - REDIS_TLS_CA_CERT set   → use that path
+	// - REDIS_TLS_CA_CERT unset → fall back to system trust store
+	tests := []struct {
+		name       string
+		caCertEnv  string
+		expectedCA string
+	}{
+		{
+			name:       "explicit CA cert env set - uses provided path",
+			caCertEnv:  "/tls/ca.crt",
+			expectedCA: "/tls/ca.crt",
+		},
+		{
+			name:       "CA cert env not set - falls back to system trust store",
+			caCertEnv:  "",
+			expectedCA: "/etc/ssl/certs/ca-certificates.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.caCertEnv != "" {
+				t.Setenv("REDIS_TLS_CA_CERT", tt.caCertEnv)
+			} else {
+				os.Unsetenv("REDIS_TLS_CA_CERT")
+			}
+
+			// Mirror the logic from sentinel GenerateConfig TLS block
+			redisTLSCACert := os.Getenv("REDIS_TLS_CA_CERT")
+			var resolvedCA string
+			if redisTLSCACert != "" {
+				resolvedCA = redisTLSCACert
+			} else {
+				resolvedCA = "/etc/ssl/certs/ca-certificates.crt"
+			}
+
+			assert.Equal(t, tt.expectedCA, resolvedCA,
+				"Sentinel CA cert path should match expected value")
+		})
+	}
+}
+
+func Test_SentinelTLSMode_CALineSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		envVars      map[string]string
+		expectCALine string
+	}{
+		{
+			name: "TLS mode with explicit CA - uses provided CA path",
+			envVars: map[string]string{
+				"TLS_MODE":           "true",
+				"REDIS_TLS_CERT":     "/tls/tls.crt",
+				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
+				"REDIS_TLS_CA_CERT":  "/tls/ca.crt",
+			},
+			expectCALine: "tls-ca-cert-file /tls/ca.crt",
+		},
+		{
+			name: "TLS mode without CA - falls back to system trust store",
+			envVars: map[string]string{
+				"TLS_MODE":           "true",
+				"REDIS_TLS_CERT":     "/tls/tls.crt",
+				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
+				// REDIS_TLS_CA_CERT intentionally not set
+			},
+			expectCALine: "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			if _, ok := tt.envVars["REDIS_TLS_CA_CERT"]; !ok {
+				os.Unsetenv("REDIS_TLS_CA_CERT")
+			}
+
+			// Mirror sentinel TLS block CA resolution
+			redisTLSCACert := os.Getenv("REDIS_TLS_CA_CERT")
+			var caLine string
+			if redisTLSCACert != "" {
+				caLine = "tls-ca-cert-file " + redisTLSCACert
+			} else {
+				caLine = "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt"
+			}
+
+			assert.Equal(t, tt.expectCALine, caLine,
+				"Sentinel TLS CA line should match expected value")
+		})
+	}
+}

--- a/internal/agent/bootstrap/sentinel/config_test.go
+++ b/internal/agent/bootstrap/sentinel/config_test.go
@@ -2,103 +2,64 @@ package bootstrap
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_SentinelTLSCAFallback_EnvLogic(t *testing.T) {
-	// Tests the CA cert selection logic used in sentinel GenerateConfig TLS block:
-	// - REDIS_TLS_CA_CERT set   → use that path
-	// - REDIS_TLS_CA_CERT unset → fall back to system trust store
+func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 	tests := []struct {
-		name       string
-		caCertEnv  string
-		expectedCA string
+		name           string
+		caCertEnv      string
+		setCACertEnv   bool
+		expectCALine   bool
+		expectedCAPath string
 	}{
 		{
-			name:       "explicit CA cert env set - uses provided path",
-			caCertEnv:  "/tls/ca.crt",
-			expectedCA: "/tls/ca.crt",
+			name:           "explicit CA cert env set - writes provided path",
+			caCertEnv:      "/tls/ca.crt",
+			setCACertEnv:   true,
+			expectCALine:   true,
+			expectedCAPath: "/tls/ca.crt",
 		},
 		{
-			name:       "CA cert env not set - falls back to system trust store",
-			caCertEnv:  "",
-			expectedCA: "/etc/ssl/certs/ca-certificates.crt",
+			name:         "CA cert env not set - omits tls-ca-cert-file",
+			setCACertEnv: false,
+			expectCALine: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.caCertEnv != "" {
+			confPath := filepath.Join(t.TempDir(), "sentinel.conf")
+
+			t.Setenv("SENTINEL_CONFIG_FILE", confPath)
+			t.Setenv("TLS_MODE", "true")
+			t.Setenv("REDIS_TLS_CERT", "/tls/tls.crt")
+			t.Setenv("REDIS_TLS_CERT_KEY", "/tls/tls.key")
+			if tt.setCACertEnv {
 				t.Setenv("REDIS_TLS_CA_CERT", tt.caCertEnv)
 			} else {
 				os.Unsetenv("REDIS_TLS_CA_CERT")
 			}
 
-			// Mirror the logic from sentinel GenerateConfig TLS block
-			redisTLSCACert := os.Getenv("REDIS_TLS_CA_CERT")
-			var resolvedCA string
-			if redisTLSCACert != "" {
-				resolvedCA = redisTLSCACert
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			// TLS should always be configured when TLS_MODE is true.
+			assert.Contains(t, conf, "tls-cert-file /tls/tls.crt")
+			assert.Contains(t, conf, "tls-key-file /tls/tls.key")
+
+			if tt.expectCALine {
+				assert.Contains(t, conf, "tls-ca-cert-file "+tt.expectedCAPath)
 			} else {
-				resolvedCA = "/etc/ssl/certs/ca-certificates.crt"
+				assert.NotContains(t, conf, "tls-ca-cert-file")
 			}
-
-			assert.Equal(t, tt.expectedCA, resolvedCA,
-				"Sentinel CA cert path should match expected value")
-		})
-	}
-}
-
-func Test_SentinelTLSMode_CALineSelection(t *testing.T) {
-	tests := []struct {
-		name         string
-		envVars      map[string]string
-		expectCALine string
-	}{
-		{
-			name: "TLS mode with explicit CA - uses provided CA path",
-			envVars: map[string]string{
-				"TLS_MODE":           "true",
-				"REDIS_TLS_CERT":     "/tls/tls.crt",
-				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
-				"REDIS_TLS_CA_CERT":  "/tls/ca.crt",
-			},
-			expectCALine: "tls-ca-cert-file /tls/ca.crt",
-		},
-		{
-			name: "TLS mode without CA - falls back to system trust store",
-			envVars: map[string]string{
-				"TLS_MODE":           "true",
-				"REDIS_TLS_CERT":     "/tls/tls.crt",
-				"REDIS_TLS_CERT_KEY": "/tls/tls.key",
-				// REDIS_TLS_CA_CERT intentionally not set
-			},
-			expectCALine: "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.envVars {
-				t.Setenv(k, v)
-			}
-			if _, ok := tt.envVars["REDIS_TLS_CA_CERT"]; !ok {
-				os.Unsetenv("REDIS_TLS_CA_CERT")
-			}
-
-			// Mirror sentinel TLS block CA resolution
-			redisTLSCACert := os.Getenv("REDIS_TLS_CA_CERT")
-			var caLine string
-			if redisTLSCACert != "" {
-				caLine = "tls-ca-cert-file " + redisTLSCACert
-			} else {
-				caLine = "tls-ca-cert-file /etc/ssl/certs/ca-certificates.crt"
-			}
-
-			assert.Equal(t, tt.expectCALine, caLine,
-				"Sentinel TLS CA line should match expected value")
 		})
 	}
 }

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -216,22 +216,46 @@ func (h *healer) getSentinelPods(ctx context.Context, rs *rsvb2.RedisSentinel) (
 	return pods, nil
 }
 
+func tlsKeyOrDefault(override, fallback string) string {
+	if override != "" {
+		return override
+	}
+	return fallback
+}
+
+func getTLSSecretKeys(tlsConfig *commonapi.TLSConfig) (caFile, certFile, keyFile string) {
+	caFile = "ca.crt"
+	certFile = "tls.crt"
+	keyFile = "tls.key"
+	if tlsConfig == nil {
+		return caFile, certFile, keyFile
+	}
+	caFile = tlsKeyOrDefault(tlsConfig.CaCertFile, caFile)
+	certFile = tlsKeyOrDefault(tlsConfig.CertKeyFile, certFile)
+	keyFile = tlsKeyOrDefault(tlsConfig.KeyFile, keyFile)
+	return caFile, certFile, keyFile
+}
+
 // getRedisTLSConfig creates a TLS configuration for Redis connections
-func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespace, tlsSecretName string) *tls.Config {
-	// This is a wrapper to access the k8sutils internal function
-	// We'll implement a simplified version here for now
+func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespace string, tlsConfig *commonapi.TLSConfig) *tls.Config {
+	if tlsConfig == nil || tlsConfig.Secret.SecretName == "" {
+		return nil
+	}
+
+	tlsSecretName := tlsConfig.Secret.SecretName
 	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, tlsSecretName, metav1.GetOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed in getting TLS secret", "secretName", tlsSecretName, "namespace", namespace)
 		return nil
 	}
 
-	tlsClientCert, certExists := secret.Data["tls.crt"]
-	tlsClientKey, keyExists := secret.Data["tls.key"]
-	tlsCACert, caExists := secret.Data["ca.crt"]
+	caFile, certFile, keyFile := getTLSSecretKeys(tlsConfig)
+	tlsClientCert, certExists := secret.Data[certFile]
+	tlsClientKey, keyExists := secret.Data[keyFile]
+	tlsCACert, caExists := secret.Data[caFile]
 
-	if !certExists || !keyExists || !caExists {
-		log.FromContext(ctx).Error(fmt.Errorf("TLS secret missing required keys"), "TLS secret is missing required keys", "secretName", tlsSecretName)
+	if !certExists || !keyExists {
+		log.FromContext(ctx).Error(fmt.Errorf("TLS secret missing required cert/key"), "TLS secret is missing required cert/key", "secretName", tlsSecretName)
 		return nil
 	}
 
@@ -239,6 +263,20 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to load TLS key pair", "secretName", tlsSecretName)
 		return nil
+	}
+
+	if !caExists && tlsConfig.CaCertFile != "" {
+		log.FromContext(ctx).Error(fmt.Errorf("configured TLS CA key file is missing in the secret"), "TLS secret is missing configured CA key", "secretName", tlsSecretName, "caKeyFile", tlsConfig.CaCertFile)
+		return nil
+	}
+
+	if !caExists {
+		log.FromContext(ctx).V(1).Info("CA certificate not found in TLS secret, using system trust store", "secretName", tlsSecretName)
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+			// RootCAs: nil instructs Go to use the system trust store
+		}
 	}
 
 	caCertPool := x509.NewCertPool()
@@ -269,7 +307,7 @@ func createConnectionInfo(ctx context.Context, pod v1.Pod, password string, tlsC
 		serviceName := common.GetHeadlessServiceNameFromPodName(pod.Name)
 		connInfo.Host = fmt.Sprintf("%s.%s.%s.svc.%s", pod.Name, serviceName, namespace, envs.GetServiceDNSDomain())
 		// Get TLS configuration
-		tlsCfg := getRedisTLSConfig(ctx, k8sClient, namespace, tlsConfig.Secret.SecretName)
+		tlsCfg := getRedisTLSConfig(ctx, k8sClient, namespace, tlsConfig)
 		connInfo.TLSConfig = tlsCfg
 	}
 

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -272,23 +272,34 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 
 	if !caExists {
 		log.FromContext(ctx).V(1).Info("CA certificate not found in TLS secret, using system trust store", "secretName", tlsSecretName)
-		return &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
-			// RootCAs: nil instructs Go to use the system trust store
+		systemCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to load system certificate pool", "secretName", tlsSecretName)
+			return nil
 		}
+		return newTLSConfigVerifyingChainWithoutHostname(cert, systemCertPool)
 	}
 
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(tlsCACert)
 
+	return newTLSConfigVerifyingChainWithoutHostname(cert, caCertPool)
+}
+
+// newTLSConfigVerifyingChainWithoutHostname builds a client *tls.Config that
+// trusts the supplied root pool and verifies the peer certificate chain WITHOUT
+// checking the server name. The operator dials Redis pods by IP / pod DNS that
+// does not match the server certificate SNI, so Go's default hostname
+// verification is disabled (InsecureSkipVerify) and the chain is instead
+// validated by VerifyPeerCertificate against the provided roots.
+func newTLSConfigVerifyingChainWithoutHostname(cert tls.Certificate, rootCAs *x509.CertPool) *tls.Config {
 	return &tls.Config{
 		Certificates:       []tls.Certificate{cert},
-		RootCAs:            caCertPool,
+		RootCAs:            rootCAs,
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // skips default verification; chain re-verified without hostname below
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-			_, _, err := cryptutil.VerifyCertificateExceptServerName(rawCerts, &tls.Config{RootCAs: caCertPool})
+			_, _, err := cryptutil.VerifyCertificateExceptServerName(rawCerts, &tls.Config{RootCAs: rootCAs})
 			return err
 		},
 	}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -385,8 +385,11 @@ func getRedisTLSArgs(tlsConfig *commonapi.TLSConfig, clientHost string) []string
 	cmd := []string{}
 	if tlsConfig != nil {
 		cmd = append(cmd, "--tls")
-		cmd = append(cmd, "--cacert")
-		cmd = append(cmd, "/tls/ca.crt")
+		if tlsConfig.CaCertFile != "" {
+			caFile, _, _ := getTLSSecretKeys(tlsConfig)
+			cmd = append(cmd, "--cacert")
+			cmd = append(cmd, "/tls/"+caFile)
+		}
 		cmd = append(cmd, "--insecure")
 	}
 	return cmd
@@ -688,7 +691,7 @@ func configureRedisClient(ctx context.Context, client kubernetes.Interface, cr *
 		DB:       0,
 	}
 	if cr.Spec.TLS != nil {
-		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS.Secret.SecretName, redisInfo.PodName)
+		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS)
 	}
 	return redis.NewClient(opts)
 }
@@ -829,7 +832,7 @@ func configureRedisReplicationClientForAddress(ctx context.Context, client kuber
 		DB:       0,
 	}
 	if cr.Spec.TLS != nil {
-		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS.Secret.SecretName, redisInfo.PodName)
+		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS)
 	}
 	return redis.NewClient(opts)
 }

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -459,7 +459,10 @@ func TestExecuteSingleLeaderAddSlots(t *testing.T) {
 			}
 		}
 		if withTLS {
-			cr.Spec.TLS = &common.TLSConfig{}
+			// CaCertFile is set explicitly so getRedisTLSArgs emits --cacert;
+			// without an explicit CA the operator now relies on --insecure and
+			// the system trust store instead of passing a CA file.
+			cr.Spec.TLS = &common.TLSConfig{CaCertFile: "ca.crt"}
 		}
 		return cr
 	}

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -627,7 +627,15 @@ func TestGetRedisTLSArgs(t *testing.T) {
 			name:       "with TLS configuration",
 			tlsConfig:  &common.TLSConfig{},
 			clientHost: "redis-host",
-			expected:   []string{"--tls", "--cacert", "/tls/ca.crt", "--insecure"},
+			expected:   []string{"--tls", "--insecure"},
+		},
+		{
+			name: "with TLS and explicit CA configuration",
+			tlsConfig: &common.TLSConfig{
+				CaCertFile: "custom-ca.crt",
+			},
+			clientHost: "redis-host",
+			expected:   []string{"--tls", "--cacert", "/tls/custom-ca.crt", "--insecure"},
 		},
 		{
 			name:       "without TLS configuration",

--- a/internal/k8sutils/secrets.go
+++ b/internal/k8sutils/secrets.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 
+	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/cryptutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -30,19 +31,25 @@ func getRedisPassword(ctx context.Context, client kubernetes.Interface, namespac
 	return "", nil
 }
 
-func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespace, tlsSecretName, podName string) *tls.Config {
+func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespace string, tlsConfig *commonapi.TLSConfig) *tls.Config {
+	if tlsConfig == nil || tlsConfig.Secret.SecretName == "" {
+		return nil
+	}
+
+	tlsSecretName := tlsConfig.Secret.SecretName
 	secret, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), tlsSecretName, metav1.GetOptions{})
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "Failed in getting TLS secret", "secretName", tlsSecretName, "namespace", namespace)
 		return nil
 	}
 
-	tlsClientCert, certExists := secret.Data["tls.crt"]
-	tlsClientKey, keyExists := secret.Data["tls.key"]
-	tlsCaCertificate, caExists := secret.Data["ca.crt"]
+	caFile, certFile, keyFile := getTLSSecretKeys(tlsConfig)
+	tlsClientCert, certExists := secret.Data[certFile]
+	tlsClientKey, keyExists := secret.Data[keyFile]
+	tlsCaCertificate, caExists := secret.Data[caFile]
 
-	if !certExists || !keyExists || !caExists {
-		logf.FromContext(ctx).Error(errors.New("required TLS keys are missing in the secret"), "Missing TLS keys in the secret")
+	if !certExists || !keyExists {
+		logf.FromContext(ctx).Error(errors.New("required TLS cert or key is missing in the secret"), "Missing TLS cert/key in the secret")
 		return nil
 	}
 
@@ -52,10 +59,25 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 		return nil
 	}
 
+	// If user explicitly set CA key and it is missing, treat this as misconfiguration.
+	if !caExists && tlsConfig.CaCertFile != "" {
+		logf.FromContext(ctx).Error(errors.New("configured TLS CA key file is missing in the secret"), "Missing configured TLS CA in the secret", "caKeyFile", tlsConfig.CaCertFile)
+		return nil
+	}
+
+	if !caExists {
+		logf.FromContext(ctx).V(1).Info("CA certificate not found in TLS secret, using system trust store", "secretName", tlsSecretName)
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+			// RootCAs: nil instructs Go to use the system trust store
+		}
+	}
+
 	tlsCaCertificates := x509.NewCertPool()
 	ok := tlsCaCertificates.AppendCertsFromPEM(tlsCaCertificate)
 	if !ok {
-		logf.FromContext(ctx).Error(err, "Invalid CA Certificates", "secretName", tlsSecretName, "namespace", namespace)
+		logf.FromContext(ctx).Error(errors.New("invalid CA certificate"), "Invalid CA Certificates", "secretName", tlsSecretName, "namespace", namespace)
 		return nil
 	}
 

--- a/internal/k8sutils/secrets.go
+++ b/internal/k8sutils/secrets.go
@@ -67,11 +67,12 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 
 	if !caExists {
 		logf.FromContext(ctx).V(1).Info("CA certificate not found in TLS secret, using system trust store", "secretName", tlsSecretName)
-		return &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
-			// RootCAs: nil instructs Go to use the system trust store
+		systemCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to load system certificate pool", "secretName", tlsSecretName)
+			return nil
 		}
+		return newTLSConfigVerifyingChainWithoutHostname(cert, systemCertPool)
 	}
 
 	tlsCaCertificates := x509.NewCertPool()
@@ -81,14 +82,24 @@ func getRedisTLSConfig(ctx context.Context, client kubernetes.Interface, namespa
 		return nil
 	}
 
+	return newTLSConfigVerifyingChainWithoutHostname(cert, tlsCaCertificates)
+}
+
+// newTLSConfigVerifyingChainWithoutHostname builds a client *tls.Config that
+// trusts the supplied root pool and verifies the peer certificate chain WITHOUT
+// checking the server name. The operator dials Redis pods by IP / pod DNS that
+// does not match the server certificate SNI, so Go's default hostname
+// verification is disabled (InsecureSkipVerify) and the chain is instead
+// validated by VerifyPeerCertificate against the provided roots.
+func newTLSConfigVerifyingChainWithoutHostname(cert tls.Certificate, rootCAs *x509.CertPool) *tls.Config {
 	return &tls.Config{
 		Certificates:       []tls.Certificate{cert},
-		RootCAs:            tlsCaCertificates,
+		RootCAs:            rootCAs,
 		MinVersion:         tls.VersionTLS12,
 		ClientAuth:         tls.NoClientCert,
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // skips default verification; chain re-verified without hostname below
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-			_, _, err := cryptutil.VerifyCertificateExceptServerName(rawCerts, &tls.Config{RootCAs: tlsCaCertificates})
+			_, _, err := cryptutil.VerifyCertificateExceptServerName(rawCerts, &tls.Config{RootCAs: rootCAs})
 			return err
 		},
 	}

--- a/internal/k8sutils/secrets_test.go
+++ b/internal/k8sutils/secrets_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 func Test_getRedisPassword(t *testing.T) {
@@ -104,6 +105,7 @@ func Test_getRedisTLSConfig(t *testing.T) {
 		redisCluster *rcvb2.RedisCluster
 		redisInfo    RedisDetails
 		expectTLS    bool
+		expectRootCA *bool
 	}{
 		{
 			name: "TLS enabled and successful configuration",
@@ -142,7 +144,46 @@ func Test_getRedisTLSConfig(t *testing.T) {
 				PodName:   "redis-pod",
 				Namespace: "default",
 			},
-			expectTLS: true,
+			expectTLS:    true,
+			expectRootCA: ptr.To(true),
+		},
+		{
+			name: "TLS enabled with no CA key and implicit CA config",
+			setup: func() *k8sClientFake.Clientset {
+				tlsSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "redis-tls-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"tls.crt": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.crt")),
+						"tls.key": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.key")),
+					},
+				}
+				client := k8sClientFake.NewSimpleClientset(tlsSecret)
+				return client
+			},
+			redisCluster: &rcvb2.RedisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "redis-cluster",
+					Namespace: "default",
+				},
+				Spec: rcvb2.RedisClusterSpec{
+					TLS: &common.TLSConfig{
+						CertKeyFile: "tls.crt",
+						KeyFile:     "tls.key",
+						Secret: corev1.SecretVolumeSource{
+							SecretName: "redis-tls-secret",
+						},
+					},
+				},
+			},
+			redisInfo: RedisDetails{
+				PodName:   "redis-pod",
+				Namespace: "default",
+			},
+			expectTLS:    true,
+			expectRootCA: ptr.To(false),
 		},
 		{
 			name: "TLS enabled but secret not found",
@@ -171,6 +212,84 @@ func Test_getRedisTLSConfig(t *testing.T) {
 				Namespace: "default",
 			},
 			expectTLS: false,
+		},
+		{
+			name: "TLS enabled with explicit CA configured but missing from secret",
+			setup: func() *k8sClientFake.Clientset {
+				tlsSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "redis-tls-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						// ca.crt is intentionally absent, but CaCertFile is explicitly set
+						"tls.crt": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.crt")),
+						"tls.key": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.key")),
+					},
+				}
+				client := k8sClientFake.NewSimpleClientset(tlsSecret)
+				return client
+			},
+			redisCluster: &rcvb2.RedisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "redis-cluster",
+					Namespace: "default",
+				},
+				Spec: rcvb2.RedisClusterSpec{
+					TLS: &common.TLSConfig{
+						CaCertFile:  "ca.crt", // explicitly set but missing from secret → misconfiguration
+						CertKeyFile: "tls.crt",
+						KeyFile:     "tls.key",
+						Secret: corev1.SecretVolumeSource{
+							SecretName: "redis-tls-secret",
+						},
+					},
+				},
+			},
+			redisInfo: RedisDetails{
+				PodName:   "redis-pod",
+				Namespace: "default",
+			},
+			expectTLS: false, // should fail fast as misconfiguration
+		},
+		{
+			name: "TLS enabled with no CA in secret and no explicit CA config uses system trust store",
+			setup: func() *k8sClientFake.Clientset {
+				tlsSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "redis-tls-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"tls.crt": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.crt")),
+						"tls.key": helperReadFile(filepath.Join("..", "..", "tests", "testdata", "secrets", "tls.key")),
+					},
+				}
+				client := k8sClientFake.NewSimpleClientset(tlsSecret)
+				return client
+			},
+			redisCluster: &rcvb2.RedisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "redis-cluster",
+					Namespace: "default",
+				},
+				Spec: rcvb2.RedisClusterSpec{
+					TLS: &common.TLSConfig{
+						// CaCertFile intentionally not set → should use system trust store
+						CertKeyFile: "tls.crt",
+						KeyFile:     "tls.key",
+						Secret: corev1.SecretVolumeSource{
+							SecretName: "redis-tls-secret",
+						},
+					},
+				},
+			},
+			redisInfo: RedisDetails{
+				PodName:   "redis-pod",
+				Namespace: "default",
+			},
+			expectTLS:    true,
+			expectRootCA: ptr.To(false), // nil RootCAs = system trust store
 		},
 		{
 			name: "TLS enabled but incomplete secret",
@@ -216,12 +335,17 @@ func Test_getRedisTLSConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := tt.setup()
 
-			tlsConfig := getRedisTLSConfig(context.TODO(), client, tt.redisCluster.Namespace, tt.redisCluster.Spec.TLS.Secret.SecretName, tt.redisInfo.PodName)
+			tlsConfig := getRedisTLSConfig(context.TODO(), client, tt.redisCluster.Namespace, tt.redisCluster.Spec.TLS)
 
 			if tt.expectTLS {
 				require.NotNil(t, tlsConfig, "Expected TLS configuration but got nil")
 				require.NotEmpty(t, tlsConfig.Certificates, "TLS Certificates should not be empty")
-				require.NotNil(t, tlsConfig.RootCAs, "Root CAs should not be nil")
+				if tt.expectRootCA != nil && *tt.expectRootCA {
+					require.NotNil(t, tlsConfig.RootCAs, "Root CAs should not be nil")
+				}
+				if tt.expectRootCA != nil && !*tt.expectRootCA {
+					require.Nil(t, tlsConfig.RootCAs, "Root CAs should be nil to use system trust store")
+				}
 			} else {
 				assert.Nil(t, tlsConfig, "Expected no TLS configuration but got one")
 			}

--- a/internal/k8sutils/secrets_test.go
+++ b/internal/k8sutils/secrets_test.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sClientFake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 )
 
 func Test_getRedisPassword(t *testing.T) {
@@ -105,7 +104,6 @@ func Test_getRedisTLSConfig(t *testing.T) {
 		redisCluster *rcvb2.RedisCluster
 		redisInfo    RedisDetails
 		expectTLS    bool
-		expectRootCA *bool
 	}{
 		{
 			name: "TLS enabled and successful configuration",
@@ -144,8 +142,7 @@ func Test_getRedisTLSConfig(t *testing.T) {
 				PodName:   "redis-pod",
 				Namespace: "default",
 			},
-			expectTLS:    true,
-			expectRootCA: ptr.To(true),
+			expectTLS: true,
 		},
 		{
 			name: "TLS enabled with no CA key and implicit CA config",
@@ -182,8 +179,7 @@ func Test_getRedisTLSConfig(t *testing.T) {
 				PodName:   "redis-pod",
 				Namespace: "default",
 			},
-			expectTLS:    true,
-			expectRootCA: ptr.To(false),
+			expectTLS: true,
 		},
 		{
 			name: "TLS enabled but secret not found",
@@ -288,8 +284,7 @@ func Test_getRedisTLSConfig(t *testing.T) {
 				PodName:   "redis-pod",
 				Namespace: "default",
 			},
-			expectTLS:    true,
-			expectRootCA: ptr.To(false), // nil RootCAs = system trust store
+			expectTLS: true, // no explicit CA → system trust store fallback
 		},
 		{
 			name: "TLS enabled but incomplete secret",
@@ -340,12 +335,15 @@ func Test_getRedisTLSConfig(t *testing.T) {
 			if tt.expectTLS {
 				require.NotNil(t, tlsConfig, "Expected TLS configuration but got nil")
 				require.NotEmpty(t, tlsConfig.Certificates, "TLS Certificates should not be empty")
-				if tt.expectRootCA != nil && *tt.expectRootCA {
-					require.NotNil(t, tlsConfig.RootCAs, "Root CAs should not be nil")
-				}
-				if tt.expectRootCA != nil && !*tt.expectRootCA {
-					require.Nil(t, tlsConfig.RootCAs, "Root CAs should be nil to use system trust store")
-				}
+				// Whether the CA comes from the secret or from the system trust
+				// store fallback, the operator dials pods by IP/pod DNS that do
+				// not match the server certificate SNI. The config must therefore
+				// skip Go's default hostname verification and verify the chain
+				// itself, otherwise the connection would fail. This is the
+				// connection semantics the fallback path must preserve.
+				require.NotNil(t, tlsConfig.RootCAs, "Root CAs should not be nil")
+				require.True(t, tlsConfig.InsecureSkipVerify, "InsecureSkipVerify should be true so the default hostname check is skipped")
+				require.NotNil(t, tlsConfig.VerifyPeerCertificate, "VerifyPeerCertificate must be set to verify the chain without hostname checks")
 			} else {
 				assert.Nil(t, tlsConfig, "Expected no TLS configuration but got one")
 			}

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -585,7 +585,7 @@ func GenerateAuthAndTLSArgs(enableAuth, enableTLS bool) (string, string) {
 		authArgs = " -a \"${REDIS_PASSWORD}\""
 	}
 	if enableTLS {
-		tlsArgs = " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\" --cacert \"${REDIS_TLS_CA_CERT}\""
+		tlsArgs = " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"
 	}
 	return authArgs, tlsArgs
 }
@@ -689,30 +689,19 @@ func generateInitContainerDef(role, name string, initcontainerParams initContain
 func GenerateTLSEnvironmentVariables(tlsconfig *commonapi.TLSConfig) []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 	root := "/tls/"
-
-	// get and set Defaults
-	caCert := "ca.crt"
-	tlsCert := "tls.crt"
-	tlsCertKey := "tls.key"
-
-	if tlsconfig.CaCertFile != "" {
-		caCert = tlsconfig.CaCertFile
-	}
-	if tlsconfig.CertKeyFile != "" {
-		tlsCert = tlsconfig.CertKeyFile
-	}
-	if tlsconfig.KeyFile != "" {
-		tlsCertKey = tlsconfig.KeyFile
-	}
+	caCert, tlsCert, tlsCertKey := getTLSSecretKeys(tlsconfig)
+	hasExplicitCA := tlsconfig != nil && tlsconfig.CaCertFile != ""
 
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  "TLS_MODE",
 		Value: "true",
 	})
-	envVars = append(envVars, corev1.EnvVar{
-		Name:  "REDIS_TLS_CA_CERT",
-		Value: path.Join(root, caCert),
-	})
+	if hasExplicitCA {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "REDIS_TLS_CA_CERT",
+			Value: path.Join(root, caCert),
+		})
+	}
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  "REDIS_TLS_CERT",
 		Value: path.Join(root, tlsCert),
@@ -751,18 +740,21 @@ func getExporterEnvironmentVariables(params containerParameters) []corev1.EnvVar
 	var envVars []corev1.EnvVar
 	redisHost := "redis://localhost:"
 	if params.TLSConfig != nil {
+		caCert, tlsCert, tlsKey := getTLSSecretKeys(params.TLSConfig)
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "REDIS_EXPORTER_TLS_CLIENT_KEY_FILE",
-			Value: "/tls/tls.key",
+			Value: path.Join("/tls/", tlsKey),
 		})
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "REDIS_EXPORTER_TLS_CLIENT_CERT_FILE",
-			Value: "/tls/tls.crt",
+			Value: path.Join("/tls/", tlsCert),
 		})
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "REDIS_EXPORTER_TLS_CA_CERT_FILE",
-			Value: "/tls/ca.crt",
-		})
+		if params.TLSConfig.CaCertFile != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "REDIS_EXPORTER_TLS_CA_CERT_FILE",
+				Value: path.Join("/tls/", caCert),
+			})
+		}
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "REDIS_EXPORTER_SKIP_TLS_VERIFICATION",
 			Value: "true",
@@ -884,7 +876,7 @@ func getProbeInfo(probe *corev1.Probe, sentinel, enableTLS, enableAuth bool) *co
 			redisHealthCheck = append(redisHealthCheck, "-a", "${REDIS_PASSWORD}")
 		}
 		if enableTLS {
-			redisHealthCheck = append(redisHealthCheck, "--tls", "--cert", "${REDIS_TLS_CERT}", "--key", "${REDIS_TLS_CERT_KEY}", "--cacert", "${REDIS_TLS_CA_CERT}")
+			redisHealthCheck = append(redisHealthCheck, "--tls", "--cert", "${REDIS_TLS_CERT}", "--key", "${REDIS_TLS_CERT_KEY}", "${REDIS_TLS_CA_CERT:+--cacert}", "${REDIS_TLS_CA_CERT}")
 		}
 		redisHealthCheck = append(redisHealthCheck, "ping")
 

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -31,8 +31,8 @@ func TestGenerateAuthAndTLSArgs(t *testing.T) {
 	}{
 		{"NoAuthNoTLS", false, false, "", ""},
 		{"AuthOnly", true, false, " -a \"${REDIS_PASSWORD}\"", ""},
-		{"TLSOnly", false, true, "", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\" --cacert \"${REDIS_TLS_CA_CERT}\""},
-		{"AuthAndTLS", true, true, " -a \"${REDIS_PASSWORD}\"", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\" --cacert \"${REDIS_TLS_CA_CERT}\""},
+		{"TLSOnly", false, true, "", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
+		{"AuthAndTLS", true, true, " -a \"${REDIS_PASSWORD}\"", " --tls --cert \"${REDIS_TLS_CERT}\" --key \"${REDIS_TLS_CERT_KEY}\"${REDIS_TLS_CA_CERT:+ --cacert \"${REDIS_TLS_CA_CERT}\"}"},
 	}
 
 	for _, tt := range tests {
@@ -1538,6 +1538,31 @@ func TestGenerateTLSEnvironmentVariables(t *testing.T) {
 	assert.ElementsMatch(t, envVars, expectedEnvVars, "EnvVars generated for TLS config are not as expected")
 }
 
+func TestGenerateTLSEnvironmentVariables_NoExplicitCA(t *testing.T) {
+	tlsConfig := &common.TLSConfig{
+		CertKeyFile: "test_tls.crt",
+		KeyFile:     "test_tls.key",
+	}
+
+	envVars := GenerateTLSEnvironmentVariables(tlsConfig)
+
+	expectedEnvVars := []corev1.EnvVar{
+		{
+			Name:  "TLS_MODE",
+			Value: "true",
+		},
+		{
+			Name:  "REDIS_TLS_CERT",
+			Value: path.Join("/tls/", "test_tls.crt"),
+		},
+		{
+			Name:  "REDIS_TLS_CERT_KEY",
+			Value: path.Join("/tls/", "test_tls.key"),
+		},
+	}
+	assert.ElementsMatch(t, envVars, expectedEnvVars, "EnvVars generated for TLS config without explicit CA are not as expected")
+}
+
 func TestGetEnvironmentVariables(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -1751,11 +1776,28 @@ func Test_getExporterEnvironmentVariables(t *testing.T) {
 				},
 			},
 			expectedEnvironment: []corev1.EnvVar{
-				{Name: "REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", Value: "/tls/tls.key"},
-				{Name: "REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", Value: "/tls/tls.crt"},
-				{Name: "REDIS_EXPORTER_TLS_CA_CERT_FILE", Value: "/tls/ca.crt"},
+				{Name: "REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", Value: "/tls/test_tls.key"},
+				{Name: "REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", Value: "/tls/test_tls.crt"},
+				{Name: "REDIS_EXPORTER_TLS_CA_CERT_FILE", Value: "/tls/test_ca.crt"},
 				{Name: "REDIS_EXPORTER_SKIP_TLS_VERIFICATION", Value: "true"},
 				{Name: "TEST_ENV", Value: "test-value"},
+			},
+		},
+		{
+			name: "Test with tls enabled and no explicit CA",
+			params: containerParameters{
+				TLSConfig: &common.TLSConfig{
+					CertKeyFile: "test_tls.crt",
+					KeyFile:     "test_tls.key",
+					Secret: corev1.SecretVolumeSource{
+						SecretName: "tls-secret",
+					},
+				},
+			},
+			expectedEnvironment: []corev1.EnvVar{
+				{Name: "REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", Value: "/tls/test_tls.key"},
+				{Name: "REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", Value: "/tls/test_tls.crt"},
+				{Name: "REDIS_EXPORTER_SKIP_TLS_VERIFICATION", Value: "true"},
 			},
 		},
 	}
@@ -1779,7 +1821,7 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 	probeWithTLS := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"sh", "-ec", "RESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} --tls --cert ${REDIS_TLS_CERT} --key ${REDIS_TLS_CERT_KEY} --cacert ${REDIS_TLS_CA_CERT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
+				Command: []string{"sh", "-ec", "RESP=\"$(redis-cli -h $(hostname) -p ${REDIS_PORT} --tls --cert ${REDIS_TLS_CERT} --key ${REDIS_TLS_CERT_KEY} ${REDIS_TLS_CA_CERT:+--cacert} ${REDIS_TLS_CA_CERT} ping)\"\n[ \"$RESP\" = \"PONG\" ]"},
 			},
 		},
 	}
@@ -1887,10 +1929,7 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 											Value: "1.0",
 										},
 										{
-											Name:  "REDIS_TLS_CA_CERT",
-											Value: path.Join("/tls/", "ca.crt"),
-										},
-										{
+
 											Name:  "REDIS_TLS_CERT",
 											Value: path.Join("/tls/", "tls.crt"),
 										},

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -1929,7 +1929,6 @@ func TestGenerateStatefulSetsDef(t *testing.T) {
 											Value: "1.0",
 										},
 										{
-
 											Name:  "REDIS_TLS_CERT",
 											Value: path.Join("/tls/", "tls.crt"),
 										},

--- a/internal/k8sutils/tls_keys.go
+++ b/internal/k8sutils/tls_keys.go
@@ -1,0 +1,27 @@
+package k8sutils
+
+import commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+
+const (
+	defaultTLSCAKeyFile   = "ca.crt"
+	defaultTLSCertKeyFile = "tls.crt"
+	defaultTLSKeyFile     = "tls.key"
+)
+
+func tlsKeyOrDefault(override, fallback string) string {
+	if override != "" {
+		return override
+	}
+	return fallback
+}
+
+func getTLSSecretKeys(tlsConfig *commonapi.TLSConfig) (caFile, certFile, keyFile string) {
+	if tlsConfig == nil {
+		return defaultTLSCAKeyFile, defaultTLSCertKeyFile, defaultTLSKeyFile
+	}
+
+	caFile = tlsKeyOrDefault(tlsConfig.CaCertFile, defaultTLSCAKeyFile)
+	certFile = tlsKeyOrDefault(tlsConfig.CertKeyFile, defaultTLSCertKeyFile)
+	keyFile = tlsKeyOrDefault(tlsConfig.KeyFile, defaultTLSKeyFile)
+	return caFile, certFile, keyFile
+}


### PR DESCRIPTION
## Description

When using TLS with publicly trusted certificates (e.g. Let's Encrypt, Google Trust Services), users no longer need to supply a `ca.crt` in their TLS secret. The operator’s container image already trusts these CAs via its system trust store. Previously, the operator would fail if `ca.crt` was missing from the secret, even when it wasn’t needed.

This change makes the CA certificate optional:

- If `CaKeyFile` is **not** explicitly set in the CR and `ca.crt` is absent from the secret, the operator falls back to the system trust store (`RootCAs: nil` in Go’s `tls.Config`).
- If `CaKeyFile` **is** explicitly set but the corresponding key is missing from the secret, the operator fails fast with a clear error (treating it as misconfiguration).
- `redis-cli` commands, health probes, and exporter env vars conditionally omit `--cacert` / `REDIS_EXPORTER_TLS_CA_CERT_FILE` when no explicit CA is configured, preventing references to non-existent files.

Fixes #1697.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.

---

## Additional context

**Files changed:**

- `internal/k8sutils/secrets.go`  
  - `getRedisTLSConfig` now returns a `tls.Config` with `RootCAs = nil` (system trust) when the CA is absent and not explicitly configured.

- `internal/controller/common/redis/heal.go`  
  - Applies the same CA-optional logic in the duplicated `getRedisTLSConfig`.

- `internal/k8sutils/redis.go`  
  - `getRedisTLSArgs` omits `--cacert` when `CaKeyFile` is empty.

- `internal/k8sutils/statefulset.go`  
  - `GenerateTLSEnvironmentVariables` and `getExporterEnvironmentVariables` conditionally emit CA-related env vars.
  - `GenerateAuthAndTLSArgs` and health probes now use shell parameter expansion (`${REDIS_TLS_CA_KEY:+--cacert ...}`) to conditionally include `--cacert`.

- **Tests**
  - `secrets_test.go`, `redis_test.go`, and `statefulset_test.go` have been updated to cover absent-CA scenarios.

This change is fully backward compatible: existing setups that include `ca.crt` in their secret continue to work identically.