### PR TITLE
fix(chart): honour redisOperator.serviceDNSDomain in webhook cert SANs

### DIFF
--- a/charts/redis-operator/templates/cert-manager.yaml
+++ b/charts/redis-operator/templates/cert-manager.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   dnsNames:
     - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc
-    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.cluster.local
+    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.{{ .Values.redisOperator.serviceDNSDomain | default "cluster.local" }}
   issuerRef:
     kind: {{ .Values.issuer.kind }}
     name: {{ .Values.issuer.name }}

--- a/charts/redis-operator/templates/mutating-webhook-configuration.yaml
+++ b/charts/redis-operator/templates/mutating-webhook-configuration.yaml
@@ -6,7 +6,8 @@
   {{- $secretName := .Values.certificate.secretName }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
   {{- $cn := printf "%s.%s.svc" .Values.service.name .Release.Namespace }}
-  {{- $altNames := list $cn (printf "%s.%s.svc.cluster.local" .Values.service.name .Release.Namespace) }}
+  {{- $dnsDomain := default "cluster.local" .Values.redisOperator.serviceDNSDomain }}
+  {{- $altNames := list $cn (printf "%s.%s.svc.%s" .Values.service.name .Release.Namespace $dnsDomain) }}
   {{- if $secret }}
     {{- $caCert = index $secret.data "ca.crt" | b64dec }}
     {{- $tlsCert = index $secret.data "tls.crt" | b64dec }}


### PR DESCRIPTION
## Summary

Both the cert-manager-managed `Certificate` (`charts/redis-operator/templates/cert-manager.yaml`) and the in-cluster self-signed webhook cert (`charts/redis-operator/templates/mutating-webhook-configuration.yaml`) hard-coded a `.cluster.local` suffix on the FQDN SAN. Operators who set `redisOperator.serviceDNSDomain` (for example `custom.domain`) saw the kube-apiserver fail webhook TLS validation because the DNS name it resolves, `<svc>.<ns>.svc.custom.domain`, is not in the issued cert.

## Fix

Derive the suffix from `redisOperator.serviceDNSDomain` with a `cluster.local` default. Existing deployments are unaffected, custom-DNS clusters work out of the box.

Fixes #1743.

## Test

- Helm template render: `<svc>.<ns>.svc.cluster.local` when serviceDNSDomain is unset / `cluster.local`, `<svc>.<ns>.svc.custom.domain` when set to `custom.domain`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
