### PR TITLE
fix(config): apply spec.redisConfig.dynamicConfig via CONFIG SET (#1757)

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -347,29 +347,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		k8sutils.CheckIfEmptyMasters(ctx, r.K8sClient, instance)
 	}
 
-	// Mark the cluster status as ready if all the leader and follower nodes are ready
-	// and the cluster is not already in Ready state (to avoid unnecessary status updates)
-	if instance.Status.ReadyLeaderReplicas == leaderReplicas && instance.Status.ReadyFollowerReplicas == followerReplicas && instance.Status.State != rcvb2.RedisClusterReady {
+	// Reconcile dynamic config on every cycle so updates after the cluster is Ready are applied (#1757).
+	if instance.Status.ReadyLeaderReplicas == leaderReplicas && instance.Status.ReadyFollowerReplicas == followerReplicas {
 		monitoring.RedisClusterHealthy.WithLabelValues(instance.Namespace, instance.Name).Set(0)
 		if k8sutils.RedisClusterStatusHealth(ctx, r.K8sClient, instance) {
 			monitoring.RedisClusterHealthy.WithLabelValues(instance.Namespace, instance.Name).Set(1)
-			// Apply dynamic config to all Redis instances in the cluster
 			if err = k8sutils.SetRedisClusterDynamicConfig(ctx, r.K8sClient, instance); err != nil {
 				logger.Error(err, "Failed to set dynamic config")
 				return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
 			}
 
-			requeue, err := r.updateStatus(ctx, instance, rcvb2.RedisClusterStatus{
-				State:                 rcvb2.RedisClusterReady,
-				Reason:                rcvb2.ReadyClusterReason,
-				ReadyLeaderReplicas:   leaderReplicas,
-				ReadyFollowerReplicas: followerReplicas,
-			})
-			if err != nil {
-				return intctrlutil.RequeueE(ctx, err, "")
-			}
-			if requeue {
-				return intctrlutil.Requeue()
+			if instance.Status.State != rcvb2.RedisClusterReady {
+				requeue, err := r.updateStatus(ctx, instance, rcvb2.RedisClusterStatus{
+					State:                 rcvb2.RedisClusterReady,
+					Reason:                rcvb2.ReadyClusterReason,
+					ReadyLeaderReplicas:   leaderReplicas,
+					ReadyFollowerReplicas: followerReplicas,
+				})
+				if err != nil {
+					return intctrlutil.RequeueE(ctx, err, "")
+				}
+				if requeue {
+					return intctrlutil.Requeue()
+				}
 			}
 		}
 	}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -869,6 +869,12 @@ func GetRedisReplicationRealMaster(ctx context.Context, client kubernetes.Interf
 
 // SetRedisClusterDynamicConfig applies dynamic configuration to each Redis instance in the cluster
 func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) error {
+	return setRedisClusterDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+		return configureRedisClient(ctx, client, cr, podName)
+	})
+}
+
+func setRedisClusterDynamicConfig(ctx context.Context, cr *rcvb2.RedisCluster, clientFactory func(podName string) *redis.Client) error {
 	// Get dynamic configuration
 	dynamicConfig := cr.Spec.GetRedisDynamicConfig()
 	if len(dynamicConfig) == 0 {
@@ -888,7 +894,7 @@ func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interfa
 			podName = cr.Name + "-follower-" + strconv.Itoa(i-int(leaderReplicas))
 		}
 
-		redisClient := configureRedisClient(ctx, client, cr, podName)
+		redisClient := clientFactory(podName)
 		defer redisClient.Close()
 
 		// Check if Redis instance is accessible

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -937,3 +937,81 @@ e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,hostname1 myself,
 		})
 	}
 }
