### PR TITLE
fix(replication): skip unreachable pods in GetRedisNodesByRole

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -692,7 +692,18 @@ func getRedisReplicationHostname(redisInfo RedisDetails, cr *rrvb2.RedisReplicat
 	return fmt.Sprintf("%s.%s-headless.%s.svc.%s", redisInfo.PodName, cr.Name, cr.Namespace, envs.GetServiceDNSDomain())
 }
 
-// Get Redis nodes by it's role i.e. master, slave and sentinel
+// GetRedisNodesByRole returns the pod names of redis pods currently serving the
+// given role (master or slave).
+//
+// Pods that cannot be reached (Pending, restarting, network blip during a
+// rolling restart, sentinel-driven IP churn) are skipped rather than aborting
+// the entire lookup. This lets the reconcile loop converge on the reachable
+// subset — labels and `<name>-master` Service endpoints stay accurate even
+// when one ordinal is temporarily unhealthy.
+//
+// See GH issues #1711 and #1738 for the prior abort-on-first-error behavior
+// that left `<name>-master` Service endpoints stale and `redis-role` labels
+// unsynced after sentinel failover or pod rolling restarts.
 func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string) ([]string, error) {
 	statefulset, err := GetStatefulSet(ctx, cl, cr.GetNamespace(), cr.GetName())
 	if err != nil {
@@ -706,10 +717,12 @@ func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 	for i := 0; i < int(replicas); i++ {
 		podName := statefulset.Name + "-" + strconv.Itoa(i)
 		redisClient := configureRedisReplicationClient(ctx, cl, cr, podName)
-		defer redisClient.Close()
 		podRole, err := checkRedisServerRole(ctx, redisClient, podName)
+		redisClient.Close()
 		if err != nil {
-			return nil, err
+			log.FromContext(ctx).V(1).Info("Skipping pod whose role cannot be determined; continuing with reachable pods",
+				"pod", podName, "error", err.Error())
+			continue
 		}
 		if podRole == redisRole {
 			pods = append(pods, podName)


### PR DESCRIPTION
## Problem
`GetRedisNodesByRole` aborts on the first redis pod whose `INFO Replication` call fails. Callers (`reconcileStatus`, `reconcileRedis`) treat the error as fatal and requeue without making progress, so:

- **#1738** — `redis-role` pod label is not updated after sentinel failover. `UpdateRedisRoleLabel` runs *after* this lookup; if the just-demoted master pod is briefly unreachable mid-restart, the whole status reconcile aborts before reaching the label update.
- **#1711** — `<name>-master` Service stays pointed at the old master when any redis pod is `Pending`/unreachable. Same abort path prevents `Status.MasterNode` and the `redis-role: master` label that drives the Service selector from updating.

## Root cause
`internal/k8sutils/redis.go::GetRedisNodesByRole`:

```go
for i := 0; i < int(replicas); i++ {
    ...
    podRole, err := checkRedisServerRole(ctx, redisClient, podName)
    if err != nil {
        return nil, err   // <-- one unreachable pod kills the whole lookup
    }
    ...
}
```

## Fix
Skip pods whose role cannot be determined and continue with the reachable subset. This matches the existing tolerant behavior in `internal/controller/common/redis/heal.go::UpdateRedisRoleLabel`, which already \`continue\`s on per-pod errors.

Also moved \`redisClient.Close()\` out of \`defer\` inside the loop — the prior code accumulated closers until function return, leaking connections on long replica counts.

## Reproduction (verified)
Tested on \`kind\` v0.31, k8s v1.34, \`quay.io/opstree/redis:v8.6.2\`:

1. Deploy \`RedisReplication\` (3 replicas) + \`RedisSentinel\` (3 replicas) with the patched operator
2. \`redis-cli SENTINEL FAILOVER myMaster\` — operator converges:
   - \`Updating master node previous=redis-0 new=redis-2\`
   - \`updated pod role label pod=redis-0 oldRole=master newRole=slave\`
   - \`updated pod role label pod=redis-2 oldRole=slave newRole=master\`
   - \`redis-master\` Service endpoint flips to new master's pod IP
3. Repeat failover redis-2 → redis-0 — same clean convergence
4. \`kubectl delete pod redis-1 --grace-period=0 --force\` mid-flight — operator does not abort, labels stay correct, no errors logged

## Checklist
- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/k8sutils/...\` clean
- [x] \`go test ./internal/k8sutils/...\` — existing tests still pass
- [x] Manual sentinel-failover reproduction on kind
- [x] CI tests

Fixes #1711
Fixes #1738