### PR TITLE
feat: RedisReplication - set pod as slave after a set number of retries

### DIFF
--- a/docs/content/en/docs/Configuration/RedisReplication/_index.md
+++ b/docs/content/en/docs/Configuration/RedisReplication/_index.md
@@ -79,6 +79,27 @@ Redis replication configuration can be customized by [values.yaml](https://githu
 | sentinel.resolveHostnames | string | `"no"` | Whether Sentinel resolves hostnames instead of IPs |
 | sentinel.announceHostnames | string | `"no"` | Whether Sentinel announces hostnames to clients |
 
+## Operator Reconciliation Behavior
+
+During RedisReplication reconciliation, the operator discovers each Redis pod role by querying Redis `INFO replication`. If a pod is temporarily unreachable, the operator retries the connection with exponential backoff before classifying the pod.
+
+- The operator retries each pod up to `REDIS_POD_REACH_ATTEMPTS` times. The default is `3`.
+- Retries use exponential backoff with a 1 second base delay.
+- If the role still cannot be read after the configured attempts, the operator assumes the pod is a replica.
+- When listing masters, unreachable pods are omitted. When listing replicas, they are included.
+- StatefulSet lookup failures still fail reconciliation.
+
+Set `REDIS_POD_REACH_ATTEMPTS` on the redis-operator deployment. With the operator Helm chart, pass it through `redisOperator.env`:
+
+```yaml
+redisOperator:
+  env:
+    - name: REDIS_POD_REACH_ATTEMPTS
+      value: "5"
+```
+
+Invalid or non-positive values fall back to the default of `3`.
+
 ## RedisReplication Instance Configuration
 
 ### Dynamic Configuration

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -220,7 +220,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	leaderSTSReady := r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-leader")
-	followerSTSReady := r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-follower")
+	// Skip follower readiness when no followers are configured. A 0-replica
+	// follower StatefulSet can fail IsStatefulSetReady after recreate because
+	// CurrentRevision never catches UpdateRevision with no pods to roll.
+	followerSTSReady := followerReplicas == 0 || r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name+"-follower")
 	if !leaderSTSReady || !followerSTSReady {
 		// Sync the actual ready replica counts from the StatefulSets so the status
 		// leaves Ready (and the reported counts drop) when pods go down after the

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -464,22 +464,21 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 		currentRealMaster := r.redisReplicationRealMaster(ctx, instance, masterNodes)
 
 		if currentRealMaster == "" && !instance.EnableSentinel() {
+			// A single identified master is enough to safely attach the slaves we
+			// already observed. Skipping on incompleteTopology delayed SlaveOf for
+			// pods classified as slaves (including assume-unreachable-as-slave) until
+			// every replica was Ready, which left the data path unreplicated.
 			log.FromContext(ctx).Info("Detected disconnected slaves, reconfiguring replication",
-				"master", realMaster, "slaves", slaveNodes)
+				"master", realMaster, "slaves", slaveNodes,
+				"observedPods", observedPods, "expectedPods", *instance.Spec.Size)
 
-			if incompleteTopology {
-				log.FromContext(ctx).Info("Skipping master-slave reconfiguration because the observed topology is incomplete",
-					"observedPods", observedPods,
-					"expectedPods", *instance.Spec.Size)
-			} else {
-				allPods := append(masterNodes, slaveNodes...)
-				if err := r.createRedisReplicationLink(ctx, instance, allPods, realMaster); err != nil {
-					log.FromContext(ctx).Error(err, "Failed to reconfigure master-slave replication",
-						"master", realMaster, "slaves", slaveNodes)
-					return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
-				}
-				log.FromContext(ctx).Info("Successfully reconfigured slave replication")
+			allPods := append(masterNodes, slaveNodes...)
+			if err := r.createRedisReplicationLink(ctx, instance, allPods, realMaster); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to reconfigure master-slave replication",
+					"master", realMaster, "slaves", slaveNodes)
+				return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
 			}
