### PR TITLE
fix: skip unprobeable pods so failover convergence doesn’t back off f…

### DIFF
--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -11,6 +11,7 @@ import (
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/cryptutil"
 	v1 "k8s.io/api/core/v1"
@@ -69,6 +70,10 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 		}
 	}
 	for _, pod := range pods.Items {
+		if !k8sutils.IsRedisPodProbeable(&pod) {
+			continue
+		}
+
 		connInfo := createConnectionInfo(ctx, pod, password, tlsConfig, h.k8s, ns, "6379")
 		isMaster, err := h.redis.Connect(connInfo).IsMaster(ctx)
 		if err != nil {

--- a/internal/controller/common/redis/heal_test.go
+++ b/internal/controller/common/redis/heal_test.go
@@ -1,0 +1,124 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
+	redisservice "github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestUpdateRedisRoleLabelSkipsUnprobeablePods(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	clientset := k8sfake.NewSimpleClientset(
+		newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true),
+		newLabeledRedisPod("redis-1", labels, "", corev1.PodRunning, true),
+		newLabeledRedisPod("redis-2", labels, "10.0.0.12", corev1.PodRunning, false),
+		newLabeledRedisPod("redis-3", labels, "", corev1.PodPending, false),
+	)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.10": true,
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.10"}, redisClient.connectHosts)
+
+	readyPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, readyPod.Labels[common.RedisRoleLabelKey])
+
+	for _, podName := range []string{"redis-1", "redis-2", "redis-3"} {
+		pod, getErr := clientset.CoreV1().Pods("default").Get(context.Background(), podName, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.Empty(t, pod.Labels[common.RedisRoleLabelKey])
+	}
+}
+
+type fakeRedisClient struct {
+	connectHosts   []string
+	isMasterByHost map[string]bool
+}
+
+func (f *fakeRedisClient) Connect(info *redisservice.ConnectionInfo) redisservice.Service {
+	f.connectHosts = append(f.connectHosts, info.Host)
+	return &fakeRedisService{
+		host:           info.Host,
+		isMasterByHost: f.isMasterByHost,
+	}
+}
+
+type fakeRedisService struct {
+	host           string
+	isMasterByHost map[string]bool
+}
+
+func (f *fakeRedisService) IsMaster(context.Context) (bool, error) {
+	return f.isMasterByHost[f.host], nil
+}
+
+func (f *fakeRedisService) GetAttachedReplicaCount(context.Context) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeRedisService) SentinelMonitor(context.Context, *redisservice.ConnectionInfo, string, string) error {
+	return nil
+}
+
+func (f *fakeRedisService) SentinelSet(context.Context, string, string, string) error {
+	return nil
+}
+
+func (f *fakeRedisService) SentinelReset(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeRedisService) GetInfoSentinel(context.Context) (*redisservice.InfoSentinelResult, error) {
+	return &redisservice.InfoSentinelResult{}, nil
+}
+
+func (f *fakeRedisService) GetClusterInfo(context.Context) (*redisservice.ClusterStatus, error) {
+	return &redisservice.ClusterStatus{}, nil
+}
+
+func newLabeledRedisPod(name string, labels map[string]string, podIP string, phase corev1.PodPhase, ready bool) *corev1.Pod {
+	podLabels := map[string]string{}
+	for key, value := range labels {
+		podLabels[key] = value
+	}
+
+	readyStatus := corev1.ConditionFalse
+	if ready {
+		readyStatus = corev1.ConditionTrue
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    podLabels,
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			PodIP: podIP,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: readyStatus,
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -34,8 +34,12 @@ const (
 type Reconciler struct {
 	client.Client
 	k8sutils.StatefulSet
-	Healer    redishealer.Healer
-	K8sClient kubernetes.Interface
+	Healer                     redishealer.Healer
+	K8sClient                  kubernetes.Interface
+	RedisNodesByRole           func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, string) ([]string, error)
+	RedisReplicationRealMaster func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string
+	CreateRedisReplicationLink func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error
+	ConfigureSentinel          func(context.Context, *rrvb2.RedisReplication, string) error
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -111,6 +115,46 @@ func connectionInfoEqual(a, b *rrvb2.ConnectionInfo) bool {
 		return false
 	}
 	return a.Host == b.Host && a.Port == b.Port && a.MasterName == b.MasterName
+}
+
+func (r *Reconciler) redisNodesByRole(ctx context.Context, instance *rrvb2.RedisReplication, role string) ([]string, error) {
+	if r.RedisNodesByRole != nil {
+		return r.RedisNodesByRole(ctx, r.K8sClient, instance, role)
+	}
+	return k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, role)
+}
+
+func (r *Reconciler) redisReplicationRealMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterPods []string) string {
+	if r.RedisReplicationRealMaster != nil {
+		return r.RedisReplicationRealMaster(ctx, r.K8sClient, instance, masterPods)
+	}
+	return k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterPods)
+}
+
+func (r *Reconciler) createRedisReplicationLink(ctx context.Context, instance *rrvb2.RedisReplication, pods []string, realMaster string) error {
+	if r.CreateRedisReplicationLink != nil {
+		return r.CreateRedisReplicationLink(ctx, r.K8sClient, instance, pods, realMaster)
+	}
+	return k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, pods, realMaster)
+}
+
+func (r *Reconciler) configureReplicationSentinel(ctx context.Context, instance *rrvb2.RedisReplication, masterPodName string) error {
+	if r.ConfigureSentinel != nil {
+		return r.ConfigureSentinel(ctx, instance, masterPodName)
+	}
+	return r.configureSentinel(ctx, instance, masterPodName)
+}
+
+func (r *Reconciler) observedRedisReplicationMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterPods []string) (string, bool) {
+	switch len(masterPods) {
+	case 0:
+		return "", false
+	case 1:
+		return masterPods[0], true
+	default:
+		realMaster := r.redisReplicationRealMaster(ctx, instance, masterPods)
+		return realMaster, realMaster != ""
+	}
 }
 
 type reconciler struct {
@@ -355,39 +399,51 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	}
 
 	var realMaster string
