### PR TITLE
fix(reconcile): guard nil-interface type assertion in StatefulSet/Service reconcile (fixes #1753)

### DIFF
--- a/internal/controller/common/service/service_reconcile.go
+++ b/internal/controller/common/service/service_reconcile.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/reconciler"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
@@ -27,7 +28,16 @@ func Reconcile(
 			update(&expected, existed.(*corev1.Service))
 		},
 	})
-	return *reconciled.(*corev1.Service), err
+	// reconciler.Reconcile returns (nil, err) on internal error paths.
+	// Avoid panicking via nil-interface type assertion (see GH #1753).
+	if err != nil || reconciled == nil {
+		return corev1.Service{}, err
+	}
+	svc, ok := reconciled.(*corev1.Service)
+	if !ok || svc == nil {
+		return corev1.Service{}, fmt.Errorf("service reconciler returned unexpected type %T", reconciled)
+	}
+	return *svc, nil
 }
 
 func needUpdate(expected, existed *corev1.Service) bool {

--- a/internal/controller/common/service/service_reconcile_test.go
+++ b/internal/controller/common/service/service_reconcile_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+func newExpected() corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-master", Namespace: "redis"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "redis", "redis-role": "master"},
+			Ports:    []corev1.ServicePort{{Port: 6379}},
+		},
+	}
+}
+
+// TestReconcile_DoesNotPanicOnUpdateError mirrors the StatefulSet panic guard
+// for Service reconcile path (same GH #1753 root cause).
+func TestReconcile_DoesNotPanicOnUpdateError(t *testing.T) {
+	scheme := newScheme(t)
+	existing := newExpected()
+	existing.Spec.Ports[0].Port = 9999 // forces update
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return errors.New("simulated update conflict")
+			},
+		}).
+		Build()
+
+	expected := newExpected()
+
+	var out corev1.Service
+	var err error
+	require.NotPanics(t, func() {
+		out, err = Reconcile(context.Background(), cli, expected, nil)
+	})
+	assert.Error(t, err)
+	assert.Equal(t, corev1.Service{}, out)
+}
+
+func TestReconcile_HappyPath(t *testing.T) {
+	scheme := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	out, err := Reconcile(context.Background(), cli, newExpected(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "redis-master", out.Name)
+	assert.Equal(t, "redis", out.Namespace)
+}

--- a/internal/controller/common/statefulset/statefulset_reconcile.go
+++ b/internal/controller/common/statefulset/statefulset_reconcile.go
@@ -2,6 +2,7 @@ package statefulset
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/reconciler"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
@@ -50,7 +51,20 @@ func Reconcile(ctx context.Context, k8sClient client.Client, expected appsv1.Sta
 			update(&expected, existed.(*appsv1.StatefulSet))
 		},
 	})
-	return *reconciled.(*appsv1.StatefulSet), err
+	// reconciler.Reconcile returns (nil, err) on several error paths
+	// (SetControllerReference, GVK lookup, Get, Update, Accessor).
+	// Dereferencing a nil interface here used to panic with
+	// "interface conversion: client.Object is nil, not *v1.StatefulSet"
+	// and crash-loop the operator on transient Update conflicts. Treat
+	// nil-result as an error path and return a zero value to the caller.
+	if err != nil || reconciled == nil {
+		return appsv1.StatefulSet{}, err
+	}
+	sts, ok := reconciled.(*appsv1.StatefulSet)
+	if !ok || sts == nil {
+		return appsv1.StatefulSet{}, fmt.Errorf("statefulset reconciler returned unexpected type %T", reconciled)
+	}
+	return *sts, nil
 }
 
 func needUpdate(expected, existed *appsv1.StatefulSet) bool {

--- a/internal/controller/common/statefulset/statefulset_reconcile_test.go
+++ b/internal/controller/common/statefulset/statefulset_reconcile_test.go
@@ -1,0 +1,81 @@
+package statefulset
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+func newExpected() appsv1.StatefulSet {
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-s", Namespace: "redis"},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "redis-s"}},
+			},
+		},
+	}
+}
+
+// TestReconcile_DoesNotPanicOnUpdateError reproduces GH #1753: the prior code
+// dereferenced a nil interface when reconciler.Reconcile returned (nil, err)
+// from an Update failure, crash-looping the operator.
+func TestReconcile_DoesNotPanicOnUpdateError(t *testing.T) {
+	scheme := newScheme(t)
+	existing := newExpected()
+	existing.Spec.ServiceName = "old-svc"
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return errors.New("simulated update conflict")
+			},
+		}).
+		Build()
+
+	expected := newExpected()
+	expected.Spec.ServiceName = "new-svc" // triggers update path
+
+	// Must not panic; must return an error and a zero-value StatefulSet.
+	var out appsv1.StatefulSet
+	var err error
+	require.NotPanics(t, func() {
+		out, err = Reconcile(context.Background(), cli, expected, nil)
+	})
+	assert.Error(t, err)
+	assert.Equal(t, appsv1.StatefulSet{}, out)
+}
+
+// TestReconcile_HappyPath ensures the non-error path still returns the
+// reconciled StatefulSet correctly.
+func TestReconcile_HappyPath(t *testing.T) {
+	scheme := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	expected := newExpected()
+
+	out, err := Reconcile(context.Background(), cli, expected, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "redis-s", out.Name)
+	assert.Equal(t, "redis", out.Namespace)
+}


