### PR TITLE
feat(client): Implement dynamic configuration support for Redis instances

### DIFF
--- a/api/redis/v1beta2/redis_types.go
+++ b/api/redis/v1beta2/redis_types.go
@@ -49,6 +49,13 @@ type RedisSpec struct {
 	HostPort                      *int                       `json:"hostPort,omitempty"`
 }
 
+func (cr *RedisSpec) GetRedisDynamicConfig() []string {
+	if cr.RedisConfig != nil && len(cr.RedisConfig.DynamicConfig) > 0 {
+		return cr.RedisConfig.DynamicConfig
+	}
+	return []string{}
+}
+
 // RedisStatus defines the observed state of Redis
 type RedisStatus struct{}
 

--- a/api/redis/v1beta2/redis_types_test.go
+++ b/api/redis/v1beta2/redis_types_test.go
@@ -1,0 +1,52 @@
+package v1beta2_test
+
+import (
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	v1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisSpec_GetRedisDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1beta2.RedisSpec
+		want []string
+	}{
+		{
+			name: "nil RedisConfig returns empty slice",
+			spec: v1beta2.RedisSpec{},
+			want: []string{},
+		},
+		{
+			name: "RedisConfig without dynamic config returns empty slice",
+			spec: v1beta2.RedisSpec{
+				RedisConfig: &common.RedisConfig{},
+			},
+			want: []string{},
+		},
+		{
+			name: "empty dynamic config returns empty slice",
+			spec: v1beta2.RedisSpec{
+				RedisConfig: &common.RedisConfig{DynamicConfig: []string{}},
+			},
+			want: []string{},
+		},
+		{
+			name: "dynamic config is returned",
+			spec: v1beta2.RedisSpec{
+				RedisConfig: &common.RedisConfig{
+					DynamicConfig: []string{"maxmemory-policy allkeys-lru", "slowlog-log-slower-than 5000"},
+				},
+			},
+			want: []string{"maxmemory-policy allkeys-lru", "slowlog-log-slower-than 5000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.spec.GetRedisDynamicConfig())
+		})
+	}
+}

--- a/api/redisreplication/v1beta2/redisreplication_types.go
+++ b/api/redisreplication/v1beta2/redisreplication_types.go
@@ -62,6 +62,13 @@ func (cr *RedisReplicationSpec) GetReplicationCounts(t string) int32 {
 	return *replica
 }
 
+func (cr *RedisReplicationSpec) GetRedisDynamicConfig() []string {
+	if cr.RedisConfig != nil && len(cr.RedisConfig.DynamicConfig) > 0 {
+		return cr.RedisConfig.DynamicConfig
+	}
+	return []string{}
+}
+
 // ConnectionInfo provides connection details for clients to connect to Redis
 type ConnectionInfo struct {
 	// Host is the service FQDN

--- a/api/redisreplication/v1beta2/redisreplication_types_test.go
+++ b/api/redisreplication/v1beta2/redisreplication_types_test.go
@@ -1,0 +1,52 @@
+package v1beta2_test
+
+import (
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	v1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisReplicationSpec_GetRedisDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1beta2.RedisReplicationSpec
+		want []string
+	}{
+		{
+			name: "nil RedisConfig returns empty slice",
+			spec: v1beta2.RedisReplicationSpec{},
+			want: []string{},
+		},
+		{
+			name: "RedisConfig without dynamic config returns empty slice",
+			spec: v1beta2.RedisReplicationSpec{
+				RedisConfig: &common.RedisConfig{},
+			},
+			want: []string{},
+		},
+		{
+			name: "empty dynamic config returns empty slice",
+			spec: v1beta2.RedisReplicationSpec{
+				RedisConfig: &common.RedisConfig{DynamicConfig: []string{}},
+			},
+			want: []string{},
+		},
+		{
+			name: "dynamic config is returned",
+			spec: v1beta2.RedisReplicationSpec{
+				RedisConfig: &common.RedisConfig{
+					DynamicConfig: []string{"maxmemory-policy allkeys-lru", "slowlog-log-slower-than 5000"},
+				},
+			},
+			want: []string{"maxmemory-policy allkeys-lru", "slowlog-log-slower-than 5000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.spec.GetRedisDynamicConfig())
+		})
+	}
+}

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -72,6 +72,7 @@ helm delete <my-release> --namespace <namespace>
 | priorityClassName | string | `""` |  |
 | redisCluster.clusterSize | int | `3` | Default number of replicas for both leader and follower when not explicitly set |
 | redisCluster.clusterVersion | string | `"v7"` |  |
+| redisCluster.dynamicConfig | list | `[]` | DynamicConfig is a list of "key value" Redis parameters applied at runtime    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is    not persisted to disk, so values are not retained across pod restarts unless    they are also provided through externalConfig.    Example:    dynamicConfig:      - "maxmemory-policy allkeys-lru"      - "slowlog-log-slower-than 5000" |
 | redisCluster.enableMasterSlaveAntiAffinity | bool | `false` | Enable pod anti-affinity between leader and follower pods by adding the appropriate label.    Notice that this requires the operator to have its mutating webhook enabled,    otherwise it will only add an annotation to the RedisCluster CR.    Default is false. |
 | redisCluster.follower.affinity | string | `nil` |  |
 | redisCluster.follower.livenessProbe | object | `{}` |  |

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -30,11 +30,14 @@ spec:
       additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
     {{- end }}
   
