### PR TITLE
chore: bump version of redis-replication chart to 0.17.0

### DIFF
--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.13
-appVersion: "0.16.13"
+version: 0.17.0
+appVersion: "0.17.0"
 type: application
 engine: gotpl
 maintainers:


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR bumps the version of the redis-replication helm chart as discussed in [slack](https://opstree.slack.com/archives/C05MBRB50JG/p1774006232072909?thread_ts=1774004837.451999&cid=C05MBRB50JG)

This triggers a release which includes the latest changes in the helm chart.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
