### PR TITLE
fix: sanitize Sentinel agent config values to prevent injection (#1763)

### DIFF
--- a/internal/agent/util/config.go
+++ b/internal/agent/util/config.go
@@ -19,11 +19,29 @@ func NewConfig(path string, defaultConfig ...string) *Config {
 	}
 }
 
+// sanitizeConfigValue strips characters that would let a value escape its
+// directive line (CR/LF) or comment-out trailing tokens (#). Returning the
+// cleaned value rather than erroring keeps the bootstrap path resilient when
+// upstream CRD validation is bypassed (e.g. existing objects, partial RBAC).
+func sanitizeConfigValue(s string) string {
+	r := strings.NewReplacer(
+		"\r", "",
+		"\n", "",
+		"#", "",
+	)
+	return r.Replace(s)
+}
+
 func (c *Config) Append(config ...string) *Config {
 	if len(config) == 0 {
 		return c
 	}
-	c.content = fmt.Sprintf("%s\n%s %s", c.content, config[0], strings.Join(config[1:], " "))
+	directive := sanitizeConfigValue(config[0])
+	args := make([]string, 0, len(config)-1)
+	for _, a := range config[1:] {
+		args = append(args, sanitizeConfigValue(a))
+	}
+	c.content = fmt.Sprintf("%s\n%s %s", c.content, directive, strings.Join(args, " "))
 	return c
 }
 

--- a/internal/agent/util/config.go
+++ b/internal/agent/util/config.go
@@ -19,17 +19,22 @@ func NewConfig(path string, defaultConfig ...string) *Config {
 	}
 }
 
-// sanitizeConfigValue strips characters that would let a value escape its
-// directive line (CR/LF) or comment-out trailing tokens (#). Returning the
-// cleaned value rather than erroring keeps the bootstrap path resilient when
-// upstream CRD validation is bypassed (e.g. existing objects, partial RBAC).
+// configValueSanitizer strips the line-breaking characters (CR/LF) that would
+// let a value escape its directive line. Redis only splits config into
+// directives on '\n' and only treats '#' as a comment at the start of a line,
+// and these values are always written after a fixed directive token, so
+// stripping CR/LF is sufficient to prevent directive injection.
+var configValueSanitizer = strings.NewReplacer(
+	"\r", "",
+	"\n", "",
+)
+
+// sanitizeConfigValue removes characters that would let a value escape its
+// directive line. Cleaning rather than erroring keeps the bootstrap path
+// resilient when upstream CRD validation is bypassed (e.g. existing objects,
+// partial RBAC).
 func sanitizeConfigValue(s string) string {
-	r := strings.NewReplacer(
-		"\r", "",
-		"\n", "",
-		"#", "",
-	)
-	return r.Replace(s)
+	return configValueSanitizer.Replace(s)
 }
 
 func (c *Config) Append(config ...string) *Config {

--- a/internal/agent/util/config_test.go
+++ b/internal/agent/util/config_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAppend_RejectsNewlineInjection guards against CRD-driven Sentinel
+// config injection (issue #1763): a malicious masterGroupName that contains
+// newlines must not be allowed to introduce extra config directives into
+// sentinel.conf.
+func TestAppend_RejectsNewlineInjection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sentinel.conf")
+	cfg := NewConfig(path)
+
+	// Mimics the agent's call site at internal/agent/bootstrap/sentinel/config.go
+	// with the PoC payload from issue #1763.
+	maliciousGroupName := "mymaster 127.0.0.1 6379 2\nsentinel deny-scripts-reconfig no\nsentinel set-auth-pass mymaster injected-password"
+	cfg.Append("sentinel monitor", maliciousGroupName, "127.0.0.1", "6379", "2")
+
+	if err := cfg.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	got := string(contents)
+
+	// The injection vector is newlines inside an appended value: each new
+	// line in sentinel.conf is parsed as an independent directive. Reject
+	// any directive line attacker-controlled tokens could spawn.
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "sentinel deny-scripts-reconfig") ||
+			strings.HasPrefix(line, "sentinel set-auth-pass") {
+			t.Errorf("config contains injected directive line %q; rendered config:\n%s", line, got)
+		}
+	}
+	if strings.Count(got, "\nsentinel monitor") != 1 {
+		t.Errorf("expected exactly one 'sentinel monitor' directive; rendered config:\n%s", got)
+	}
+}
+
+// TestAppend_PreservesValidValues ensures sanitization does not mangle
+// well-formed inputs.
+func TestAppend_PreservesValidValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sentinel.conf")
+	cfg := NewConfig(path)
+
+	cfg.Append("sentinel monitor", "mymaster", "127.0.0.1", "6379", "2")
+	cfg.Append("sentinel down-after-milliseconds", "mymaster", "30000")
+
+	if err := cfg.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	got := string(contents)
+
+	for _, want := range []string{
+		"sentinel monitor mymaster 127.0.0.1 6379 2",
+		"sentinel down-after-milliseconds mymaster 30000",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in rendered config, got:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1763.

The agent's `Config.Append` interpolated CRD-derived strings (`masterGroupName`, `quorum`, etc.) into `sentinel.conf` with no escaping, so a newline in any value let an attacker with CRD-create RBAC inject extra Sentinel/Redis directives. This patch strips CR/LF/# from each appended directive and argument so values can't break out of their line, and adds a regression test using the issue's exact PoC payload.