### PR DESCRIPTION
## Problem
`internal/controller/common/reconciler/reconciler.go::Reconcile` returns `(nil, err)` on multiple internal error paths:

- `SetControllerReference` failure
- `apiutil.GVKForObject` failure
- `client.Get` non-`NotFound` failure
- `meta.Accessor` failure
- `client.Update` conflict / forbidden

The two callers — `internal/controller/common/statefulset/statefulset_reconcile.go` and `internal/controller/common/service/service_reconcile.go` — did the type assertion + deref *before* checking the error:

```go
return *reconciled.(*appsv1.StatefulSet), err
```

When `reconciled` is the nil interface, the type assertion panics:

```
panic: interface conversion: client.Object is nil, not *v1.StatefulSet [recovered]
    panic: interface conversion: client.Object is nil, not *v1.StatefulSet

goroutine N [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
...
github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/statefulset.Reconcile(...)
    /workspace/internal/controller/common/statefulset/statefulset_reconcile.go:53 +0x225
```

controller-runtime recovers the panic, but the goroutine is killed and the reconcile is requeued, so every subsequent attempt panics on the same code path → operator crash-loop.

## Fix
Guard the type assertion in both reconcile shims:

```go
if err != nil || reconciled == nil {
    return appsv1.StatefulSet{}, err
}
sts, ok := reconciled.(*appsv1.StatefulSet)
if !ok || sts == nil {
    return appsv1.StatefulSet{}, fmt.Errorf("statefulset reconciler returned unexpected type %T", reconciled)
}
return *sts, nil
```

Same shape for the Service reconcile path.

## Tests
Added `statefulset_reconcile_test.go` and `service_reconcile_test.go`:

- `TestReconcile_DoesNotPanicOnUpdateError` — installs a fake-client interceptor that returns an error from `Update`, asserts `Reconcile` does **not panic** and returns `(zero-value, err)`. Reproduces the GH #1753 panic against the old code.
- `TestReconcile_HappyPath` — verifies create path still returns the reconciled object.

```
$ go test ./internal/controller/common/... -v -count=1
=== RUN   TestReconcile_DoesNotPanicOnUpdateError
--- PASS: TestReconcile_DoesNotPanicOnUpdateError (0.00s)
=== RUN   TestReconcile_HappyPath
--- PASS: TestReconcile_HappyPath (0.00s)
PASS
ok  	.../internal/controller/common/service
=== RUN   TestReconcile_DoesNotPanicOnUpdateError
--- PASS: TestReconcile_DoesNotPanicOnUpdateError (0.00s)
=== RUN   TestReconcile_HappyPath
--- PASS: TestReconcile_HappyPath (0.00s)
PASS
ok  	.../internal/controller/common/statefulset
```

## Related
Same crash-loop also surfaces the symptoms described in #1738 and #1711 (labels stuck, master Service stale) because the panic prevents the label / master-update path from running. Those issues are addressed separately in #1775.

Fixes #1753