### PR TITLE
fix: use lowercase appendonly.aof to match legacy data

### DIFF
--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -126,7 +126,15 @@ func GenerateConfig() error {
 		cfg.Append("save", "300 10")
 		cfg.Append("save", "60 10000")
 		cfg.Append("Appendonly", "yes")
-		cfg.Append("Appendfilename", "\"Appendonly.aof\"")
+		// Use lowercase "appendonly.aof" so the init-container and the
+		// legacy redis-operator controller agree on the AOF file name.
+		// Existing clusters created with the non-init-container path
+		// write appendonly.aof; switching GenerateConfigInInitContainer
+		// from false to true on a running cluster used to point redis at
+		// Appendonly.aof instead, which (on case-sensitive filesystems)
+		// meant redis found no AOF on startup, re-initialized empty, and
+		// silently destroyed the data. See OT-CONTAINER-KIT/redis-operator#1746.
+		cfg.Append("Appendfilename", "\"appendonly.aof\"")
 		cfg.Append("dir", dataDir)
 	} else {
 		fmt.Println("Running without persistence mode")

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -126,14 +126,7 @@ func GenerateConfig() error {
 		cfg.Append("save", "300 10")
 		cfg.Append("save", "60 10000")
 		cfg.Append("Appendonly", "yes")
-		// Use lowercase "appendonly.aof" so the init-container and the
-		// legacy redis-operator controller agree on the AOF file name.
-		// Existing clusters created with the non-init-container path
-		// write appendonly.aof; switching GenerateConfigInInitContainer
-		// from false to true on a running cluster used to point redis at
-		// Appendonly.aof instead, which (on case-sensitive filesystems)
-		// meant redis found no AOF on startup, re-initialized empty, and
-		// silently destroyed the data. See OT-CONTAINER-KIT/redis-operator#1746.
+		// lowercase to match the file written by the non-init-container path (#1746)
 		cfg.Append("Appendfilename", "\"appendonly.aof\"")
 		cfg.Append("dir", dataDir)
 	} else {


### PR DESCRIPTION
## Summary

The `GenerateConfigInInitContainer` path wrote `appendfilename` as `Appendonly.aof`, while the legacy controller-rendered config uses lowercase `appendonly.aof`. Switching the feature gate from `false` to `true` on an existing cluster silently destroyed the AOF: on case-sensitive filesystems redis started up, failed to open the capitalized file, treated the data directory as empty, and re-initialized.

## Fix

Lowercase the filename so both code paths reference the same file and existing AOFs survive the migration.

Fixes #1746.

## Test

- `go build ./internal/agent/bootstrap/...` green.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
