### PR TITLE
fix: reset follower with stale state before add-node to prevent "Node is not empty" loop

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -313,18 +313,27 @@ func ExecuteRedisReplicationCommand(ctx context.Context, client kubernetes.Inter
 			if !checkRedisNodePresence(ctx, nodes, podIP) {
 				log.FromContext(ctx).V(1).Info("Adding node to cluster.", "Node.IP", podIP, "Follower.Pod", followerPod)
 				cmd := createRedisReplicationCommand(ctx, client, cr, leaderPod, followerPod)
-				redisClient := configureRedisClient(ctx, client, cr, followerPod.PodName)
-				pong, err := redisClient.Ping(ctx).Result()
-				redisClient.Close()
+				followerClient := configureRedisClient(ctx, client, cr, followerPod.PodName)
+				pong, err := followerClient.Ping(ctx).Result()
 				if err != nil {
+					followerClient.Close()
 					log.FromContext(ctx).Error(err, "Failed to ping Redis server", "Follower.Pod", followerPod)
 					continue
 				}
-				if pong == "PONG" {
-					executeCommand(ctx, client, cr, cmd, cr.Name+"-leader-0")
-				} else {
+				if pong != "PONG" {
+					followerClient.Close()
 					log.FromContext(ctx).V(1).Info("Skipping execution of command due to failed Redis ping", "Follower.Pod", followerPod)
+					continue
 				}
+				// redis-cli --cluster add-node requires the target node to be
+				// completely empty (no cluster state, no keys in db0). After a
+				// leader CLUSTER RESET the follower retains stale state which
+				// causes add-node to fail with "Node is not empty". Reset it.
+				if err := resetFollowerIfNotEmpty(ctx, followerClient); err != nil {
+					log.FromContext(ctx).Error(err, "Failed to reset follower before add-node", "Follower.Pod", followerPod)
+				}
+				followerClient.Close()
+				executeCommand(ctx, client, cr, cmd, cr.Name+"-leader-0")
 			} else {
 				log.FromContext(ctx).V(1).Info("Skipping Adding node to cluster, already present.", "Follower.Pod", followerPod)
 			}
@@ -332,6 +341,38 @@ func ExecuteRedisReplicationCommand(ctx context.Context, client kubernetes.Inter
 			followerIdx++
 		}
 	}
+}
+
+// resetFollowerIfNotEmpty checks whether a follower node has stale cluster
+// state or data in database 0 and, if so, issues CLUSTER RESET HARD to clear
+// it. redis-cli --cluster add-node requires the target to be completely empty;
+// without this reset the command fails with "Node is not empty" when the
+// follower retains state from a previous cluster incarnation (e.g. after a
+// leader-only CLUSTER RESET during single-node bootstrap).
+func resetFollowerIfNotEmpty(ctx context.Context, client *redis.Client) error {
+	nodesOutput, err := client.ClusterNodes(ctx).Result()
+	if err != nil {
+		return fmt.Errorf("failed to check follower cluster nodes: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(nodesOutput), "\n")
+	knownNodes := len(lines)
+
+	dbSize, err := client.DBSize(ctx).Result()
+	if err != nil {
+		return fmt.Errorf("failed to check follower db size: %w", err)
+	}
+
+	if knownNodes <= 1 && dbSize == 0 {
+		return nil
+	}
+
+	log.FromContext(ctx).Info("Follower is not empty, issuing CLUSTER RESET HARD before add-node",
+		"KnownNodes", knownNodes, "DBSize", dbSize)
+	resetCmd := redis.NewStringCmd(ctx, "cluster", "reset", "hard")
+	if err := client.Process(ctx, resetCmd); err != nil {
+		return fmt.Errorf("CLUSTER RESET HARD failed: %w", err)
+	}
+	return nil
 }
 
 type clusterNodesResponse []string

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -878,6 +878,79 @@ func Test_checkRedisServerRole(t *testing.T) {
 	}
 }
 
+func TestResetFollowerIfNotEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		clusterNodes     string
+		dbSize           int64
+		expectReset      bool
+		clusterNodesErr  error
+		dbSizeErr        error
+		wantErr          bool
+	}{
+		{
+			name:         "empty node — no reset needed",
+			clusterNodes: "abc123 127.0.0.1:6379@16379,myself myself,master - 0 0 0 connected",
+			dbSize:       0,
+			expectReset:  false,
+		},
+		{
+			name: "stale cluster state — reset needed",
+			clusterNodes: "abc123 127.0.0.1:6379@16379,follower-0 myself,slave def456 0 0 0 connected\n" +
+				"def456 10.0.0.1:6379@16379,leader-0 master - 0 0 0 connected 0-16383",
+			dbSize:      0,
+			expectReset: true,
+		},
+		{
+			name:         "keys in db0 — reset needed",
+			clusterNodes: "abc123 127.0.0.1:6379@16379,myself myself,master - 0 0 0 connected",
+			dbSize:       42,
+			expectReset:  true,
+		},
+		{
+			name:            "cluster nodes error — returns error",
+			clusterNodesErr: redis.ErrClosed,
+			wantErr:         true,
+		},
+		{
+			name:         "db size error — returns error",
+			clusterNodes: "abc123 127.0.0.1:6379@16379,myself myself,master - 0 0 0 connected",
+			dbSizeErr:    redis.ErrClosed,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := redismock.NewClientMock()
+
+			if tc.clusterNodesErr != nil {
+				mock.ExpectClusterNodes().SetErr(tc.clusterNodesErr)
+			} else {
+				mock.ExpectClusterNodes().SetVal(tc.clusterNodes)
+				if tc.dbSizeErr != nil {
+					mock.ExpectDBSize().SetErr(tc.dbSizeErr)
+				} else {
+					mock.ExpectDBSize().SetVal(tc.dbSize)
+					if tc.expectReset {
+						mock.Regexp().ExpectClusterResetHard().SetVal("OK")
+					}
+				}
+			}
+
+			err := resetFollowerIfNotEmpty(ctx, db)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestClusterNodes(t *testing.T) {
 	// Discard logs
 


### PR DESCRIPTION
## Summary

- Before `redis-cli --cluster add-node`, check if the follower has stale cluster state (knows other nodes) or data in db0
- If so, issue `CLUSTER RESET HARD` to clear both, allowing `add-node` to succeed
- The follower re-syncs from the master via full sync after joining

After a leader-only `CLUSTER RESET` during single-node bootstrap, the follower retains its previous cluster state and replicated data. `add-node` rejects it with "Node is not empty", causing an infinite error loop on every reconcile cycle.

Fixes #1733
Related: #1407

## Test plan

- [x] Unit tests for `resetFollowerIfNotEmpty` covering: empty node (no-op), stale cluster state, keys in db0, error paths
- [x] Full `k8sutils` test suite passes
- [ ] Manual verification on a single-leader RedisCluster (`clusterSize: 1` with 1 follower) — delete the leader PVC to trigger bootstrap, confirm follower is reset and re-added automatically