+			log.FromContext(ctx).Info("Successfully reconfigured slave replication")
 		}
 	}
 

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -19,8 +19,10 @@ import (
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testing.T) {
+func TestReconcileRedisReconfiguresDisconnectedSlavesEvenWhenTopologyIsIncomplete(t *testing.T) {
 	createCalled := false
+	var gotPods []string
+	var gotMaster string
 	r := &Reconciler{
 		K8sClient: fake.NewSimpleClientset(),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
@@ -32,8 +34,10 @@ func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testin
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
-		CreateRedisReplicationLink: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error {
+		CreateRedisReplicationLink: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, pods []string, realMaster string) error {
 			createCalled = true
+			gotPods = append([]string{}, pods...)
+			gotMaster = realMaster
 			return nil
 		},
 	}
@@ -41,7 +45,9 @@ func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testin
 
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
-	assert.False(t, createCalled)
+	assert.True(t, createCalled)
+	assert.ElementsMatch(t, []string{"example-replication-0", "example-replication-1"}, gotPods)
+	assert.Equal(t, "example-replication-0", gotMaster)
 }
 
 func TestReconcileRedisSkipsReplicationChangesWhenMultipleMastersAreObservedButTopologyIsIncomplete(t *testing.T) {

--- a/internal/envs/envs.go
+++ b/internal/envs/envs.go
@@ -48,6 +48,9 @@ const (
 
 	// ServiceDNSDomain defines the DNS domain suffix for Kubernetes services
 	ServiceDNSDomain = "SERVICE_DNS_DOMAIN"
+
+	// RedisPodReachAttemptsEnv defines the number of attempts to reach a Redis pod during replication reconciliation
+	RedisPodReachAttemptsEnv = "REDIS_POD_REACH_ATTEMPTS"
 )
 
 var (
@@ -100,6 +103,16 @@ func GetMaxConcurrentReconciles(defaultValue int) int {
 func GetExecCommandTimeout(defaultValue time.Duration) time.Duration {
 	if valueStr := os.Getenv(ExecCommandTimeoutEnv); valueStr != "" {
 		if value, err := time.ParseDuration(valueStr); err == nil && value > 0 {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+// GetRedisPodReachAttempts returns the number of attempts to reach a Redis pod during replication reconciliation.
+func GetRedisPodReachAttempts(defaultValue int) int {
+	if valueStr := strings.TrimSpace(os.Getenv(RedisPodReachAttemptsEnv)); valueStr != "" {
+		if value, err := strconv.Atoi(valueStr); err == nil && value > 0 {
 			return value
 		}
 	}

--- a/internal/envs/envs_test.go
+++ b/internal/envs/envs_test.go
@@ -155,6 +155,56 @@ func TestGetExecCommandTimeout(t *testing.T) {
 	}
 }
 
+func TestGetRedisPodReachAttempts(t *testing.T) {
+	tests := []struct {
+		name          string
+		envValue      string
+		defaultValue  int
+		expectedValue int
+	}{
+		{
+			name:          "empty value with default",
+			envValue:      "",
+			defaultValue:  3,
+			expectedValue: 3,
+		},
+		{
+			name:          "valid value",
+			envValue:      "5",
+			defaultValue:  3,
+			expectedValue: 5,
+		},
+		{
+			name:          "invalid value with default",
+			envValue:      "invalid",
+			defaultValue:  3,
+			expectedValue: 3,
+		},
+		{
+			name:          "non-positive value with default",
+			envValue:      "0",
+			defaultValue:  3,
+			expectedValue: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(RedisPodReachAttemptsEnv, tt.envValue)
+				defer os.Unsetenv(RedisPodReachAttemptsEnv)
+			} else {
+				os.Unsetenv(RedisPodReachAttemptsEnv)
+			}
+
+			actualValue := GetRedisPodReachAttempts(tt.defaultValue)
+			if actualValue != tt.expectedValue {
+				t.Errorf("GetRedisPodReachAttempts() = %v, want %v", actualValue, tt.expectedValue)
+			}
+		})
+	}
+}
+
 func TestIsWebhookEnabled(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -898,13 +898,41 @@ func getRedisReplicationHostname(redisInfo RedisDetails, cr *rrvb2.RedisReplicat
 	return fmt.Sprintf("%s.%s-headless.%s.svc.%s", redisInfo.PodName, cr.Name, cr.Namespace, envs.GetServiceDNSDomain())
 }
 
+const defaultRedisPodReachAttempts = 3
+
+func getRedisReplicationPodRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, pod *corev1.Pod) string {
+	var podRole string
+	attempts := envs.GetRedisPodReachAttempts(defaultRedisPodReachAttempts)
+	err := retry.Do(
+		func() error {
+			redisClient := configureRedisReplicationClientForPod(ctx, cl, cr, pod)
+			defer redisClient.Close()
+
+			role, err := checkRedisServerRole(ctx, redisClient, pod.Name)
+			if err != nil {
+				return err
+			}
+			podRole = role
+			return nil
+		},
+		retry.Attempts(uint(attempts)),
+		retry.Delay(1000*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
+		retry.OnRetry(func(n uint, err error) {
+			log.FromContext(ctx).V(1).Info("Retrying reach redis pod", "pod", pod.Name, "attempt", n+1, "error", err)
+		}),
+	)
+	if err != nil {
+		log.FromContext(ctx).Info("Assuming unreachable redis pod is a slave", "pod", pod.Name, "attempts", attempts, "error", err)
+		return "slave"
+	}
+	return podRole
+}
+
 // Get Redis nodes by it's role i.e. master, slave and sentinel
 func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string) ([]string, error) {
 	return getRedisNodesByRole(ctx, cl, cr, redisRole, func(ctx context.Context, pod *corev1.Pod) (string, error) {
-		redisClient := configureRedisReplicationClientForPod(ctx, cl, cr, pod)
-		defer redisClient.Close()
-
-		return checkRedisServerRole(ctx, redisClient, pod.Name)
+		return getRedisReplicationPodRole(ctx, cl, cr, pod), nil
 	})
 }
 

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -59,6 +59,17 @@ func (s *StatefulSetService) IsStatefulSetReady(ctx context.Context, namespace, 
 		replicas = int(*sts.Spec.Replicas)
 	}
 
+	// Scaled-to-zero StatefulSets have no pods to roll CurrentRevision forward.
+	// After recreate/update, CurrentRevision can permanently differ from
+	// UpdateRevision, which would otherwise leave callers stuck "not ready".
+	if replicas == 0 {
+		if sts.Status.ObservedGeneration != sts.Generation {
+			log.FromContext(ctx).V(1).Info("StatefulSet is not ready", "Status.ObservedGeneration", sts.Status.ObservedGeneration, "Generation", sts.Generation)
+			return false
+		}
+		return true
+	}
+
 	if expectedUpdateReplicas := replicas - partition; sts.Status.UpdatedReplicas < int32(expectedUpdateReplicas) {
 		log.FromContext(ctx).V(1).Info("StatefulSet is not ready", "Status.UpdatedReplicas", sts.Status.UpdatedReplicas, "ExpectedUpdateReplicas", expectedUpdateReplicas)
 		return false

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -21,6 +21,83 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func TestIsStatefulSetReadyZeroReplicas(t *testing.T) {
+	tests := []struct {
+		name   string
+		sts    *appsv1.StatefulSet
+		want   bool
+	}{
+		{
+			name: "zero replicas with mismatched revisions is ready once observed",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "example-follower",
+					Namespace:  "default",
+					Generation: 2,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					CurrentRevision:    "example-follower-old",
+					UpdateRevision:     "example-follower-new",
+					ReadyReplicas:      0,
+					UpdatedReplicas:    0,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "zero replicas not ready until generation is observed",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "example-follower",
+					Namespace:  "default",
+					Generation: 2,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					CurrentRevision:    "example-follower-new",
+					UpdateRevision:     "example-follower-new",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-zero replicas still require matching revisions",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "example-leader",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					CurrentRevision:    "example-leader-old",
+					UpdateRevision:     "example-leader-new",
+					ReadyReplicas:      3,
+					UpdatedReplicas:    3,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewStatefulSetService(k8sClientFake.NewSimpleClientset(tt.sts))
+			assert.Equal(t, tt.want, svc.IsStatefulSetReady(context.Background(), tt.sts.Namespace, tt.sts.Name))
+		})
+	}
+}
+
 func TestGenerateAuthAndTLSArgs(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
@@ -32,9 +32,34 @@ spec:
         - apply:
             file: replication.yaml
         - assert:
+            file: ready-sts.yaml
+        - assert:
             file: ready-replication.yaml
 
-    # Step 4: Test ACL authentication on master
+    # Step 4: Wait until replicas are linked to the master before exercising data path
+    - name: Wait for replication link
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              #!/bin/bash
+              set -e
+              for i in $(seq 1 60); do
+                INFO=$(kubectl exec --namespace "${NAMESPACE}" redis-replication-acl-pvc-1 -- \
+                  redis-cli -p 6379 --user repluser --pass repl@secure --no-auth-warning info replication 2>&1 || true)
+                if echo "${INFO}" | grep -q 'role:slave' && echo "${INFO}" | grep -q 'master_link_status:up'; then
+                  echo "replication link is up"
+                  exit 0
+                fi
+                echo "attempt ${i}: waiting for replica link..."
+                sleep 3
+              done
+              echo "timed out waiting for replication link"
+              exit 1
+            check:
+              (contains($stdout, 'replication link is up')): true
+
+    # Step 5: Test ACL authentication on master
     - name: Test ACL user authentication on master
       try:
         - script:
@@ -45,7 +70,7 @@ spec:
             check:
               (contains($stdout, 'PONG')): true
 
-    # Step 5: Test write operation on master
+    # Step 6: Test write operation on master
     - name: Test write operation on master
       try:
         - script:
@@ -56,20 +81,30 @@ spec:
             check:
               (contains($stdout, 'OK')): true
 
-    # Step 6: Test read operation on replica
+    # Step 7: Test read operation on replica
     - name: Test read operation on replica
       try:
-        - sleep:
-            duration: 30s
         - script:
-            timeout: 30s
-            content: >
-              kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-1 --
-              redis-cli -p 6379 --user repluser --pass repl@secure get repl-key 2>&1
+            timeout: 90s
+            content: |
+              #!/bin/bash
+              set -e
+              for i in $(seq 1 20); do
+                VALUE=$(kubectl exec --namespace "${NAMESPACE}" redis-replication-acl-pvc-1 -- \
+                  redis-cli -p 6379 --user repluser --pass repl@secure --no-auth-warning get repl-key 2>&1 || true)
+                if echo "${VALUE}" | grep -q 'ACL PVC replication test'; then
+                  echo "${VALUE}"
+                  exit 0
+                fi
+                echo "attempt ${i}: replica value='${VALUE}', waiting..."
+                sleep 2
+              done
+              echo "timed out waiting for key on replica"
+              exit 1
             check:
               (contains($stdout, 'ACL PVC replication test')): true
 
-    # Step 7: Verify ACL file on master
+    # Step 8: Verify ACL file on master
     - name: Verify ACL file on master
       try:
         - script:
@@ -80,7 +115,7 @@ spec:
             check:
               (contains($stdout, 'user repluser')): true
 
-    # Step 8: Verify ACL file on replica
+    # Step 9: Verify ACL file on replica
     - name: Verify ACL file on replica
       try:
         - script:
@@ -90,15 +125,3 @@ spec:
               cat /data/redis/user.acl 2>&1
             check:
               (contains($stdout, 'user repluser')): true
-
-    # Step 9: Test replication status
-    - name: Verify replication status
-      try:
-        - script:
-            timeout: 30s
-            content: >
-              kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-1 --
-              redis-cli -p 6379 --user repluser --pass repl@secure info replication 2>&1
-            check:
-              (contains($stdout, 'role:slave')): true
-              (contains($stdout, 'master_link_status:up')): true

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/ready-sts.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/ready-sts.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-replication-acl-pvc
+status:
+  readyReplicas: 3
+  replicas: 3


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Replication reconciliation no longer fails when a single Redis pod is temporarily unreachable. GetRedisNodesByRole retries each pod with backoff, then classifies it as a slave if the role still cannot be read.

During restarts, or network issues, GetRedisNodesByRole could fail on anunreachable pod and abort the reconcile, that made replication setup and status updates false when pods were not all ready at once.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->


New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