-  {{- if .Values.redisCluster.maxMemoryPercentOfLimit }}
-  {{- if gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0 }}
+  {{- if or (and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0)) (.Values.redisCluster.dynamicConfig) }}
   redisConfig:
+    {{- if and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0) }}
     maxMemoryPercentOfLimit: {{ .Values.redisCluster.maxMemoryPercentOfLimit }}
-  {{- end }}
+    {{- end }}
+    {{- if .Values.redisCluster.dynamicConfig }}
+    dynamicConfig: {{ toYaml .Values.redisCluster.dynamicConfig | nindent 6 }}
+    {{- end }}
   {{- end }}
 
   redisExporter:

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -30,6 +30,15 @@ redisCluster:
   #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  # -- DynamicConfig is a list of "key value" Redis parameters applied at runtime
+  #    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is
+  #    not persisted to disk, so values are not retained across pod restarts unless
+  #    they are also provided through externalConfig.
+  #    Example:
+  #    dynamicConfig:
+  #      - "maxmemory-policy allkeys-lru"
+  #      - "slowlog-log-slower-than 5000"
+  dynamicConfig: []
   persistentVolumeClaimRetentionPolicy: {}
     # whenDeleted: Delete
     # whenScaled: Retain

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -81,6 +81,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
 | redisReplication.clusterSize | int | `3` |  |
+| redisReplication.dynamicConfig | list | `[]` | DynamicConfig is a list of "key value" Redis parameters applied at runtime    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is    not persisted to disk, so values are not retained across pod restarts unless    they are also provided through externalConfig.    Example:    dynamicConfig:      - "maxmemory-policy allkeys-lru"      - "slowlog-log-slower-than 5000" |
 | redisReplication.ignoreAnnotations | list | `[]` |  |
 | redisReplication.image | string | `"quay.io/opstree/redis"` |  |
 | redisReplication.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -59,13 +59,16 @@ spec:
     securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
     {{- end }}
   
-  {{- if or .Values.externalConfig.enabled (and .Values.redisReplication.maxMemoryPercentOfLimit (gt (int .Values.redisReplication.maxMemoryPercentOfLimit) 0)) }}
+  {{- if or .Values.externalConfig.enabled (and .Values.redisReplication.maxMemoryPercentOfLimit (gt (int .Values.redisReplication.maxMemoryPercentOfLimit) 0)) (.Values.redisReplication.dynamicConfig) }}
   redisConfig:
     {{- if .Values.externalConfig.enabled }}
     additionalRedisConfig: "{{ .Values.redisReplication.name | default .Release.Name }}-ext-config"
     {{- end }}
     {{- if and .Values.redisReplication.maxMemoryPercentOfLimit (gt (int .Values.redisReplication.maxMemoryPercentOfLimit) 0) }}
     maxMemoryPercentOfLimit: {{ .Values.redisReplication.maxMemoryPercentOfLimit }}
+    {{- end }}
+    {{- if .Values.redisReplication.dynamicConfig }}
+    dynamicConfig: {{ toYaml .Values.redisReplication.dynamicConfig | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- if .Values.storageSpec }}

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -28,6 +28,15 @@ redisReplication:
   #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  # -- DynamicConfig is a list of "key value" Redis parameters applied at runtime
+  #    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is
+  #    not persisted to disk, so values are not retained across pod restarts unless
+  #    they are also provided through externalConfig.
+  #    Example:
+  #    dynamicConfig:
+  #      - "maxmemory-policy allkeys-lru"
+  #      - "slowlog-log-slower-than 5000"
+  dynamicConfig: []
   persistentVolumeClaimRetentionPolicy: {}
     # whenDeleted: Delete
     # whenScaled: Retain

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -75,6 +75,7 @@ helm delete <my-release> --namespace <namespace>
 | redisExporter.resources | object | `{}` |  |
 | redisExporter.securityContext | object | `{}` |  |
 | redisExporter.tag | string | `"v1.44.0"` |  |
+| redisStandalone.dynamicConfig | list | `[]` | DynamicConfig is a list of "key value" Redis parameters applied at runtime    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is    not persisted to disk, so values are not retained across pod restarts unless    they are also provided through externalConfig.    Example:    dynamicConfig:      - "maxmemory-policy allkeys-lru"      - "slowlog-log-slower-than 5000" |
 | redisStandalone.ignoreAnnotations | list | `[]` |  |
 | redisStandalone.image | string | `"quay.io/opstree/redis"` |  |
 | redisStandalone.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -50,13 +50,16 @@ spec:
     securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
     {{- end }}
   
-  {{- if or .Values.externalConfig.enabled (and .Values.redisStandalone.maxMemoryPercentOfLimit (gt (int .Values.redisStandalone.maxMemoryPercentOfLimit) 0)) }}
+  {{- if or .Values.externalConfig.enabled (and .Values.redisStandalone.maxMemoryPercentOfLimit (gt (int .Values.redisStandalone.maxMemoryPercentOfLimit) 0)) (.Values.redisStandalone.dynamicConfig) }}
   redisConfig:
     {{- if .Values.externalConfig.enabled }}
     additionalRedisConfig: "{{ .Values.redisStandalone.name | default .Release.Name }}-ext-config"
     {{- end }}
     {{- if and .Values.redisStandalone.maxMemoryPercentOfLimit (gt (int .Values.redisStandalone.maxMemoryPercentOfLimit) 0) }}
     maxMemoryPercentOfLimit: {{ .Values.redisStandalone.maxMemoryPercentOfLimit }}
