### PR TITLE
docs: clarify supported Redis deployment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   </a>
 </p>
 
-A Golang-based Redis operator that will make/oversee Redis standalone and cluster mode setup on top of Kubernetes. It can create a Redis cluster setup with best practices on Cloud as well as the bare metal environment. Also, it provides an in-built monitoring capability using redis-exporter.
+A Golang-based Redis operator that will make/oversee Redis standalone, cluster, replication, and sentinel mode setup on top of Kubernetes. It can create Redis setups with best practices on Cloud as well as the bare metal environment. Also, it provides an in-built monitoring capability using redis-exporter.
 
 For documentation, please refer to <https://redis-operator.opstree.dev/>
 
@@ -45,7 +45,7 @@ There are multiple problems that people face while setting up Redis setup on Kub
 
 Here are the features which are supported by this operator:
 
-- Redis cluster and standalone mode setup
+- Redis standalone, cluster, replication, and sentinel mode setup
 - Redis cluster failover and recovery
 - Inbuilt monitoring with redis exporter
 - Password and password-less setup of Redis


### PR DESCRIPTION
## What

This updates the README to mention all Redis deployment modes currently supported by the operator: standalone, cluster, replication, and sentinel.

## Why

The README currently highlights standalone and cluster modes, while the docs/examples already include Redis Replication and Redis Sentinel.

## Testing

Docs-only change. No code tests required.

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**
 Signed-off-by: vexsx p.gheiratian1382@yahoo.com