+
+// TestSetRedisClusterDynamicConfigAppliesConfigSet is a regression test for issue #1757.
+func TestSetRedisClusterDynamicConfigAppliesConfigSet(t *testing.T) {
+	leaderReplicas := int32(2)
+	followerReplicas := int32(1)
+	cr := &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "rc", Namespace: "default"},
+		Spec: rcvb2.RedisClusterSpec{
+			ClusterSize: ptr.To(leaderReplicas),
+			RedisLeader: rcvb2.RedisLeader{
+				RedisLeader: common.RedisLeader{Replicas: ptr.To(leaderReplicas)},
+			},
+			RedisFollower: rcvb2.RedisFollower{
+				RedisFollower: common.RedisFollower{Replicas: ptr.To(followerReplicas)},
+			},
+			RedisConfig: &common.RedisConfig{
+				DynamicConfig: []string{
+					"maxmemory-samples 11",
+					"maxmemory-policy allkeys-lru",
+				},
+			},
+		},
+	}
+
+	clientByPod := map[string]*redis.Client{}
+	mockByPod := map[string]redismock.ClientMock{}
+	expectedPods := []string{"rc-leader-0", "rc-leader-1", "rc-follower-0"}
+	for _, pod := range expectedPods {
+		c, m := redismock.NewClientMock()
+		m.ExpectPing().SetVal("PONG")
+		m.ExpectConfigSet("maxmemory-samples", "11").SetVal("OK")
+		m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+		clientByPod[pod] = c
+		mockByPod[pod] = m
+	}
+
+	visited := map[string]int{}
+	factory := func(podName string) *redis.Client {
+		visited[podName]++
+		c, ok := clientByPod[podName]
+		if !ok {
+			t.Fatalf("unexpected pod %q passed to client factory", podName)
+		}
+		return c
+	}
+
+	err := setRedisClusterDynamicConfig(context.Background(), cr, factory)
+	assert.NoError(t, err)
+
+	for _, pod := range expectedPods {
+		assert.Equalf(t, 1, visited[pod], "expected %s to be configured exactly once", pod)
+		if mErr := mockByPod[pod].ExpectationsWereMet(); mErr != nil {
+			t.Errorf("unfulfilled CONFIG SET expectations for %s: %s", pod, mErr)
+		}
+	}
+}
+
+func TestSetRedisClusterDynamicConfigEmptyIsNoop(t *testing.T) {
+	cr := &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "rc", Namespace: "default"},
+		Spec: rcvb2.RedisClusterSpec{
+			ClusterSize: ptr.To(int32(1)),
+			RedisLeader: rcvb2.RedisLeader{
+				RedisLeader: common.RedisLeader{Replicas: ptr.To(int32(1))},
+			},
+			RedisFollower: rcvb2.RedisFollower{
+				RedisFollower: common.RedisFollower{Replicas: ptr.To(int32(0))},
+			},
+		},
+	}
+
+	factory := func(podName string) *redis.Client {
+		t.Fatalf("client factory must not be called when dynamicConfig is empty (got pod %q)", podName)
+		return nil
+	}
+
+	assert.NoError(t, setRedisClusterDynamicConfig(context.Background(), cr, factory))
+}


### PR DESCRIPTION
**Description**

Fixes #1757.

The `SetRedisClusterDynamicConfig` call was gated by `instance.Status.State != rcvb2.RedisClusterReady`, so updates to `spec.redisConfig.dynamicConfig` were never re-applied once the cluster reached the Ready state. This lifts that gate and re-runs `CONFIG SET` on every reconcile when all replicas are ready and the cluster is healthy; `CONFIG SET` is idempotent so unchanged values are a no-op.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

`SetRedisClusterDynamicConfig` is split into a thin public wrapper plus an inner function that takes a `*redis.Client` factory, so the apply mechanics (PING gating, per-key `CONFIG SET`, multi-pod iteration) can be unit-tested with `go-redis/redismock` (`TestSetRedisClusterDynamicConfigAppliesConfigSet`, `TestSetRedisClusterDynamicConfigEmptyIsNoop`).