### PR TITLE
statefulset reconcile: nil-check before assertion

### DIFF
--- a/internal/controller/common/statefulset/statefulset_reconcile.go
+++ b/internal/controller/common/statefulset/statefulset_reconcile.go
@@ -50,7 +50,14 @@ func Reconcile(ctx context.Context, k8sClient client.Client, expected appsv1.Sta
 			update(&expected, existed.(*appsv1.StatefulSet))
 		},
 	})
-	return *reconciled.(*appsv1.StatefulSet), err
+	if reconciled == nil {
+		return expected, err
+	}
+	sts, ok := reconciled.(*appsv1.StatefulSet)
+	if !ok || sts == nil {
+		return expected, err
+	}
+	return *sts, err
 }
 
 func needUpdate(expected, existed *appsv1.StatefulSet) bool {


### PR DESCRIPTION
Closes #1753. `reconciler.Reconcile` returns nil on transient errors; the bare `reconciled.(*appsv1.StatefulSet)` then panics every RedisReplication sentinel reconcile.