### PR TITLE
fix(cluster): only render pdb.maxUnavailable / minAvailable when set

### DIFF
--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -33,8 +33,12 @@ tolerations:
 {{- if .pdb.enabled  }}
 pdb:
   enabled: {{ .pdb.enabled }}
+{{- if .pdb.maxUnavailable }}
   maxUnavailable: {{ .pdb.maxUnavailable }}
+{{- end }}
+{{- if .pdb.minAvailable }}
   minAvailable: {{ .pdb.minAvailable }}
+{{- end }}
 {{- end }}
 {{- if .nodeSelector }}
 nodeSelector:


### PR DESCRIPTION
## Summary

Fixes #1745.

The `_helpers.tpl` PDB block unconditionally rendered both `maxUnavailable` and `minAvailable` from `values.yaml`, which the chart defaults to `(1, 1)`:

```gotemplate
{{- if .pdb.enabled }}
pdb:
  enabled: {{ .pdb.enabled }}
  maxUnavailable: {{ .pdb.maxUnavailable }}
  minAvailable: {{ .pdb.minAvailable }}
{{- end }}
```

When a user enabled the PDB without clearing one of them, the RedisCluster CR carried both fields and the operator propagated them to the PodDisruptionBudget controller, which rejects the object:

```
PodDisruptionBudget.policy is invalid: spec: Invalid value:
minAvailable and maxUnavailable cannot be both set
```

RedisCluster reconciliation then loops on the failed PDB and follower StatefulSets are never created.

## Fix

Guard each field with `{{- if .pdb.<field> }}` so users who explicitly set only one keep the chart behaviour they asked for, while setting both still renders both (preserving current behaviour for deliberately-configured overrides).

## Test plan

- [x] Hand-verified the rendered YAML shape with each of the three configurations (only `maxUnavailable`, only `minAvailable`, both)
- [ ] `helm lint charts/redis-cluster` (no `helm` available in my local env; left for CI)
