### PR TITLE
fix(sentinel): don't announce-ip 0.0.0.0 when using hostname discovery

### DIFF
--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -74,8 +74,16 @@ func GenerateConfig() error {
 			cfg.Append("sentinel myid", sentinelID)
 		}
 
-		// If resolveHostnames is set to yes, then we need to announce the hostnames
-		if announceHostnames == "yes" && resolveHostnames == "yes" {
+		// When announceHostnames=yes + resolveHostnames=yes, peer
+		// discovery is expected to go through DNS, not IP. The
+		// previous behaviour here wrote `sentinel announce-ip <ip>`
+		// with whatever IP env var happened to hold - in practice the
+		// operator never sets IP, so the default "0.0.0.0" wound up
+		// in sentinel.conf and Sentinels could not find each other
+		// (#1748). Emit an announce-ip only when we actually have a
+		// concrete IP to announce (i.e. the operator has set IP), and
+		// rely on announce-hostnames + resolve-hostnames otherwise.
+		if announceHostnames == "yes" && resolveHostnames == "yes" && ip != "" && ip != "0.0.0.0" {
 			cfg.Append("sentinel announce-ip", ip)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #1748.

With `announceHostnames=yes` + `resolveHostnames=yes`, the initContainer wrote `sentinel announce-ip <ip>` using whatever value the `IP` env variable held. The operator doesn't set `IP` on the Sentinel pod, so `CoalesceEnv("IP", "0.0.0.0")` returned the `0.0.0.0` default and that ended up in `sentinel.conf` - Sentinels then broadcast `0.0.0.0` to peers and could not find each other, silently short-circuiting hostname discovery.

## Fix

Emit the `announce-ip` line only when we actually have a usable IP (i.e. the operator has set `IP` to something other than `""` / `0.0.0.0`), and rely on `announce-hostnames` + `resolve-hostnames` otherwise. When both hostname modes are on without a real IP, Redis Sentinel auto-discovers via DNS, which is exactly the intent of the feature.

Deployments that do set an IP explicitly (direct-IP mode or dual-stack configurations where `IP` is propagated) keep the previous behaviour.

## Test plan

- [x] `go build ./internal/agent/...`
- [x] Traced both config paths:
  - `announceHostnames=yes + resolveHostnames=yes + IP unset` → no `announce-ip` line, hostname discovery works
  - `announceHostnames=yes + resolveHostnames=yes + IP=10.0.0.42` → `announce-ip 10.0.0.42` line retained
  - `announceHostnames=no` → unchanged
