### PR TITLE
fix(replication): promote a replica when the set has no master

### DIFF
--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -410,6 +410,27 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 			}
 			log.FromContext(ctx).Info("Successfully reconfigured slave replication")
 		}
+	} else if len(masterNodes) == 0 && len(slaveNodes) > 0 {
+		// No pod reports role:master but replicas exist: the replication set has
+		// lost its master with no surviving master pod (for example the previous
+		// master was deleted and its Pod IP was recycled, leaving the replicas
+		// replicating from a node that is no longer their master). Neither this
+		// reconcile loop nor Sentinel recovers this on its own — Sentinel may
+		// still consider the stale master "up" — so elect a local pod and promote
+		// it to master, then re-point the remaining replicas at it.
+		realMaster = slaveNodes[0]
+		if instance.Status.MasterNode != "" && k8sutils.IsPodRunning(ctx, r.K8sClient, instance.Namespace, instance.Status.MasterNode) {
+			log.FromContext(ctx).Info("No master found; preferring last-known master from status for promotion",
+				"statusMasterNode", instance.Status.MasterNode)
+			realMaster = instance.Status.MasterNode
+		}
+		log.FromContext(ctx).Info("No master found among replication pods; promoting a replica to master",
+			"electedMaster", realMaster, "replicas", slaveNodes)
+		if err := k8sutils.CreateMasterSlaveReplication(ctx, r.K8sClient, instance, slaveNodes, realMaster); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to promote replica to master", "electedMaster", realMaster)
+			return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
+		}
+		log.FromContext(ctx).Info("Successfully promoted replica to master", "master", realMaster)
 	}
 
 	monitoring.RedisReplicationReplicasSizeMismatch.WithLabelValues(instance.Namespace, instance.Name).Set(0)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -786,6 +786,20 @@ func CreateMasterSlaveReplication(ctx context.Context, client kubernetes.Interfa
 		log.FromContext(ctx).V(1).Info("Using IP address for non-TLS master replication", "masterAddr", realMasterAddr)
 	}
 
+	// Ensure the elected master is actually a master. When every pod is a
+	// replica (e.g. the previous master's Pod IP was recycled, leaving the
+	// replicas replicating from a node that is no longer their master), the
+	// elected pod is itself a replica and must be promoted with SLAVEOF NO ONE,
+	// otherwise the replication set never regains a master. Promoting a pod that
+	// is already a master is a no-op, so this is safe for all callers.
+	masterClient := configureRedisReplicationClient(ctx, client, cr, realMasterPod)
+	defer masterClient.Close()
+	log.FromContext(ctx).V(1).Info("Promoting elected master node", "pod", realMasterPod)
+	if err := masterClient.SlaveOf(ctx, "NO", "ONE").Err(); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to promote pod to master", "pod", realMasterPod)
+		return err
+	}
+
 	for i := 0; i < len(masterPods); i++ {
 		if masterPods[i] != realMasterPod {
 			redisClient := configureRedisReplicationClient(ctx, client, cr, masterPods[i])


### PR DESCRIPTION
**Description**

In `RedisReplication` + `RedisSentinel` mode the operator only *discovers* an existing master; it never *promotes* one. `reconcileRedis` handles `len(masterNodes) > 1` and `len(masterNodes) == 1`, but has no branch for `== 0`. So when every pod is a replica — e.g. the master pod is deleted and its Pod IP is recycled by another pod, leaving the replicas replicating from a node that is no longer their master — `realMaster` stays `""`, no promotion happens, the master Service has no endpoints, and `RedisReplicationHasMaster` stays `0`. Sentinel does not recover it either: if the stale master address is still reachable it considers the master "up" and never fails over. The set is permanently master-less. (Only `RedisCluster` mode had failover/promotion logic; replication mode had none.)

This PR:

- `reconcileRedis`: adds a `len(masterNodes) == 0 && len(slaveNodes) > 0` branch that elects a local pod (preferring `Status.MasterNode` if it is a running pod, else the first replica) and promotes it, then re-points the remaining replicas.
- `CreateMasterSlaveReplication`: promotes the elected master with `SLAVEOF NO ONE` before demoting the others, so it is correct even when the elected pod is currently a replica. Promoting a pod that is already a master is a no-op, so all existing callers are unaffected.

Fixes #1777

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass. <!-- see Additional Context -->
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

The promotion runs inside `CreateMasterSlaveReplication`, which constructs its own go-redis clients internally (via `configureRedisReplicationClient`), so it isn't directly unit-testable without refactoring its client construction, and the existing `reconcileRedis` tests run under envtest with no live Redis. I verified the change manually in a multi-tenant, Sentinel-managed setup where replicas had been orphaned onto a recycled master Pod IP: before the change the set stayed master-less indefinitely; after it, the operator promotes a local replica (`SLAVEOF NO ONE`), the other pods replicate from it (`connected_slaves` > 0), the master Service gets an endpoint, and Sentinel re-converges on the local master. Happy to add an e2e (chainsaw) test that orphans/removes the master and asserts a new master is elected if you'd prefer that — just let me know.