-	masterNodes, err := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "master")
+	masterNodes, err := r.redisNodesByRole(ctx, instance, "master")
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	slaveNodes, err := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "slave")
+	slaveNodes, err := r.redisNodesByRole(ctx, instance, "slave")
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
+	incompleteTopology := instance.Spec.Size != nil && (len(masterNodes)+len(slaveNodes)) < int(*instance.Spec.Size)
+	realMaster, masterPositivelyIdentified := r.observedRedisReplicationMaster(ctx, instance, masterNodes)
 	if len(masterNodes) > 1 {
 		log.FromContext(ctx).Info("Creating redis replication by executing replication creation commands")
 
-		realMaster = k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
-		if len(slaveNodes) == 0 {
+		if realMaster == "" && len(slaveNodes) == 0 && !incompleteTopology {
 			realMaster = masterNodes[0]
 		}
-		if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, masterNodes, realMaster); err != nil {
+		if incompleteTopology {
+			log.FromContext(ctx).Info("Skipping replication reconfiguration because the observed topology is incomplete",
+				"observedPods", len(masterNodes)+len(slaveNodes),
+				"expectedPods", *instance.Spec.Size)
+		} else if realMaster == "" {
+			log.FromContext(ctx).Info("Skipping replication reconfiguration because the current master could not be identified")
+		} else if err := r.createRedisReplicationLink(ctx, instance, masterNodes, realMaster); err != nil {
 			return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
 		}
 	} else if len(masterNodes) == 1 && len(slaveNodes) > 0 {
-		realMaster = masterNodes[0]
-		currentRealMaster := k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
+		currentRealMaster := r.redisReplicationRealMaster(ctx, instance, masterNodes)
 
 		if currentRealMaster == "" && !instance.EnableSentinel() {
 			log.FromContext(ctx).Info("Detected disconnected slaves, reconfiguring replication",
 				"master", realMaster, "slaves", slaveNodes)
 
-			allPods := append(masterNodes, slaveNodes...)
-			if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, allPods, realMaster); err != nil {
-				log.FromContext(ctx).Error(err, "Failed to reconfigure master-slave replication",
-					"master", realMaster, "slaves", slaveNodes)
-				return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
+			if incompleteTopology {
+				log.FromContext(ctx).Info("Skipping master-slave reconfiguration because the observed topology is incomplete",
+					"observedPods", len(masterNodes)+len(slaveNodes),
+					"expectedPods", *instance.Spec.Size)
+			} else {
+				allPods := append(masterNodes, slaveNodes...)
+				if err := r.createRedisReplicationLink(ctx, instance, allPods, realMaster); err != nil {
+					log.FromContext(ctx).Error(err, "Failed to reconfigure master-slave replication",
+						"master", realMaster, "slaves", slaveNodes)
+					return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
+				}
+				log.FromContext(ctx).Info("Successfully reconfigured slave replication")
 			}
-			log.FromContext(ctx).Info("Successfully reconfigured slave replication")
 		}
 	}
 
@@ -400,7 +456,11 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	monitoring.RedisReplicationReplicasSizeDesired.WithLabelValues(instance.Namespace, instance.Name).Set(float64(*instance.Spec.Size))
 
 	if instance.EnableSentinel() {
-		if err := r.configureSentinel(ctx, instance, realMaster); err != nil {
+		if incompleteTopology && !masterPositivelyIdentified {
+			log.FromContext(ctx).Info("Skipping sentinel reconfiguration because topology is incomplete and the master is ambiguous",
+				"observedPods", len(masterNodes)+len(slaveNodes),
+				"expectedPods", *instance.Spec.Size)
+		} else if err := r.configureReplicationSentinel(ctx, instance, realMaster); err != nil {
 			log.FromContext(ctx).Error(err, "failed to configure sentinel")
 		}
 	}
@@ -413,11 +473,11 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisR
 	var err error
 	var realMaster string
 
-	masterNodes, err := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "master")
+	masterNodes, err := r.redisNodesByRole(ctx, instance, "master")
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	realMaster = k8sutils.GetRedisReplicationRealMaster(ctx, r.K8sClient, instance, masterNodes)
+	realMaster, _ = r.observedRedisReplicationMaster(ctx, instance, masterNodes)
 	if err = r.UpdateRedisReplicationMaster(ctx, instance, realMaster); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
@@ -426,7 +486,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisR
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
 
-	slaveNodes, err := k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, "slave")
+	slaveNodes, err := r.redisNodesByRole(ctx, instance, "slave")
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -407,7 +407,8 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	incompleteTopology := instance.Spec.Size != nil && (len(masterNodes)+len(slaveNodes)) < int(*instance.Spec.Size)
+	observedPods := len(masterNodes) + len(slaveNodes)
+	incompleteTopology := instance.Spec.Size != nil && observedPods < int(*instance.Spec.Size)
 	realMaster, masterPositivelyIdentified := r.observedRedisReplicationMaster(ctx, instance, masterNodes)
 	if len(masterNodes) > 1 {
 		log.FromContext(ctx).Info("Creating redis replication by executing replication creation commands")
@@ -435,7 +436,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 		}
 		if incompleteTopology {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the observed topology is incomplete",
-				"observedPods", len(masterNodes)+len(slaveNodes),
+				"observedPods", observedPods,
 				"expectedPods", *instance.Spec.Size)
 		} else if realMaster == "" {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the current master could not be identified")
@@ -451,7 +452,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 
 			if incompleteTopology {
 				log.FromContext(ctx).Info("Skipping master-slave reconfiguration because the observed topology is incomplete",
-					"observedPods", len(masterNodes)+len(slaveNodes),
+					"observedPods", observedPods,
 					"expectedPods", *instance.Spec.Size)
 			} else {
 				allPods := append(masterNodes, slaveNodes...)
@@ -466,17 +467,17 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	}
 
 	monitoring.RedisReplicationReplicasSizeMismatch.WithLabelValues(instance.Namespace, instance.Name).Set(0)
-	if instance.Spec.Size != nil && int(*instance.Spec.Size) != (len(masterNodes)+len(slaveNodes)) {
+	if instance.Spec.Size != nil && int(*instance.Spec.Size) != observedPods {
 		monitoring.RedisReplicationReplicasSizeMismatch.WithLabelValues(instance.Namespace, instance.Name).Set(1)
 	}
 
-	monitoring.RedisReplicationReplicasSizeCurrent.WithLabelValues(instance.Namespace, instance.Name).Set(float64(len(masterNodes) + len(slaveNodes)))
+	monitoring.RedisReplicationReplicasSizeCurrent.WithLabelValues(instance.Namespace, instance.Name).Set(float64(observedPods))
 	monitoring.RedisReplicationReplicasSizeDesired.WithLabelValues(instance.Namespace, instance.Name).Set(float64(*instance.Spec.Size))
 
 	if instance.EnableSentinel() {
 		if incompleteTopology && !masterPositivelyIdentified {
 			log.FromContext(ctx).Info("Skipping sentinel reconfiguration because topology is incomplete and the master is ambiguous",
-				"observedPods", len(masterNodes)+len(slaveNodes),
+				"observedPods", observedPods,
 				"expectedPods", *instance.Spec.Size)
 		} else if err := r.configureReplicationSentinel(ctx, instance, realMaster); err != nil {
 			log.FromContext(ctx).Error(err, "failed to configure sentinel")

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -1,0 +1,259 @@
+package redisreplication
+
+import (
+	"context"
+	"testing"
+
+	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testing.T) {
+	createCalled := false
+	r := &Reconciler{
+		K8sClient: fake.NewSimpleClientset(),
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-0"}, nil
+			}
+			return []string{"example-replication-1"}, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		CreateRedisReplicationLink: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error {
+			createCalled = true
+			return nil
+		},
+	}
+	result, err := r.reconcileRedis(context.Background(), newReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.False(t, createCalled)
+}
+
+func TestReconcileRedisSkipsReplicationChangesWhenMultipleMastersAreObservedButTopologyIsIncomplete(t *testing.T) {
+	createCalled := false
+	r := &Reconciler{
+		K8sClient: fake.NewSimpleClientset(),
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-0", "example-replication-1"}, nil
+			}
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return "example-replication-1"
+		},
+		CreateRedisReplicationLink: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error {
+			createCalled = true
+			return nil
+		},
+	}
+
+	result, err := r.reconcileRedis(context.Background(), newReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.False(t, createCalled)
+}
+
+func TestReconcileRedisKeepsHealthyBehaviorWhenTopologyIsComplete(t *testing.T) {
+	createCalled := false
+	var gotPods []string
+	var gotMaster string
+	r := &Reconciler{
+		K8sClient: fake.NewSimpleClientset(),
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-0", "example-replication-1"}, nil
+			}
+			return []string{"example-replication-2"}, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return "example-replication-1"
+		},
+		CreateRedisReplicationLink: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, pods []string, realMaster string) error {
+			createCalled = true
+			gotPods = append([]string{}, pods...)
+			gotMaster = realMaster
+			return nil
+		},
+	}
+	result, err := r.reconcileRedis(context.Background(), newReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, createCalled)
+	assert.ElementsMatch(t, []string{"example-replication-0", "example-replication-1"}, gotPods)
+	assert.Equal(t, "example-replication-1", gotMaster)
+}
+
+func TestReconcileStatusStillRunsWhenOnePodIsUnobserved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	healer := &fakeHealer{}
+	r := &Reconciler{
+		Client:    ctrlClient,
+		K8sClient: fake.NewSimpleClientset(),
+		Healer:    healer,
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-1"}, nil
+			}
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, healer.updateCalled)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
+}
+
+func TestReconcileRedisSkipsSentinelReconfigurationWhenTopologyIsIncompleteAndMasterIsAmbiguous(t *testing.T) {
+	createCalled := false
+	sentinelCalled := false
+	r := &Reconciler{
+		StatefulSet: &fakeStatefulSetService{},
+		K8sClient:   fake.NewSimpleClientset(),
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-0", "example-replication-1"}, nil
+			}
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		CreateRedisReplicationLink: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error {
+			createCalled = true
+			return nil
+		},
+		ConfigureSentinel: func(context.Context, *rrvb2.RedisReplication, string) error {
+			sentinelCalled = true
+			return nil
+		},
+	}
+
+	result, err := r.reconcileRedis(context.Background(), newSentinelReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.False(t, createCalled)
+	assert.False(t, sentinelCalled)
+}
+
+func TestReconcileRedisConfiguresSentinelForSingleObservedMaster(t *testing.T) {
+	sentinelCalled := false
+	var gotMaster string
+	r := &Reconciler{
+		StatefulSet: &fakeStatefulSetService{},
+		K8sClient:   fake.NewSimpleClientset(),
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-1"}, nil
+			}
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		ConfigureSentinel: func(_ context.Context, _ *rrvb2.RedisReplication, master string) error {
+			sentinelCalled = true
+			gotMaster = master
+			return nil
+		},
+	}
+
+	result, err := r.reconcileRedis(context.Background(), newSentinelReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, sentinelCalled)
+	assert.Equal(t, "example-replication-1", gotMaster)
+}
+
+func newReplicationInstanceForTest() *rrvb2.RedisReplication {
+	size := int32(3)
+	return &rrvb2.RedisReplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-replication",
+			Namespace: "default",
+		},
+		Spec: rrvb2.RedisReplicationSpec{
+			Size: ptr.To(size),
+			KubernetesConfig: commonapi.KubernetesConfig{
+				Image: "redis:7",
+			},
+		},
+	}
+}
+
+func newSentinelReplicationInstanceForTest() *rrvb2.RedisReplication {
+	instance := newReplicationInstanceForTest()
+	instance.Spec.Sentinel = &rrvb2.Sentinel{Size: 3}
+	return instance
+}
+
+type fakeStatefulSetService struct{}
+
+func (f *fakeStatefulSetService) IsStatefulSetReady(context.Context, string, string) bool {
+	return true
+}
+
+func (f *fakeStatefulSetService) GetStatefulSetReplicas(context.Context, string, string) int32 {
+	return 0
+}
+
+type fakeHealer struct {
+	updateCalled bool
+}
+
+func (f *fakeHealer) SentinelMonitor(context.Context, *rsvb2.RedisSentinel, string) error {
+	return nil
+}
+
+func (f *fakeHealer) SentinelSet(context.Context, *rsvb2.RedisSentinel, string) error {
+	return nil
+}
+
+func (f *fakeHealer) SentinelReset(context.Context, *rsvb2.RedisSentinel) error {
+	return nil
+}
+
+func (f *fakeHealer) UpdateRedisRoleLabel(context.Context, string, map[string]string, *commonapi.ExistingPasswordSecret, *commonapi.TLSConfig) error {
+	f.updateCalled = true
+	return nil
+}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -20,6 +20,7 @@ import (
 	redis "github.com/redis/go-redis/v9"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -657,10 +658,26 @@ func checkRedisNodePresence(ctx context.Context, nodeList []clusterNodesResponse
 
 // configureRedisClient will configure the Redis Client
 func configureRedisReplicationClient(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication, podName string) *redis.Client {
-	redisInfo := RedisDetails{
+	pod, err := client.CoreV1().Pods(cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err == nil {
+		return configureRedisReplicationClientForPod(ctx, client, cr, pod)
+	}
+
+	log.FromContext(ctx).V(1).Info("Falling back to redis replication pod lookup during client configuration", "pod", podName, "error", err)
+	return configureRedisReplicationClientForAddress(ctx, client, cr, RedisDetails{
 		PodName:   podName,
 		Namespace: cr.Namespace,
-	}
+	}, "")
+}
+
+func configureRedisReplicationClientForPod(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication, pod *corev1.Pod) *redis.Client {
+	return configureRedisReplicationClientForAddress(ctx, client, cr, RedisDetails{
+		PodName:   pod.Name,
+		Namespace: cr.Namespace,
+	}, pod.Status.PodIP)
+}
+
+func configureRedisReplicationClientForAddress(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication, redisInfo RedisDetails, podIP string) *redis.Client {
 	var err error
 	var pass string
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
@@ -674,8 +691,10 @@ func configureRedisReplicationClient(ctx context.Context, client kubernetes.Inte
 		// Use DNS name for TLS connections
 		addr = fmt.Sprintf("%s:%d", getRedisReplicationHostname(redisInfo, cr), 6379)
 	} else {
-		// Use IP address for non-TLS connections
-		addr = getRedisServerAddress(ctx, client, redisInfo, 6379)
+		if podIP == "" {
+			podIP = getRedisServerIP(ctx, client, redisInfo)
+		}
+		addr = formatRedisAddress(podIP, 6379)
 	}
 	opts := &redis.Options{
 		Addr:     addr,
@@ -683,9 +702,20 @@ func configureRedisReplicationClient(ctx context.Context, client kubernetes.Inte
 		DB:       0,
 	}
 	if cr.Spec.TLS != nil {
-		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS.Secret.SecretName, podName)
+		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS.Secret.SecretName, redisInfo.PodName)
 	}
 	return redis.NewClient(opts)
+}
+
+func formatRedisAddress(ip string, port int) string {
+	if ip == "" {
+		return fmt.Sprintf("%s:%d", ip, port)
+	}
+	format := "%s:%d"
+	if net.ParseIP(ip).To4() == nil {
+		format = "[%s]:%d"
+	}
+	return fmt.Sprintf(format, ip, port)
 }
 
 func getRedisReplicationHostname(redisInfo RedisDetails, cr *rrvb2.RedisReplication) string {
@@ -694,6 +724,15 @@ func getRedisReplicationHostname(redisInfo RedisDetails, cr *rrvb2.RedisReplicat
 
 // Get Redis nodes by it's role i.e. master, slave and sentinel
 func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string) ([]string, error) {
+	return getRedisNodesByRole(ctx, cl, cr, redisRole, func(ctx context.Context, pod *corev1.Pod) (string, error) {
+		redisClient := configureRedisReplicationClientForPod(ctx, cl, cr, pod)
+		defer redisClient.Close()
+
+		return checkRedisServerRole(ctx, redisClient, pod.Name)
+	})
+}
+
+func getRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string, probeRole func(context.Context, *corev1.Pod) (string, error)) ([]string, error) {
 	statefulset, err := GetStatefulSet(ctx, cl, cr.GetNamespace(), cr.GetName())
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to Get the Statefulset of the", "custom resource", cr.Name, "in namespace", cr.Namespace)
@@ -705,9 +744,19 @@ func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 
 	for i := 0; i < int(replicas); i++ {
 		podName := statefulset.Name + "-" + strconv.Itoa(i)
-		redisClient := configureRedisReplicationClient(ctx, cl, cr, podName)
-		defer redisClient.Close()
-		podRole, err := checkRedisServerRole(ctx, redisClient, podName)
+		pod, err := cl.CoreV1().Pods(cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		if !IsRedisPodProbeable(pod) {
+			continue
+		}
+
+		podRole, err := probeRole(ctx, pod)
 		if err != nil {
 			return nil, err
 		}
@@ -717,6 +766,18 @@ func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 	}
 
 	return pods, nil
+}
+
+func IsRedisPodProbeable(pod *corev1.Pod) bool {
+	if pod == nil || pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // Check the Redis Server Role i.e. master, slave and sentinel

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -71,15 +71,7 @@ func getRedisServerIP(ctx context.Context, client kubernetes.Interface, redisInf
 }
 
 func getRedisServerAddress(ctx context.Context, client kubernetes.Interface, rd RedisDetails, port int) string {
-	ip := getRedisServerIP(ctx, client, rd)
-	format := "%s:%d"
-
-	// if ip is IPv6, wrap it in brackets
-	if net.ParseIP(ip).To4() == nil {
-		format = "[%s]:%d"
-	}
-
-	return fmt.Sprintf(format, ip, port)
+	return formatRedisAddress(getRedisServerIP(ctx, client, rd), port)
 }
 
 func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, rd RedisDetails) string {

--- a/internal/k8sutils/redis_get_nodes_by_role_test.go
+++ b/internal/k8sutils/redis_get_nodes_by_role_test.go
@@ -1,0 +1,216 @@
+package k8sutils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+func TestIsRedisPodProbeable(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "nil pod",
+			pod:  nil,
+			want: false,
+		},
+		{
+			name: "pod pending",
+			pod:  newPendingRedisPod("example-replication-0"),
+			want: false,
+		},
+		{
+			name: "pod running but not ready",
+			pod:  newRunningNotReadyRedisPod("example-replication-0", "10.0.0.10"),
+			want: false,
+		},
+		{
+			name: "pod running and ready without ip",
+			pod:  newReadyRedisPod("example-replication-0", ""),
+			want: false,
+		},
+		{
+			name: "pod running and ready with ip",
+			pod:  newReadyRedisPod("example-replication-0", "10.0.0.10"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsRedisPodProbeable(tt.pod))
+		})
+	}
+}
+
+func TestGetRedisNodesByRoleSkipsUnprobeablePods(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  runtime.Object
+	}{
+		{
+			name: "pod not found",
+			pod:  nil,
+		},
+		{
+			name: "pod pending",
+			pod:  newPendingRedisPod("example-replication-2"),
+		},
+		{
+			name: "pod running but not ready",
+			pod:  newRunningNotReadyRedisPod("example-replication-2", "10.0.0.12"),
+		},
+		{
+			name: "pod running and ready without ip",
+			pod:  newReadyRedisPod("example-replication-2", ""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []runtime.Object{
+				newRedisReplicationStatefulSet(),
+				newReadyRedisPod("example-replication-0", "10.0.0.10"),
+				newReadyRedisPod("example-replication-1", "10.0.0.11"),
+			}
+			if tt.pod != nil {
+				objects = append(objects, tt.pod)
+			}
+			client := k8sClientFake.NewSimpleClientset(objects...)
+
+			var probedPods []string
+			nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
+				probedPods = append(probedPods, pod.Name)
+				if pod.Name == "example-replication-0" {
+					return "master", nil
+				}
+				return "slave", nil
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, []string{"example-replication-0"}, nodes)
+			assert.ElementsMatch(t, []string{"example-replication-0", "example-replication-1"}, probedPods)
+		})
+	}
+}
+
+func TestGetRedisNodesByRoleFailsWhenReadyPodProbeFails(t *testing.T) {
+	client := k8sClientFake.NewSimpleClientset(
+		newRedisReplicationStatefulSet(),
+		newReadyRedisPod("example-replication-0", "10.0.0.10"),
+		newReadyRedisPod("example-replication-1", "10.0.0.11"),
+		newReadyRedisPod("example-replication-2", "10.0.0.12"),
+	)
+
+	_, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
+		if pod.Name == "example-replication-1" {
+			return "", errors.New("probe failed")
+		}
+		return "slave", nil
+	})
+
+	assert.ErrorContains(t, err, "probe failed")
+}
+
+func TestGetRedisNodesByRoleCompleteTopology(t *testing.T) {
+	client := k8sClientFake.NewSimpleClientset(
+		newRedisReplicationStatefulSet(),
+		newReadyRedisPod("example-replication-0", "10.0.0.10"),
+		newReadyRedisPod("example-replication-1", "10.0.0.11"),
+		newReadyRedisPod("example-replication-2", "10.0.0.12"),
+	)
+
+	nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "slave", func(_ context.Context, pod *corev1.Pod) (string, error) {
+		if pod.Name == "example-replication-0" {
+			return "master", nil
+		}
+		return "slave", nil
+	})
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"example-replication-1", "example-replication-2"}, nodes)
+}
+
+func newRedisReplication() *rrvb2.RedisReplication {
+	size := int32(3)
+	return &rrvb2.RedisReplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-replication",
+			Namespace: "default",
+		},
+		Spec: rrvb2.RedisReplicationSpec{
+			Size: ptr.To(size),
+		},
+	}
+}
+
+func newRedisReplicationStatefulSet() *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-replication",
+			Namespace: "default",
+		},
+	}
+}
+
+func newReadyRedisPod(name, podIP string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func newRunningNotReadyRedisPod(name, podIP string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+}
+
+func newPendingRedisPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+}