+    {{- end }}
+    {{- if .Values.redisStandalone.dynamicConfig }}
+    dynamicConfig: {{ toYaml .Values.redisStandalone.dynamicConfig | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- if .Values.storageSpec }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,6 +28,15 @@ redisStandalone:
   #    When a memory limit exists, the operator also exposes the computed value via the REDIS_MAX_MEMORY env var.
   #    Default is 0 (disabled).
   maxMemoryPercentOfLimit: 0
+  # -- DynamicConfig is a list of "key value" Redis parameters applied at runtime
+  #    via CONFIG SET (without triggering a rolling restart). Note: CONFIG SET is
+  #    not persisted to disk, so values are not retained across pod restarts unless
+  #    they are also provided through externalConfig.
+  #    Example:
+  #    dynamicConfig:
+  #      - "maxmemory-policy allkeys-lru"
+  #      - "slowlog-log-slower-than 5000"
+  dynamicConfig: []
   persistentVolumeClaimRetentionPolicy: {}
     # whenDeleted: Delete
     # whenScaled: Retain

--- a/docs/content/en/docs/Configuration/Redis/_index.md
+++ b/docs/content/en/docs/Configuration/Redis/_index.md
@@ -72,3 +72,49 @@ Redis standalone configuration can be customized by [values.yaml](https://github
 | storageSpec.volumeClaimTemplate.spec.accessModes[0]             | string | `"ReadWriteOnce"`                                                        |                                                                                                                                                                       |
 | storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"1Gi"`                                                                  |                                                                                                                                                                       |
 | tolerations                                                     | list   | `[]`                                                                     |                                                                                                                                                                       |
+
+## Redis Standalone Instance Configuration
+
+### Dynamic Configuration
+
+Redis Operator supports dynamic configuration for the standalone Redis instance through the top-level `redisConfig` field. You can set Redis configuration parameters that can be modified at runtime without requiring a restart.
+
+#### Example Configuration
+
+```yaml
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: redis-standalone
+spec:
+  redisConfig:
+    dynamicConfig:
+      - "maxmemory-policy allkeys-lru"
+      - "slowlog-log-slower-than 5000"
+```
+
+#### Configuration Application
+
+- Dynamic configurations are applied to the standalone Redis instance via `CONFIG SET`
+- Configuration is applied only after the instance's StatefulSet is in a ready state
+- If the instance is not ready or accessible, it will be skipped and retried in the next reconciliation
+
+#### Important Notes
+
+1. **Configuration Validation**
+   - Ensure the configuration parameters are supported by your Redis version
+   - Use proper format: "parameter value" (e.g., "maxmemory-policy allkeys-lru")
+   - Invalid configurations will be logged and skipped
+
+2. **Monitoring**
+   - Configuration changes are logged at the pod level
+   - Check pod logs for configuration status and any errors
+   - Use `kubectl exec` to verify configurations:
+
+   ```bash
+   kubectl exec -it <pod-name> -- redis-cli CONFIG GET <parameter>
+   ```
+
+3. **Limitations**
+   - Only supports parameters that can be modified at runtime
+   - `CONFIG SET` is not persisted to disk, so values supplied through `dynamicConfig` are **not retained across pod restarts** unless they are also provided through `externalConfig` (`additionalRedisConfig`). `dynamicConfig` is applied at runtime only and intentionally does not rewrite the ConfigMap, so that runtime-tunable parameters do not trigger a StatefulSet rolling restart.

--- a/docs/content/en/docs/Configuration/RedisCluster/_index.md
+++ b/docs/content/en/docs/Configuration/RedisCluster/_index.md
@@ -139,3 +139,4 @@ spec:
 
 4. **Limitations**
    - Only supports parameters that can be modified at runtime
+   - `CONFIG SET` is not persisted to disk, so values supplied through `dynamicConfig` are **not retained across pod restarts** unless they are also provided through `externalConfig` (`additionalRedisConfig`). `dynamicConfig` is applied at runtime only and intentionally does not rewrite the ConfigMap, so that runtime-tunable parameters do not trigger a StatefulSet rolling restart.

--- a/docs/content/en/docs/Configuration/RedisReplication/_index.md
+++ b/docs/content/en/docs/Configuration/RedisReplication/_index.md
@@ -128,3 +128,4 @@ spec:
 
 4. **Limitations**
    - Only supports parameters that can be modified at runtime
+   - `CONFIG SET` is not persisted to disk, so values supplied through `dynamicConfig` are **not retained across pod restarts** unless they are also provided through `externalConfig` (`additionalRedisConfig`). `dynamicConfig` is applied at runtime only and intentionally does not rewrite the ConfigMap, so that runtime-tunable parameters do not trigger a StatefulSet rolling restart.

--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -242,8 +242,9 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, maxConcu
 	healer := redis.NewHealer(k8sClient)
 
 	if err := (&rediscontroller.Reconciler{
-		Client:    mgr.GetClient(),
-		K8sClient: k8sClient,
+		Client:      mgr.GetClient(),
+		K8sClient:   k8sClient,
+		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Redis")
 		return err

--- a/internal/controller/redis/redis_controller.go
+++ b/internal/controller/redis/redis_controller.go
@@ -18,6 +18,7 @@ package redis
 
 import (
 	"context"
+	"time"
 
 	rvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
@@ -38,6 +39,7 @@ const (
 // Reconciler reconciles a Redis object
 type Reconciler struct {
 	client.Client
+	k8sutils.StatefulSet
 	K8sClient kubernetes.Interface
 }
 
@@ -67,6 +69,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	err = k8sutils.CreateStandaloneService(ctx, instance, r.K8sClient)
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "failed to create service")
+	}
+
+	if len(instance.Spec.GetRedisDynamicConfig()) > 0 {
+		if !r.IsStatefulSetReady(ctx, instance.Namespace, instance.Name) {
+			return intctrlutil.RequeueAfter(ctx, time.Second*10, "waiting for redis statefulset to be ready before applying dynamic config")
+		}
+		applied, err := k8sutils.SetRedisStandaloneDynamicConfig(ctx, r.K8sClient, instance)
+		if err != nil {
+			return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
+		}
+		if !applied {
+			return intctrlutil.RequeueAfter(ctx, time.Second*10, "waiting for redis to become reachable to apply dynamic config")
+		}
 	}
 	return intctrlutil.Reconciled()
 }

--- a/internal/controller/redis/redis_controller_suite_test.go
+++ b/internal/controller/redis/redis_controller_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	rvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -94,8 +95,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{
-		Client:    k8sManager.GetClient(),
-		K8sClient: k8sClient,
+		Client:      k8sManager.GetClient(),
+		K8sClient:   k8sClient,
+		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
 	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -398,6 +398,12 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 		}
 	}
 
+	if len(instance.Spec.GetRedisDynamicConfig()) > 0 && r.IsStatefulSetReady(ctx, instance.Namespace, instance.RedisStatefulSet()) {
+		if err := k8sutils.SetRedisReplicationDynamicConfig(ctx, r.K8sClient, instance); err != nil {
+			return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
+		}
+	}
+
 	var realMaster string
 	masterNodes, err := r.redisNodesByRole(ctx, instance, "master")
 	if err != nil {

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
@@ -696,6 +697,30 @@ func configureRedisClient(ctx context.Context, client kubernetes.Interface, cr *
 	return redis.NewClient(opts)
 }
 
+func configureRedisStandaloneClient(ctx context.Context, client kubernetes.Interface, cr *rvb2.Redis, podName string) *redis.Client {
+	redisInfo := RedisDetails{
+		PodName:   podName,
+		Namespace: cr.Namespace,
+	}
+	var err error
+	var pass string
+	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
+		pass, err = getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Error in getting redis password")
+		}
+	}
+	opts := &redis.Options{
+		Addr:     getRedisServerAddress(ctx, client, redisInfo, common.RedisPort),
+		Password: pass,
+		DB:       0,
+	}
+	if cr.Spec.TLS != nil {
+		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS)
+	}
+	return redis.NewClient(opts)
+}
+
 // executeCommand will execute the commands in pod
 func executeCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) {
 	execOut, execErr := executeCommand1(ctx, client, cr, cmd, podName)
@@ -1005,6 +1030,41 @@ func GetRedisReplicationRealMaster(ctx context.Context, client kubernetes.Interf
 	return ""
 }
 
+func applyDynamicConfig(ctx context.Context, redisClient *redis.Client, podName string, dynamicConfig []string) (bool, error) {
+	pong, err := redisClient.Ping(ctx).Result()
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to ping Redis instance", "pod", podName)
+		return false, nil
+	}
+	if pong != "PONG" {
+		log.FromContext(ctx).V(1).Info("Redis instance not ready", "pod", podName)
+		return false, nil
+	}
+
+	for _, config := range dynamicConfig {
+		parts := strings.SplitN(config, " ", 2)
+		if len(parts) != 2 {
+			log.FromContext(ctx).Error(nil, "Invalid config format", "config", config)
+			continue
+		}
+
+		if err := redisClient.ConfigSet(ctx, parts[0], parts[1]).Err(); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to set config",
+				"key", parts[0],
+				"value", parts[1],
+				"pod", podName)
+			return true, err
+		}
+
+		log.FromContext(ctx).V(1).Info("Successfully set config",
+			"key", parts[0],
+			"value", parts[1],
+			"pod", podName)
+	}
+
+	return true, nil
+}
+
 // SetRedisClusterDynamicConfig applies dynamic configuration to each Redis instance in the cluster
 func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) error {
 	// Get dynamic configuration
@@ -1027,42 +1087,58 @@ func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interfa
 		}
 
 		redisClient := configureRedisClient(ctx, client, cr, podName)
-		defer redisClient.Close()
-
-		// Check if Redis instance is accessible
-		pong, err := redisClient.Ping(ctx).Result()
+		_, err := applyDynamicConfig(ctx, redisClient, podName, dynamicConfig)
+		redisClient.Close()
 		if err != nil {
-			log.FromContext(ctx).Error(err, "Failed to ping Redis instance", "pod", podName)
-			continue
-		}
-		if pong != "PONG" {
-			log.FromContext(ctx).V(1).Info("Redis instance not ready", "pod", podName)
-			continue
-		}
-
-		// Apply dynamic configuration parameters
-		for _, config := range dynamicConfig {
-			parts := strings.SplitN(config, " ", 2)
-			if len(parts) != 2 {
-				log.FromContext(ctx).Error(nil, "Invalid config format", "config", config)
-				continue
-			}
-
-			err := redisClient.ConfigSet(ctx, parts[0], parts[1]).Err()
-			if err != nil {
-				log.FromContext(ctx).Error(err, "Failed to set config",
-					"key", parts[0],
-					"value", parts[1],
-					"pod", podName)
-				return err
-			}
-
-			log.FromContext(ctx).V(1).Info("Successfully set config",
-				"key", parts[0],
-				"value", parts[1],
-				"pod", podName)
+			return err
 		}
 	}
 
 	return nil
+}
+
+func SetRedisReplicationDynamicConfig(ctx context.Context, client kubernetes.Interface, cr *rrvb2.RedisReplication) error {
+	return setRedisReplicationDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+		return configureRedisReplicationClient(ctx, client, cr, podName)
+	})
+}
+
+func setRedisReplicationDynamicConfig(ctx context.Context, cr *rrvb2.RedisReplication, makeClient func(podName string) *redis.Client) error {
+	dynamicConfig := cr.Spec.GetRedisDynamicConfig()
+	if len(dynamicConfig) == 0 {
+		return nil
+	}
+
+	replicas := cr.Spec.GetReplicationCounts("")
+	for i := 0; i < int(replicas); i++ {
+		podName := cr.Name + "-" + strconv.Itoa(i)
+
+		redisClient := makeClient(podName)
+		_, err := applyDynamicConfig(ctx, redisClient, podName, dynamicConfig)
+		redisClient.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func SetRedisStandaloneDynamicConfig(ctx context.Context, client kubernetes.Interface, cr *rvb2.Redis) (bool, error) {
+	return setRedisStandaloneDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+		return configureRedisStandaloneClient(ctx, client, cr, podName)
+	})
+}
+
+func setRedisStandaloneDynamicConfig(ctx context.Context, cr *rvb2.Redis, makeClient func(podName string) *redis.Client) (bool, error) {
+	dynamicConfig := cr.Spec.GetRedisDynamicConfig()
+	if len(dynamicConfig) == 0 {
+		return true, nil
+	}
+
+	podName := cr.Name + "-0"
+	redisClient := makeClient(podName)
+	defer redisClient.Close()
+
+	return applyDynamicConfig(ctx, redisClient, podName, dynamicConfig)
 }

--- a/internal/k8sutils/redis_dynamic_config_test.go
+++ b/internal/k8sutils/redis_dynamic_config_test.go
@@ -1,0 +1,252 @@
+package k8sutils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	rvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
+	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	"github.com/go-redis/redismock/v9"
+	redis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestApplyDynamicConfig(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("applies all entries when reachable", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		mock.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+		mock.ExpectConfigSet("slowlog-log-slower-than", "5000").SetVal("OK")
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{
+			"maxmemory-policy allkeys-lru",
+			"slowlog-log-slower-than 5000",
+		})
+		assert.NoError(t, err)
+		assert.True(t, applied)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("preserves spaces in the value", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		// Only the first space splits key from value; the value may contain spaces.
+		mock.ExpectConfigSet("save", "900 1 300 10").SetVal("OK")
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{"save 900 1 300 10"})
+		assert.NoError(t, err)
+		assert.True(t, applied)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skips pod and reports not-applied when ping fails", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetErr(errors.New("connection refused"))
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{"maxmemory-policy allkeys-lru"})
+		assert.NoError(t, err)
+		assert.False(t, applied, "an unreachable pod must report not-applied so the caller can retry")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skips pod and reports not-applied when not PONG", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("LOADING Redis is loading the dataset in memory")
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{"maxmemory-policy allkeys-lru"})
+		assert.NoError(t, err)
+		assert.False(t, applied)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skips malformed entries but applies valid ones", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		mock.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{
+			"missing-value",
+			"maxmemory-policy allkeys-lru",
+		})
+		assert.NoError(t, err)
+		assert.True(t, applied)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns error when CONFIG SET fails", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		mock.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetErr(errors.New("CONFIG SET failed"))
+
+		applied, err := applyDynamicConfig(ctx, client, "redis-0", []string{"maxmemory-policy allkeys-lru"})
+		assert.Error(t, err)
+		assert.True(t, applied, "the pod was reachable, so it is considered applied even though a CONFIG SET failed")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSetRedisReplicationDynamicConfig(t *testing.T) {
+	ctx := context.Background()
+
+	newReplication := func(size int32) *rrvb2.RedisReplication {
+		return &rrvb2.RedisReplication{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-replication", Namespace: "default"},
+			Spec: rrvb2.RedisReplicationSpec{
+				Size: ptr.To(size),
+				RedisConfig: &common.RedisConfig{
+					DynamicConfig: []string{"maxmemory-policy allkeys-lru"},
+				},
+			},
+		}
+	}
+
+	t.Run("applies config to every replica pod", func(t *testing.T) {
+		cr := newReplication(3)
+		mocks := map[string]redismock.ClientMock{}
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			m.ExpectPing().SetVal("PONG")
+			m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			mocks[podName] = m
+			return c
+		}
+
+		err := setRedisReplicationDynamicConfig(ctx, cr, makeClient)
+		assert.NoError(t, err)
+		assert.Len(t, mocks, 3)
+		for _, name := range []string{"redis-replication-0", "redis-replication-1", "redis-replication-2"} {
+			m, ok := mocks[name]
+			assert.True(t, ok, "expected a client for pod %s", name)
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+	})
+
+	t.Run("no-op when dynamic config is empty", func(t *testing.T) {
+		cr := newReplication(3)
+		cr.Spec.RedisConfig = nil
+		called := false
+		err := setRedisReplicationDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, called, "client factory must not be called without dynamic config")
+	})
+
+	t.Run("continues past unreachable pods", func(t *testing.T) {
+		cr := newReplication(2)
+		mocks := map[string]redismock.ClientMock{}
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			if podName == "redis-replication-0" {
+				m.ExpectPing().SetErr(errors.New("connection refused"))
+			} else {
+				m.ExpectPing().SetVal("PONG")
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			}
+			mocks[podName] = m
+			return c
+		}
+
+		err := setRedisReplicationDynamicConfig(ctx, cr, makeClient)
+		assert.NoError(t, err)
+		assert.Len(t, mocks, 2, "every pod should be visited even if an earlier one is unreachable")
+		for _, m := range mocks {
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+	})
+
+	t.Run("returns error when a CONFIG SET fails", func(t *testing.T) {
+		cr := newReplication(2)
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			m.ExpectPing().SetVal("PONG")
+			if podName == "redis-replication-0" {
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetErr(errors.New("CONFIG SET failed"))
+			} else {
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			}
+			return c
+		}
+
+		err := setRedisReplicationDynamicConfig(ctx, cr, makeClient)
+		assert.Error(t, err)
+	})
+}
+
+func TestSetRedisStandaloneDynamicConfig(t *testing.T) {
+	ctx := context.Background()
+
+	newStandalone := func() *rvb2.Redis {
+		return &rvb2.Redis{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-standalone", Namespace: "default"},
+			Spec: rvb2.RedisSpec{
+				RedisConfig: &common.RedisConfig{
+					DynamicConfig: []string{"maxmemory-policy allkeys-lru"},
+				},
+			},
+		}
+	}
+
+	t.Run("applies config to the single pod", func(t *testing.T) {
+		cr := newStandalone()
+		var requestedPod string
+		c, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		mock.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+
+		applied, err := setRedisStandaloneDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			requestedPod = podName
+			return c
+		})
+		assert.NoError(t, err)
+		assert.True(t, applied)
+		assert.Equal(t, "redis-standalone-0", requestedPod)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("reports not-applied when the pod is unreachable", func(t *testing.T) {
+		cr := newStandalone()
+		c, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetErr(errors.New("connection refused"))
+
+		applied, err := setRedisStandaloneDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			return c
+		})
+		assert.NoError(t, err)
+		assert.False(t, applied, "an unreachable pod must report not-applied so the controller requeues and retries")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("no-op when dynamic config is empty", func(t *testing.T) {
+		cr := newStandalone()
+		cr.Spec.RedisConfig = nil
+		called := false
+		applied, err := setRedisStandaloneDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.True(t, applied, "an empty config has nothing to apply and should not force a requeue")
+		assert.False(t, called, "client factory must not be called without dynamic config")
+	})
+
+	t.Run("returns error when CONFIG SET fails", func(t *testing.T) {
+		cr := newStandalone()
+		c, mock := redismock.NewClientMock()
+		mock.ExpectPing().SetVal("PONG")
+		mock.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetErr(errors.New("CONFIG SET failed"))
+
+		_, err := setRedisStandaloneDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			return c
+		})
+		assert.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/chainsaw-test.yaml
@@ -45,7 +45,7 @@ spec:
                 exit 1
               fi
               # Annotation should either be empty/unset or reflect actual capacity, not the shrink target
-              if [ "${ANNOTATION}" == "536870912" ]; then
+              if [ "${ANNOTATION}" = "536870912" ]; then
                 echo "FAIL: annotation was incorrectly updated to shrink target (512Mi = 536870912)"
                 exit 1
               fi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
@@ -57,49 +57,35 @@ spec:
     - name: Assert config
       try:
         - script:
-            timeout: 30s
+            timeout: 90s
             content: |
               #!/bin/bash
               set -e
 
-              # Randomly select one leader and one follower
-              LEADER_INDEX=$((RANDOM % 3))
-              FOLLOWER_INDEX=$((RANDOM % 3))
+              # Check every leader and follower reflects the applied configuration.
+              # NB: this content runs under /bin/sh (dash) via `sh -c`, so it must
+              # stay POSIX-compatible (no bash-only constructs such as $RANDOM).
+              for ROLE in leader follower; do
+                for INDEX in 0 1 2; do
+                  POD="redis-cluster-v1beta2-${ROLE}-${INDEX}"
+                  CMD="kubectl exec -n ${NAMESPACE} ${POD} -c redis-cluster-v1beta2-${ROLE} -- redis-cli --no-auth-warning -a Opstree1234 --tls --cacert /tls/ca.crt"
+                  SLOWLOG_VALUE=$(${CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
+                  TCP_KEEPALIVE_VALUE=$(${CMD} config get tcp-keepalive | grep -A1 "tcp-keepalive" | tail -n1)
+                  if [ "$SLOWLOG_VALUE" != "5000" ]; then
+                    echo "${POD} slowlog-log-slower-than value is $SLOWLOG_VALUE, expected 5000"
+                    exit 1
+                  fi
+                  if [ "$TCP_KEEPALIVE_VALUE" != "400" ]; then
+                    echo "${POD} tcp-keepalive value is $TCP_KEEPALIVE_VALUE, expected 400"
+                    exit 1
+                  fi
+                done
+              done
 
-              echo "Checking leader-${LEADER_INDEX} and follower-${FOLLOWER_INDEX}"
-
-              # Check leader configuration
-              LEADER_CMD="kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-leader-${LEADER_INDEX}"
-              LEADER_CMD="${LEADER_CMD} -c redis-cluster-v1beta2-leader -- redis-cli --no-auth-warning -a Opstree1234 --tls --cacert /tls/ca.crt"
-              SLOWLOG_VALUE=$(${LEADER_CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
-              TCP_KEEPALIVE_VALUE=$(${LEADER_CMD} config get tcp-keepalive | grep -A1 "tcp-keepalive" | tail -n1)
-              if [ "$SLOWLOG_VALUE" != "5000" ]; then
-                echo "leader-${LEADER_INDEX} slowlog-log-slower-than value is $SLOWLOG_VALUE, expected 5000"
-                exit 1
-              fi
-              if [ "$TCP_KEEPALIVE_VALUE" != "400" ]; then
-                echo "leader-${LEADER_INDEX} tcp-keepalive value is $TCP_KEEPALIVE_VALUE, expected 400"
-                exit 1
-              fi
-
-              # Check follower configuration
-              FOLLOWER_CMD="kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-follower-${FOLLOWER_INDEX}"
-              FOLLOWER_CMD="${FOLLOWER_CMD} -c redis-cluster-v1beta2-follower -- redis-cli --no-auth-warning -a Opstree1234 --tls --cacert /tls/ca.crt"
-              SLOWLOG_VALUE=$(${FOLLOWER_CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
-              TCP_KEEPALIVE_VALUE=$(${FOLLOWER_CMD} config get tcp-keepalive | grep -A1 "tcp-keepalive" | tail -n1)
-              if [ "$SLOWLOG_VALUE" != "5000" ]; then
-                echo "follower-${FOLLOWER_INDEX} slowlog-log-slower-than value is $SLOWLOG_VALUE, expected 5000"
-                exit 1
-              fi
-              if [ "$TCP_KEEPALIVE_VALUE" != "400" ]; then
-                echo "follower-${LEADER_INDEX} tcp-keepalive value is $TCP_KEEPALIVE_VALUE, expected 400"
-                exit 1
-              fi
-
-              echo "Redis instances leader-${LEADER_INDEX} and follower-${FOLLOWER_INDEX} have correct slowlog-log-slower-than configuration"
+              echo "All Redis leaders and followers have correct slowlog-log-slower-than and tcp-keepalive configuration"
               exit 0
             check:
-              (contains($stdout, 'have correct slowlog-log-slower-than configuration')): true
+              (contains($stdout, 'All Redis leaders and followers have correct')): true
 
     - name: Check maxmemory
       try:
@@ -112,7 +98,7 @@ spec:
               # maxmemory should not equal to 0
               MAXMEMORY=$(kubectl exec -n ${NAMESPACE} redis-cluster-v1beta2-leader-0 -c redis-cluster-v1beta2-leader -- \
               redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree1234 config get maxmemory | grep -A1 "maxmemory" | tail -n1)
-              if [ "$MAXMEMORY" == "0" ]; then
+              if [ "$MAXMEMORY" = "0" ]; then
                 echo "maxmemory value is $MAXMEMORY, expected not 0"
                 exit 1
               fi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
@@ -35,7 +35,7 @@ spec:
 
               # maxmemory should not equal to 0
               MAXMEMORY=$(kubectl exec -n ${NAMESPACE} redis-replication-0 -c redis-replication -- redis-cli --no-auth-warning -a Opstree1234 config get maxmemory | grep -A1 "maxmemory" | tail -n1)
-              if [ "$MAXMEMORY" == "0" ]; then
+              if [ "$MAXMEMORY" = "0" ]; then
                 echo "maxmemory value is $MAXMEMORY, expected not 0"
                 exit 1
               fi
@@ -64,7 +64,7 @@ spec:
                     break
                   fi
                 done
-                if [ "$ALL_OK" == "true" ]; then
+                if [ "$ALL_OK" = "true" ]; then
                   echo "all replicas have correct dynamic configuration"
                   exit 0
                 fi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
@@ -41,6 +41,40 @@ spec:
               fi
               exit 0
 
+    - name: Assert dynamic config
+      description: dynamicConfig is applied at runtime via CONFIG SET to every replica without a restart
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              #!/bin/bash
+              set -e
+
+              # The operator applies dynamicConfig on a reconcile after the pods are
+              # ready, so poll until every replica reflects the CONFIG SET values.
+              for i in $(seq 1 30); do
+                ALL_OK=true
+                for POD in redis-replication-0 redis-replication-1 redis-replication-2; do
+                  CMD="kubectl exec -n ${NAMESPACE} ${POD} -c redis-replication -- redis-cli --no-auth-warning -a Opstree1234"
+                  POLICY=$(${CMD} config get maxmemory-policy | grep -A1 "maxmemory-policy" | tail -n1)
+                  SLOWLOG=$(${CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
+                  if [ "$POLICY" != "allkeys-lru" ] || [ "$SLOWLOG" != "5000" ]; then
+                    echo "attempt ${i}: ${POD} maxmemory-policy=${POLICY} slowlog-log-slower-than=${SLOWLOG}, waiting..."
+                    ALL_OK=false
+                    break
+                  fi
+                done
+                if [ "$ALL_OK" == "true" ]; then
+                  echo "all replicas have correct dynamic configuration"
+                  exit 0
+                fi
+                sleep 3
+              done
+              echo "timed out waiting for dynamic configuration to be applied"
+              exit 1
+            check:
+              (contains($stdout, 'all replicas have correct dynamic configuration')): true
+
 
     - name: Resize pvc
       try:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/replication.yaml
@@ -11,6 +11,9 @@ spec:
   clusterSize: 3
   redisConfig:
     maxMemoryPercentOfLimit: 80
+    dynamicConfig:
+      - "maxmemory-policy allkeys-lru"
+      - "slowlog-log-slower-than 5000"
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/chainsaw-test.yaml
@@ -31,3 +31,30 @@ spec:
                 exit 1
               fi
               exit 0
+
+    - name: Assert dynamic config
+      description: dynamicConfig is applied at runtime via CONFIG SET without a restart
+      try:
+        - script:
+            timeout: 90s
+            content: |
+              #!/bin/bash
+              set -e
+              CMD="kubectl exec -n ${NAMESPACE} redis-standalone-v1beta2-0 -c redis-standalone-v1beta2 -- redis-cli --no-auth-warning"
+
+              # The operator applies dynamicConfig on a reconcile after the pod is
+              # ready, so poll until the CONFIG SET values appear.
+              for i in $(seq 1 30); do
+                POLICY=$(${CMD} config get maxmemory-policy | grep -A1 "maxmemory-policy" | tail -n1)
+                SLOWLOG=$(${CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
+                if [ "$POLICY" == "allkeys-lru" ] && [ "$SLOWLOG" == "5000" ]; then
+                  echo "standalone has correct dynamic configuration"
+                  exit 0
+                fi
+                echo "attempt ${i}: maxmemory-policy=${POLICY} slowlog-log-slower-than=${SLOWLOG}, waiting..."
+                sleep 3
+              done
+              echo "timed out waiting for dynamic configuration to be applied"
+              exit 1
+            check:
+              (contains($stdout, 'has correct dynamic configuration')): true

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/chainsaw-test.yaml
@@ -26,7 +26,7 @@ spec:
               set -e
               # maxmemory should not equal to 0
               MAXMEMORY=$(kubectl exec -n ${NAMESPACE} redis-standalone-v1beta2-0 -c redis-standalone-v1beta2 -- redis-cli --no-auth-warning config get maxmemory | grep -A1 "maxmemory" | tail -n1)
-              if [ "$MAXMEMORY" == "0" ]; then
+              if [ "$MAXMEMORY" = "0" ]; then
                 echo "maxmemory value is $MAXMEMORY, expected not 0"
                 exit 1
               fi
@@ -47,7 +47,7 @@ spec:
               for i in $(seq 1 30); do
                 POLICY=$(${CMD} config get maxmemory-policy | grep -A1 "maxmemory-policy" | tail -n1)
                 SLOWLOG=$(${CMD} config get slowlog-log-slower-than | grep -A1 "slowlog-log-slower-than" | tail -n1)
-                if [ "$POLICY" == "allkeys-lru" ] && [ "$SLOWLOG" == "5000" ]; then
+                if [ "$POLICY" = "allkeys-lru" ] && [ "$SLOWLOG" = "5000" ]; then
                   echo "standalone has correct dynamic configuration"
                   exit 0
                 fi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/standalone.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   redisConfig:
     maxMemoryPercentOfLimit: 80
+    dynamicConfig:
+      - "maxmemory-policy allkeys-lru"
+      - "slowlog-log-slower-than 5000"
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000


### PR DESCRIPTION


<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1239

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

- Added dynamicConfig field to Redis, RedisCluster, and RedisReplication CRDs to allow runtime configuration via CONFIG SET.
- Updated Helm charts to include dynamicConfig in values.yaml and templates.
- Implemented logic in controllers to apply dynamic configurations to Redis instances after they are ready.
- Created unit tests for dynamic configuration application and validation.
- Enhanced e2e tests to verify dynamic configuration is applied correctly without requiring restarts.
