### PR TITLE
feat: make master/slave anti-affinity topology key configurable

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -99,6 +99,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.leader.serviceType | string | `"ClusterIP"` |  |
 | redisCluster.leader.tolerations | list | `[]` |  |
 | redisCluster.leader.topologySpreadConstraints | list | `[]` |  |
+| redisCluster.masterSlaveAntiAffinityTopologyKey | string | `""` | TopologyKey for the leader/follower anti-affinity term injected by the operator's    mutating webhook. Empty preserves the previous behaviour ("kubernetes.io/hostname",    i.e. separate nodes). Set to "topology.kubernetes.io/zone" to force each follower into    a different zone than its corresponding leader. Only effective when    enableMasterSlaveAntiAffinity is true and the operator's mutating webhook is enabled. |
 | redisCluster.maxMemoryPercentOfLimit | int | `0` | MaxMemoryPercentOfLimit is the percentage of the Redis container memory limit to be used as maxmemory.    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.    Default is 0 (disabled). |
 | redisCluster.minReadySeconds | int | `0` |  |
 | redisCluster.name | string | `""` |  |

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.redisCluster.enableMasterSlaveAntiAffinity }}
     redisclusters.redis.redis.opstreelabs.in/role-anti-affinity: "true"
     {{- end }}
+    {{- with .Values.redisCluster.masterSlaveAntiAffinityTopologyKey }}
+    redisclusters.redis.redis.opstreelabs.in/role-anti-affinity-topology-key: {{ . | quote }}
+    {{- end }}
 spec:
   clusterSize: {{ .Values.redisCluster.clusterSize }}
   persistenceEnabled: {{ .Values.redisCluster.persistenceEnabled }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -38,6 +38,12 @@ redisCluster:
   #    otherwise it will only add an annotation to the RedisCluster CR.
   #    Default is false.
   enableMasterSlaveAntiAffinity: false
+  # -- TopologyKey for the leader/follower anti-affinity term injected by the operator's
+  #    mutating webhook. Empty preserves the previous behaviour ("kubernetes.io/hostname",
+  #    i.e. separate nodes). Set to "topology.kubernetes.io/zone" to force each follower into
+  #    a different zone than its corresponding leader. Only effective when
+  #    enableMasterSlaveAntiAffinity is true and the operator's mutating webhook is enabled.
+  masterSlaveAntiAffinityTopologyKey: ""
   leader:
     # -- Number of Redis leader (master) nodes. If not set, uses clusterSize value
     replicas: 3

--- a/internal/webhook/pod_webhook.go
+++ b/internal/webhook/pod_webhook.go
@@ -53,6 +53,14 @@ const (
 
 const annotationKeyEnablePodAntiAffinity = "redisclusters.redis.redis.opstreelabs.in/role-anti-affinity"
 
+// annotationKeyPodAntiAffinityTopologyKey optionally overrides the topologyKey used for the
+// injected leader/follower anti-affinity term. When the annotation is absent or empty the
+// webhook falls back to defaultAntiAffinityTopologyKey, preserving the previous behaviour.
+const annotationKeyPodAntiAffinityTopologyKey = "redisclusters.redis.redis.opstreelabs.in/role-anti-affinity-topology-key"
+
+// defaultAntiAffinityTopologyKey is the topologyKey applied when no override annotation is set.
+const defaultAntiAffinityTopologyKey = "kubernetes.io/hostname"
+
 func (v *PodAntiAffiniytMutate) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := v.logger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 
@@ -129,7 +137,7 @@ func (v *PodAntiAffiniytMutate) AddPodAntiAffinity(pod *corev1.Pod) {
 				},
 			},
 		},
-		TopologyKey: "kubernetes.io/hostname",
+		TopologyKey: v.getAntiAffinityTopologyKey(pod),
 	}
 
 	pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, addAntiAffinity)
@@ -164,4 +172,14 @@ func (v *PodAntiAffiniytMutate) getAntiAffinityValue(podName string) string {
 		return strings.ReplaceAll(podName, "leader", "follower")
 	}
 	return ""
+}
+
+// getAntiAffinityTopologyKey returns the topologyKey for the injected anti-affinity term.
+// It honours the role-anti-affinity-topology-key annotation when present and non-empty,
+// otherwise it falls back to the historical default of "kubernetes.io/hostname".
+func (v *PodAntiAffiniytMutate) getAntiAffinityTopologyKey(pod *corev1.Pod) string {
+	if key, ok := pod.GetAnnotations()[annotationKeyPodAntiAffinityTopologyKey]; ok && key != "" {
+		return key
+	}
+	return defaultAntiAffinityTopologyKey
 }

--- a/internal/webhook/pod_webhook_test.go
+++ b/internal/webhook/pod_webhook_test.go
@@ -73,6 +73,48 @@ func TestPodAntiAffinityMutate_Handle(t *testing.T) {
 			},
 		},
 		{
+			name: "Should use custom topologyKey from annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "redis-follower-0",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationKeyEnablePodAntiAffinity:      "true",
+						annotationKeyPodAntiAffinityTopologyKey: "topology.kubernetes.io/zone",
+						podAnnotationsRedisClusterApp:           "db-01",
+					},
+					Labels: map[string]string{
+						podLabelsRedisType: "redis-cluster",
+					},
+				},
+				Spec: corev1.PodSpec{},
+			},
+			expectedPatches: []jsonpatch.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/affinity",
+					Value: map[string]interface{}{
+						"podAntiAffinity": map[string]interface{}{
+							"requiredDuringSchedulingIgnoredDuringExecution": []interface{}{
+								map[string]interface{}{
+									"labelSelector": map[string]interface{}{
+										"matchExpressions": []interface{}{
+											map[string]interface{}{
+												"key":      "statefulset.kubernetes.io/pod-name",
+												"operator": "In",
+												"values":   []interface{}{"redis-leader-0"},
+											},
+										},
+									},
+									"topologyKey": "topology.kubernetes.io/zone",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Should not mutate pod without proper annotations",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Description**

Fixes #1599 

Makes the `TopologyKey` for `MasterSlaveAntiAffinity` configurable via an annotation, defaulting to the previous value so existing behaviour is unchanged.

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**