### PR TITLE
fix: survive nil reconciler result instead of panicking

### DIFF
--- a/internal/controller/common/statefulset/statefulset_reconcile.go
+++ b/internal/controller/common/statefulset/statefulset_reconcile.go
@@ -50,7 +50,20 @@ func Reconcile(ctx context.Context, k8sClient client.Client, expected appsv1.Sta
 			update(&expected, existed.(*appsv1.StatefulSet))
 		},
 	})
-	return *reconciled.(*appsv1.StatefulSet), err
+	// reconciler.Reconcile can return (nil, err) when the downstream
+	// Create/Update failed; the previous unconditional type assertion
+	// panicked the reconciler with 'interface conversion: client.Object
+	// is nil, not *v1.StatefulSet' and crash-looped the operator. Fall
+	// back to the expected object so the controller receives a valid
+	// StatefulSet alongside the error and schedules a requeue.
+	if err != nil || reconciled == nil {
+		return expected, err
+	}
+	sts, ok := reconciled.(*appsv1.StatefulSet)
+	if !ok || sts == nil {
+		return expected, err
+	}
+	return *sts, err
 }
 
 func needUpdate(expected, existed *appsv1.StatefulSet) bool {


### PR DESCRIPTION
Fixes OT-CONTAINER-KIT/redis-operator#1753.

## Problem

`statefulset.Reconcile` unconditionally type-asserted the reconciler result as `*appsv1.StatefulSet`:

```go
return *reconciled.(*appsv1.StatefulSet), err
```

`reconciler.Reconcile` can return `(nil, err)` when the underlying Create/Update failed, so the assertion panicked:

```
panic: interface conversion: client.Object is nil, not *v1.StatefulSet
```

This crashlooped the operator pod every reconcile cycle on `RedisReplication` CRs with an embedded sentinel (`redis-s` StatefulSet), and the managed StatefulSets lost their labels entirely.

## Fix

Fall back to the expected StatefulSet and propagate `err` when the reconciler returned `nil` (or a non-StatefulSet), so the controller receives a valid value alongside the error and schedules a requeue instead of taking down the whole worker.

## Test

`go build ./internal/controller/common/statefulset/...` clean; no existing tests in that package.