### PR TITLE
chore: update redis-cluster external service configuration

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -55,9 +55,9 @@ helm delete <my-release> --namespace <namespace>
 | env | list | `[]` |  |
 | externalConfig.data | string | `"tcp-keepalive 400\nslowlog-max-len 158\nstream-node-max-bytes 2048\n"` |  |
 | externalConfig.enabled | bool | `false` |  |
-| externalService.enabled | bool | `false` |  |
-| externalService.port | int | `6379` |  |
-| externalService.serviceType | string | `"LoadBalancer"` |  |
+| followerExternalService.enabled | bool | `false` |  |
+| followerExternalService.port | int | `6379` |  |
+| followerExternalService.serviceType | string | `"LoadBalancer"` |  |
 | initContainer.args | list | `[]` |  |
 | initContainer.command | list | `[]` |  |
 | initContainer.enabled | bool | `false` |  |
@@ -66,6 +66,9 @@ helm delete <my-release> --namespace <namespace>
 | initContainer.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainer.resources | object | `{}` |  |
 | labels | object | `{}` |  |
+| leaderExternalService.enabled | bool | `false` |  |
+| leaderExternalService.port | int | `6379` |  |
+| leaderExternalService.serviceType | string | `"LoadBalancer"` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | priorityClassName | string | `""` |  |

--- a/charts/redis-cluster/templates/follower-service.yaml
+++ b/charts/redis-cluster/templates/follower-service.yaml
@@ -1,13 +1,13 @@
 {{- $followerReplicas := .Values.redisCluster.follower.replicas | default .Values.redisCluster.clusterSize }}
-{{- if and (gt (int $followerReplicas) 0) (eq .Values.externalService.enabled true) }}
+{{- if and (gt (int $followerReplicas) 0) (eq .Values.followerExternalService.enabled true) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.redisCluster.name | default .Release.Name }}-follower-external-service
-{{- if .Values.externalService.annotations }}
+{{- if .Values.followerExternalService.annotations }}
   annotations:
-{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{ toYaml .Values.followerExternalService.annotations | indent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
@@ -17,14 +17,17 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
 spec:
-  type: {{ .Values.externalService.serviceType }}
+  type: {{ .Values.followerExternalService.serviceType }}
   selector:
     app: {{ .Values.redisCluster.name | default .Release.Name }}-follower
     redis_setup_type: cluster
     role: follower
   ports:
     - protocol: TCP
-      port: {{ .Values.externalService.port }}
+      port: {{ .Values.followerExternalService.port }}
       targetPort: 6379
       name: client
+      {{- if and (eq .Values.followerExternalService.serviceType "NodePort") (hasKey .Values.followerExternalService "nodePort") }}
+      nodePort: {{ .Values.followerExternalService.nodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/redis-cluster/templates/leader-service.yaml
+++ b/charts/redis-cluster/templates/leader-service.yaml
@@ -1,13 +1,13 @@
 {{- $leaderReplicas := .Values.redisCluster.leader.replicas | default .Values.redisCluster.clusterSize }}
-{{- if and (gt (int $leaderReplicas) 0) (eq .Values.externalService.enabled true) }}
+{{- if and (gt (int $leaderReplicas) 0) (eq .Values.leaderExternalService.enabled true) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.redisCluster.name | default .Release.Name }}-leader-external-service
-{{- if .Values.externalService.annotations }}
+{{- if .Values.leaderExternalService.annotations }}
   annotations:
-{{ toYaml .Values.externalService.annotations | indent 4 }}
+{{ toYaml .Values.leaderExternalService.annotations | indent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.redisCluster.name | default .Release.Name }}
@@ -17,14 +17,17 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: middleware
 spec:
-  type: {{ .Values.externalService.serviceType }}
+  type: {{ .Values.leaderExternalService.serviceType }}
   selector:
     app: {{ .Values.redisCluster.name | default .Release.Name }}-leader
     redis_setup_type: cluster
     role: leader
   ports:
     - protocol: TCP
-      port: {{ .Values.externalService.port }}
+      port: {{ .Values.leaderExternalService.port }}
       targetPort: 6379
       name: client
+      {{- if and (eq .Values.leaderExternalService.serviceType "NodePort") (hasKey .Values.leaderExternalService "nodePort") }}
+      nodePort: {{ .Values.leaderExternalService.nodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -146,12 +146,21 @@ externalConfig:
     slowlog-max-len 158
     stream-node-max-bytes 2048
 
-externalService:
+leaderExternalService:
   enabled: false
   # annotations:
   #   foo: bar
   serviceType: LoadBalancer
   port: 6379
+  #nodePort: 30951
+
+followerExternalService:
+  enabled: false
+  # annotations:
+  #   foo: bar
+  serviceType: LoadBalancer
+  port: 6379
+  #nodePort: 30952
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

# Description
## Problem

Currently, both leader and follower external services share the same configuration from `externalService` section, which causes some issues:

1. **Cannot independently enable/disable** - Users must either expose both or none
2. **Port conflict** - When specifying `nodePort`, both services try to use the same port
3. **Inflexible** - Cannot configure different service types (e.g., `NodePort` for *leader*, `LoadBalancer` for *follower*)

## Solution

Split `externalService` into two separate configurations:

- `leaderExternalService` - For exposing leader nodes 
- `followerExternalService` - For exposing follower nodes

### Key Features

- Independent enable/disable for each service  
-  Customizable `nodePort` per service (no conflict)  
-  Different `serviceType` per service  
-  Separate annotations for cloud provider configurations  


**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
