### PR TITLE
fix(redisreplication): re-point slaves with stale master_host (#1779)

### DIFF
--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -420,6 +420,14 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	monitoring.RedisReplicationReplicasSizeCurrent.WithLabelValues(instance.Namespace, instance.Name).Set(float64(len(masterNodes) + len(slaveNodes)))
 	monitoring.RedisReplicationReplicasSizeDesired.WithLabelValues(instance.Namespace, instance.Name).Set(float64(*instance.Spec.Size))
 
+	// Re-point any slave whose live master_host differs from the current
+	// master. Covers the graceful master-pod-IP-change case where sentinel
+	// updates its own view but never sends SLAVEOF to slaves (no failover
+	// event). Best-effort. See #1779.
+	if realMaster != "" && len(slaveNodes) > 0 {
+		k8sutils.RepointStaleSlaves(ctx, r.K8sClient, instance, realMaster, slaveNodes)
+	}
+
 	if instance.EnableSentinel() {
 		if err := r.configureSentinel(ctx, instance, realMaster); err != nil {
 			log.FromContext(ctx).Error(err, "failed to configure sentinel")

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -802,6 +802,63 @@ func CreateMasterSlaveReplication(ctx context.Context, client kubernetes.Interfa
 	return nil
 }
 
+// RepointStaleSlaves issues SLAVEOF to any slave pod whose live master_host
+// differs from the operator-known current master. Best-effort: failures are
+// logged and skipped, never fail the reconcile. Addresses #1779 — silent
+// SPOF when master pod IP changes (graceful pod recreation, not a sentinel
+// failover) and slaves keep replicating from the dead old IP.
+func RepointStaleSlaves(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication, currentMasterPod string, slavePods []string) {
+	if currentMasterPod == "" || len(slavePods) == 0 {
+		return
+	}
+
+	currentMasterInfo := RedisDetails{
+		PodName:   currentMasterPod,
+		Namespace: cr.Namespace,
+	}
+
+	var currentMasterAddr string
+	if cr.Spec.TLS != nil {
+		currentMasterAddr = getRedisReplicationHostname(currentMasterInfo, cr)
+	} else {
+		currentMasterAddr = getRedisServerIP(ctx, client, currentMasterInfo)
+		if currentMasterAddr == "" {
+			log.FromContext(ctx).V(1).Info("RepointStaleSlaves: empty current master IP, skipping", "master", currentMasterPod)
+			return
+		}
+	}
+
+	for _, podName := range slavePods {
+		redisClient := configureRedisReplicationClient(ctx, client, cr, podName)
+		info, err := redisClient.Info(ctx, "Replication").Result()
+		if err != nil {
+			log.FromContext(ctx).Error(err, "RepointStaleSlaves: INFO replication failed", "pod", podName)
+			redisClient.Close()
+			continue
+		}
+
+		var currentHost string
+		for _, line := range strings.Split(info, "\r\n") {
+			if v, ok := strings.CutPrefix(line, "master_host:"); ok {
+				currentHost = strings.TrimSpace(v)
+				break
+			}
+		}
+
+		if currentHost == "" || currentHost == currentMasterAddr {
+			redisClient.Close()
+			continue
+		}
+
+		log.FromContext(ctx).Info("Stale master_host on slave, issuing SLAVEOF to current master",
+			"pod", podName, "stale", currentHost, "current", currentMasterAddr)
+		if err := redisClient.SlaveOf(ctx, currentMasterAddr, "6379").Err(); err != nil {
+			log.FromContext(ctx).Error(err, "RepointStaleSlaves: SLAVEOF failed", "pod", podName, "master", currentMasterAddr)
+		}
+		redisClient.Close()
+	}
+}
+
 func GetRedisReplicationRealMaster(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication, masterPods []string) string {
 	for _, podName := range masterPods {
 		redisClient := configureRedisReplicationClient(ctx, client, cr, podName)


### PR DESCRIPTION
Fixes #1779.

## Problem

When a `RedisReplication` master pod is recreated with a new IP (graceful pod restart, node reboot, eviction — anything short of a sentinel-detected `+sdown` failover), the operator currently never re-points slaves at the new master. Slaves keep `master_host: <stale_old_ip>`, `master_link_status: down` indefinitely. Master reports `connected_slaves: 0`. Sentinel sees the master correctly via the freshly-issued `SENTINEL MONITOR` and updates the master Service endpoint — so apps think everything is healthy, but the cluster has zero functioning replicas. Silent SPOF.

Investigation summary:
- `SentinelReset` (the only recovery action on detected `Sentinel has incorrect number of slaves`) targets sentinel pods on port 26379 — it purges sentinel's known-slaves cache; it does NOT touch slave data pods.
- The existing slave-reconfigure branch in `reconcileRedis` (`internal/controller/redisreplication/redisreplication_controller.go:401`) is gated by `!instance.EnableSentinel()`, so sentinel-enabled (recommended HA) deployments never take that path.
- `CreateMasterSlaveReplication` iterates only over role:master pods (for split-brain handling); never iterates slaves with stale `master_host`.
- `grep -rni \"slaveof\|replicaof\" internal/ pkg/` confirms exactly one `SLAVEOF` call site in the entire codebase, gated as above.

Production reproducer + 19-hour silent SPOF in #1779.

## Change

Adds a small best-effort helper `k8sutils.RepointStaleSlaves` that, on every reconcile when a real master is known and slaves exist, queries `INFO replication` on each slave and issues `SLAVEOF <current-master-addr> 6379` if the live `master_host` disagrees with the operator-known master.

- **Reuses `configureRedisReplicationClient`** so TLS, `ExistingPasswordSecret`, and the IP-vs-hostname switch are all handled identically to the existing `SLAVEOF` call in `CreateMasterSlaveReplication`.
- **Best-effort:** per-pod failures are logged and skipped, never fail the reconcile (matches the `configureSentinel` precedent).
- **Idempotent:** `SLAVEOF` only issued on actual mismatch — cheap `INFO` otherwise.
- **Unconditional trigger** (not gated on \"Sentinel has incorrect number of slaves\"): that per-sentinel-view signal can lie when a slave is registered with a sentinel but actually replicating from a different/stale IP. The cheap `INFO` per reconcile is acceptable cost.

## Test plan

- [ ] CI passes (this PR adds no new tests; the existing `CreateMasterSlaveReplication` / `GetRedisReplicationRealMaster` are also untested at the unit-test level — happy to add miniredis-based tests if you'd like, just want to confirm the approach first since it would mean introducing a new test infra pattern)
- [ ] Manual repro on 3-node cluster:
  1. Healthy RedisReplication + Sentinel, `connected_slaves: 2`
  2. `kubectl delete pod <master-pod>`
  3. **Before this PR:** slaves stuck on old IP, `connected_slaves: 0` indefinitely
  4. **After this PR:** within one reconcile (~30s) operator logs `\"Stale master_host on slave, issuing SLAVEOF to current master\"` and slaves recover

I will run the manual repro on my prod cluster (k3s v1.35.2, 3 node bare metal) once a build with this fix is available — happy to confirm and provide log evidence.

## Scope (deliberately small)

- Does NOT touch the existing `!EnableSentinel()` recovery branch — that path is a separate question (#1314, #1052)
- Does NOT change `SentinelReset` behavior
- Does NOT modify `CreateMasterSlaveReplication`

The helper is small and additive; risk profile is per-pod idempotent `SLAVEOF` calls when `INFO replication.master_host` mismatches the operator-computed master address. If `realMaster` is empty or no slaves exist, function returns immediately.

Cross-references: #1052, #1179, #1314, #1635, #1711, #1719 all describe variants of this same root cause class. #1449 was a partial fix gated to non-sentinel setups. #1705 ports the right pattern (per-reconcile repair) to RedisCluster — this PR ports the analogous (smaller) pattern to RedisReplication.