### PR DESCRIPTION
**Description**

## Summary

Fix RedisReplication failover convergence when one Redis pod is unreachable during Sentinel-led master promotion.

Previously, `GetRedisNodesByRole()` would fail the reconcile as soon as it hit an unreachable Redis pod. In the reported scenario, that meant the operator could not update `redis-role` labels or `RedisReplication.status.masterNode` after Sentinel had already promoted a new master. As a result, the `<name>-master` Service kept pointing at the wrong pod and clients remained stuck until controller-runtime eventually retried after exponential backoff.

This change updates the controller to reason over the probable Redis topology instead of aborting on a single unavailable ordinal.

## What changed

- Skip Redis pods that are not probeable yet when discovering roles.
  - `Pending` pods
  - non-`Ready` pods
  - pods without a `PodIP`
- Reuse pod data directly when building Redis clients for role checks.
- Update the role-label healer to skip unprobeable pods as well.
- Avoid replication or Sentinel reconfiguration when the observed topology is incomplete and the current master cannot be identified safely.
- Add focused unit coverage for:
  - skipping unprobeable pods in role discovery
  - continuing status reconciliation when one pod is unobserved
  - avoiding unsafe replication/Sentinel changes on incomplete topology
  - preserving existing behavior when topology is complete

## Why this fixes the issue

With this change, a failed or pending old master no longer causes reconcile to return an error just because that ordinal cannot be probed. The operator can continue to observe the surviving ready Redis pods, identify the Sentinel-elected master, update `status.masterNode`, and refresh `redis-role` labels. That allows the `<name>-master` Service to move to the new master quickly instead of waiting for error-driven exponential backoff to unwind.

In short:
- client recovery now follows the healthy promoted master
- the reconcile loop no longer enters the long backoff path for this failure mode
- unsafe reconfiguration is avoided while topology is incomplete

## Validation

Executed:
- `env GOCACHE=/tmp/redis-operator-go-build-cache go test ./internal/k8sutils`
- `env GOCACHE=/tmp/redis-operator-go-build-cache go test ./internal/controller/common/redis`
- `env GOCACHE=/tmp/redis-operator-go-build-cache go test ./internal/controller/redisreplication -run 'TestReconcileRedis|TestReconcileStatus'`

Fixes #1711

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.