### PR TITLE
fix(charts/redis-operator): use dynamic serviceDNSDomain in cert-manager

### DIFF
--- a/charts/redis-operator/templates/cert-manager.yaml
+++ b/charts/redis-operator/templates/cert-manager.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   dnsNames:
     - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc
-    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.cluster.local
+    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.{{ .Values.redisOperator.serviceDNSDomain }}
   issuerRef:
     kind: {{ .Values.issuer.kind }}
     name: {{ .Values.issuer.name }}


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This PR addresses an issue in the ```redis-operator``` Helm chart where the ```Certificate``` resource SANs (Subject Alternative Names) were hardcoded to use the ```.cluster.local``` domain suffix.

When a cluster is configured with a custom ```serviceDNSDomain``` (e.g., ```custom.domain```), the generated certificate fails to match the actual service identity, as the SANs do not reflect the environment's DNS configuration.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1743

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**
To verify the fix, the chart was deployed with a custom domain configuration:
```
redisOperator:
  serviceDNSDomain: "custom.domain"
```
<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
