### PR TITLE
fix(chart): make minAvailable and maxUnavailable optional in redis-replication chart

### DIFF
--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.17.1
+appVersion: "0.17.1"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -125,8 +125,12 @@ spec:
   {{- if .Values.pdb.enabled }}
   pdb:
     enabled: {{ .Values.pdb.enabled }}
+    {{- if .Values.pdb.minAvailable }}
     minAvailable: {{ .Values.pdb.minAvailable }}
+    {{- end }}
+    {{- if .Values.pdb.maxUnavailable }}
     maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+    {{- end }}
   {{- end }}
   {{- if .Values.sentinel.enabled }}
   sentinel:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -201,7 +201,9 @@ env: []
 
 pdb:
   enabled: false
+  # Mutually exclusive with `maxUnavailable`
   minAvailable: 1
+  # Mutually exclusive with `minAvailable`
   maxUnavailable: null
 
 # -- Sentinel configuration for automatic failover.


### PR DESCRIPTION
**Description**

The poddisruptionbudget specification states that either `minAvailable` or `maxUnavailable` should be set.

When using server-side apply we get an error that `maxUnavailable` is set even though it is 'null' in the chart's values:
```bash
The RedisReplication "test" is invalid: spec.pdb.maxUnavailable: Invalid value: "null": spec.pdb.maxUnavailable in body must be of type integer: "null"
```

<!-- Please provide a summary of the change here. -->
The provided change makes the `minAvailable` or `maxUnavailable` values optional. Either one of them could be set, but not both.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
