### PR TITLE
fix: omit empty tls-ca-cert-file to prevent fatal config error (#1715)

### DIFF
--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -100,7 +100,10 @@ func GenerateConfig() error {
 	if tlsMode == "true" {
 		cfg.Append("tls-cert-file", util.CoalesceEnv1("REDIS_TLS_CERT", ""))
 		cfg.Append("tls-key-file", util.CoalesceEnv1("REDIS_TLS_CERT_KEY", ""))
-		cfg.Append("tls-ca-cert-file", util.CoalesceEnv1("REDIS_TLS_CA_CERT", ""))
+		caCert := util.CoalesceEnv1("REDIS_TLS_CA_CERT", "")
+		if caCert != "" {
+			cfg.Append("tls-ca-cert-file", caCert)
+		}
 		cfg.Append("tls-auth-clients", "optional")
 		cfg.Append("tls-replication", "yes")
 

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -109,7 +109,9 @@ func GenerateConfig() error {
 			cfg.Append("tls-port", "26379")
 			cfg.Append("tls-cert-file", redisTLSCert)
 			cfg.Append("tls-key-file", redisTLSCertKey)
-			cfg.Append("tls-ca-cert-file", redisTLSCACert)
+			if redisTLSCACert != "" {
+				cfg.Append("tls-ca-cert-file", redisTLSCACert)
+			}
 			cfg.Append("tls-auth-clients", "optional")
 			// Sentinel should use tls for replication connection.
 			cfg.Append("tls-replication", "yes")


### PR DESCRIPTION
This PR fixes a fatal configuration error that occurs when a Redis cluster is deployed with TLS but without a provided CA certificate (ca.crt omitted from the Secret).

In v0.24.0, if the CA cert environment variable is empty, the operator writes tls-ca-cert-file "" into the generated redis.conf. This causes the Redis configuration parser to fail with a wrong number of arguments fatal error, crashing the pod.

Changes made:

    Added a conditional initialization check in internal/agent/bootstrap/redis/config.go.

    Added a conditional initialization check in internal/agent/bootstrap/sentinel/config.go.
    The tls-ca-cert-file directive is now only appended if the certificate value is not an empty string.

Fixes #1715

Type of change

    Bug fix (non-breaking change which fixes an issue)

Checklist

    [ ] Tests have been added/modified and all tests pass.

    [x] Functionality/bugs have been confirmed to be unchanged or fixed.

    [x] I have performed a self-review of my own code.

    [ ] Documentation has been updated or added where necessary.

Additional Context

I successfully reproduced the issue locally on a K3s cluster. I verified the root cause and ensured that this logical fix prevents the empty argument from being written to the configuration file, allowing the Redis pods to start correctly without crashing into a CrashLoopBackOff state.