### PR TITLE
chore: update version to 0.25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ===========================
 
 # Current Operator version
-VERSION ?= 0.24.0
+VERSION ?= 0.25.0
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 0.24.0
-appVersion: "0.24.0"
+version: 0.25.0
+appVersion: "0.25.0"
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
 engine: gotpl
 maintainers:

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -119,7 +119,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | redisOperator.imagePullPolicy | string | `"Always"` |  |
 | redisOperator.imagePullSecrets | list | `[]` |  |
 | redisOperator.imageTag | string | `""` |  |
-| redisOperator.initContainerImageTag | string | `"v0.24.0"` | initContainerImageTag is the init-config init container image tag. If not specified, defaults to imageTag, then falls back to chart appVersion. Typically only needs to be set when using a different version for the init container. |
+| redisOperator.initContainerImageTag | string | `"v0.25.0"` | initContainerImageTag is the init-config init container image tag. If not specified, defaults to imageTag, then falls back to chart appVersion. Typically only needs to be set when using a different version for the init container. |
 | redisOperator.metrics.bindAddress | string | `":8080"` |  |
 | redisOperator.metrics.enabled | bool | `true` |  |
 | redisOperator.name | string | `"redis-operator"` |  |

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -7,7 +7,7 @@ redisOperator:
   # -- initContainerImageTag is the init-config init container image tag.
   # If not specified, defaults to imageTag, then falls back to chart appVersion.
   # Typically only needs to be set when using a different version for the init container.
-  initContainerImageTag: "v0.24.0"
+  initContainerImageTag: "v0.25.0"
   imagePullPolicy: Always
   imagePullSecrets: []
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opstree/redis-operator
-  newTag: v0.24.0
+  newTag: v0.25.0

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -83,7 +83,7 @@ gcs_engine_id = "016691298986124624340:x7qv2dywdao"
 # current release branch. Never is rc.
 release_branch = "release-1.27.0"
 # the main version. Never is rc.
-release_version = "0.24.0"
+release_version = "0.25.0"
 
 # shown for production
 supported_k8s = "1.23"


### PR DESCRIPTION
## Summary

- Update `charts/redis-operator/Chart.yaml` version and appVersion from `0.24.0` to `0.25.0`
- Update `charts/redis-operator/values.yaml` initContainerImageTag to `v0.25.0`
- Update `charts/redis-operator/README.md` initContainerImageTag default value reference
- Update `config/manager/kustomization.yaml` newTag to `v0.25.0`
- Update `Makefile` VERSION to `0.25.0`
- Update `docs/config.toml` release_version to `0.25.0`

The tag `v0.25.0` was released on March 26, 2026, but the corresponding version bump commit (following the same pattern as [#1660](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1660) for v0.24.0 and [#1631](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1631) for v0.23.0) was never merged, leaving the Helm chart and related configuration files still pointing to `0.24.0`.