### PR TITLE
Fix Sentinel bootstrap writing 0.0.0.0 as monitored master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs-$(CRD_REF_DOCS_VERSION)
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.17
+ENVTEST_USE_DEPRECATED_GCS ?= false
 GOLANGCI_LINT_VERSION ?= v2.4.0
 KUTTL_VERSION ?= 0.15.0
 KIND_VERSION ?= v0.24.0
@@ -71,7 +72,7 @@ all: manager
 # Run tests
 .PHONY: test
 test: generate fmt vet manifests
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --use-deprecated-gcs=$(ENVTEST_USE_DEPRECATED_GCS) -p path)" go test ./... -coverprofile cover.out
 
 # Build manager binary
 .PHONY: manager
@@ -291,4 +292,3 @@ GOBIN=$(LOCALBIN) go install $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef
-

--- a/hack/integrationSetup.sh
+++ b/hack/integrationSetup.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 K8S_VERSION="${K8S_VERSION:="1.28.x"}"
 KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
+ENVTEST_USE_DEPRECATED_GCS="${ENVTEST_USE_DEPRECATED_GCS:=false}"
 
 main() {
     tools
@@ -33,7 +34,7 @@ kubebuilder() {
     sudo mkdir -p ${KUBEBUILDER_ASSETS}
     sudo chown "${USER}" ${KUBEBUILDER_ASSETS}
     arch=$(go env GOARCH)
-    ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")/* ${KUBEBUILDER_ASSETS}
+    ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}" --use-deprecated-gcs="${ENVTEST_USE_DEPRECATED_GCS}")/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS
 }
 

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -46,7 +46,7 @@ func GenerateConfig() error {
 	// sentinel_mode_setup
 	{
 		masterGroupName, _ := util.CoalesceEnv("MASTER_GROUP_NAME", "mymaster")
-		ip, _ := util.CoalesceEnv("IP", "0.0.0.0")
+		ip, _ := util.CoalesceEnv("IP", "")
 		port, _ := util.CoalesceEnv("PORT", "6379")
 		quorum, _ := util.CoalesceEnv("QUORUM", "2")
 		downAfterMilliseconds, _ := util.CoalesceEnv("DOWN_AFTER_MILLISECONDS", "30000")
@@ -55,7 +55,11 @@ func GenerateConfig() error {
 		resolveHostnames, _ := util.CoalesceEnv("RESOLVE_HOSTNAMES", "no")
 		announceHostnames, _ := util.CoalesceEnv("ANNOUNCE_HOSTNAMES", "no")
 
-		cfg.Append("sentinel monitor", masterGroupName, ip, port, quorum)
+		if ip != "" && ip != "0.0.0.0" {
+			cfg.Append("sentinel monitor", masterGroupName, ip, port, quorum)
+		} else {
+			fmt.Println("Skipping sentinel monitor bootstrap because IP is unset")
+		}
 		cfg.Append("sentinel down-after-milliseconds", masterGroupName, downAfterMilliseconds)
 		cfg.Append("sentinel parallel-syncs", masterGroupName, parallelSyncs)
 		cfg.Append("sentinel failover-timeout", masterGroupName, failoverTimeout)
@@ -76,7 +80,7 @@ func GenerateConfig() error {
 		}
 
 		// If resolveHostnames is set to yes, then we need to announce the hostnames
-		if announceHostnames == "yes" && resolveHostnames == "yes" {
+		if announceHostnames == "yes" && resolveHostnames == "yes" && ip != "" && ip != "0.0.0.0" {
 			cfg.Append("sentinel announce-ip", ip)
 		}
 	}

--- a/internal/agent/bootstrap/sentinel/config_test.go
+++ b/internal/agent/bootstrap/sentinel/config_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,82 @@ func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 				assert.Contains(t, conf, "tls-ca-cert-file "+tt.expectedCAPath)
 			} else {
 				assert.NotContains(t, conf, "tls-ca-cert-file")
+			}
+		})
+	}
+}
+
+func TestGenerateConfig_SentinelMonitorBootstrap(t *testing.T) {
+	tests := []struct {
+		name                 string
+		ip                   string
+		setIP                bool
+		announceHostnames    string
+		resolveHostnames     string
+		wantMonitorLine      bool
+		wantAnnounceIPLine   bool
+		expectedMonitorValue string
+	}{
+		{
+			name:               "omits monitor when IP is unset",
+			setIP:              false,
+			announceHostnames:  "no",
+			resolveHostnames:   "no",
+			wantMonitorLine:    false,
+			wantAnnounceIPLine: false,
+		},
+		{
+			name:               "omits monitor when IP is 0.0.0.0",
+			ip:                 "0.0.0.0",
+			setIP:              true,
+			announceHostnames:  "yes",
+			resolveHostnames:   "yes",
+			wantMonitorLine:    false,
+			wantAnnounceIPLine: false,
+		},
+		{
+			name:                 "writes monitor and announce-ip when IP is valid",
+			ip:                   "10.0.0.15",
+			setIP:                true,
+			announceHostnames:    "yes",
+			resolveHostnames:     "yes",
+			wantMonitorLine:      true,
+			wantAnnounceIPLine:   true,
+			expectedMonitorValue: "sentinel monitor mymaster 10.0.0.15 6379 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			confPath := filepath.Join(t.TempDir(), "sentinel.conf")
+			t.Setenv("SENTINEL_CONFIG_FILE", confPath)
+			t.Setenv("MASTER_GROUP_NAME", "mymaster")
+			t.Setenv("PORT", "6379")
+			t.Setenv("QUORUM", "2")
+			t.Setenv("ANNOUNCE_HOSTNAMES", tt.announceHostnames)
+			t.Setenv("RESOLVE_HOSTNAMES", tt.resolveHostnames)
+			if tt.setIP {
+				t.Setenv("IP", tt.ip)
+			} else {
+				os.Unsetenv("IP")
+			}
+
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			hasMonitor := strings.Contains(conf, "\nsentinel monitor ")
+			assert.Equal(t, tt.wantMonitorLine, hasMonitor, conf)
+			if tt.wantMonitorLine {
+				assert.Contains(t, conf, tt.expectedMonitorValue)
+			}
+
+			hasAnnounceIP := strings.Contains(conf, "sentinel announce-ip ")
+			assert.Equal(t, tt.wantAnnounceIPLine, hasAnnounceIP, conf)
+			if tt.wantAnnounceIPLine {
+				assert.Contains(t, conf, "sentinel announce-ip "+tt.ip)
 			}
 		})
 	}

--- a/internal/controller/redisreplication/redisreplication_sentinel.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel.go
@@ -126,7 +126,39 @@ func buildSentinelContainer(rr *rrvb2.RedisReplication) corev1.Container {
 
 func buildSentinelEnv(rr *rrvb2.RedisReplication) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
+		{Name: "MASTER_GROUP_NAME", Value: masterGroupName},
+		{Name: "PORT", Value: "6379"},
 		{Name: "QUORUM", Value: fmt.Sprintf("%d", rr.Spec.Sentinel.Size/2+1)},
+	}
+	if rr.Spec.Sentinel.DownAfterMilliseconds != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "DOWN_AFTER_MILLISECONDS",
+			Value: rr.Spec.Sentinel.DownAfterMilliseconds,
+		})
+	}
+	if rr.Spec.Sentinel.ParallelSyncs != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "PARALLEL_SYNCS",
+			Value: rr.Spec.Sentinel.ParallelSyncs,
+		})
+	}
+	if rr.Spec.Sentinel.FailoverTimeout != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "FAILOVER_TIMEOUT",
+			Value: rr.Spec.Sentinel.FailoverTimeout,
+		})
+	}
+	if rr.Spec.Sentinel.ResolveHostnames != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "RESOLVE_HOSTNAMES",
+			Value: rr.Spec.Sentinel.ResolveHostnames,
+		})
+	}
+	if rr.Spec.Sentinel.AnnounceHostnames != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "ANNOUNCE_HOSTNAMES",
+			Value: rr.Spec.Sentinel.AnnounceHostnames,
+		})
 	}
 	passwordSecret := rr.Spec.KubernetesConfig.ExistingPasswordSecret
 	if rr.Spec.Sentinel.ExistingPasswordSecret != nil {

--- a/internal/controller/redisreplication/redisreplication_sentinel_test.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel_test.go
@@ -167,9 +167,9 @@ func TestBuildSentinelEnv(t *testing.T) {
 
 	t.Run("no password secret only sets quorum", func(t *testing.T) {
 		envs := buildSentinelEnv(newRR(nil, nil))
-		require.Len(t, envs, 1)
-		assert.Equal(t, "QUORUM", envs[0].Name)
-		assert.Equal(t, "2", envs[0].Value) // size 3 -> 3/2+1
+		assertEnvValue(t, envs, "MASTER_GROUP_NAME", masterGroupName)
+		assertEnvValue(t, envs, "PORT", "6379")
+		assertEnvValue(t, envs, "QUORUM", "2") // size 3 -> 3/2+1
 	})
 
 	t.Run("falls back to top-level redis secret", func(t *testing.T) {
@@ -186,6 +186,22 @@ func TestBuildSentinelEnv(t *testing.T) {
 		envs := buildSentinelEnv(newRR(nil, sentinelSecret))
 		assertMasterPassword(t, envs, "sentinel-secret", "sentinel-password")
 	})
+
+	t.Run("passes sentinel tuning env to bootstrap", func(t *testing.T) {
+		rr := newRR(nil, nil)
+		rr.Spec.Sentinel.DownAfterMilliseconds = "5000"
+		rr.Spec.Sentinel.ParallelSyncs = "1"
+		rr.Spec.Sentinel.FailoverTimeout = "10000"
+		rr.Spec.Sentinel.ResolveHostnames = "yes"
+		rr.Spec.Sentinel.AnnounceHostnames = "yes"
+
+		envs := buildSentinelEnv(rr)
+		assertEnvValue(t, envs, "DOWN_AFTER_MILLISECONDS", "5000")
+		assertEnvValue(t, envs, "PARALLEL_SYNCS", "1")
+		assertEnvValue(t, envs, "FAILOVER_TIMEOUT", "10000")
+		assertEnvValue(t, envs, "RESOLVE_HOSTNAMES", "yes")
+		assertEnvValue(t, envs, "ANNOUNCE_HOSTNAMES", "yes")
+	})
 }
 
 func assertMasterPassword(t *testing.T, envs []corev1.EnvVar, wantName, wantKey string) {
@@ -201,6 +217,17 @@ func assertMasterPassword(t *testing.T, envs []corev1.EnvVar, wantName, wantKey 
 		return
 	}
 	t.Fatalf("MASTER_PASSWORD env var not found in %+v", envs)
+}
+
+func assertEnvValue(t *testing.T, envs []corev1.EnvVar, name, want string) {
+	t.Helper()
+	for _, e := range envs {
+		if e.Name == name {
+			assert.Equal(t, want, e.Value)
+			return
+		}
+	}
+	t.Fatalf("%s env var not found in %+v", name, envs)
 }
 
 // TestConfigureSentinelPodUsesSentinelRedisSecret exercises the controller path


### PR DESCRIPTION
## Summary

Fixes OT-CONTAINER-KIT/redis-operator#1806

## Root Cause

Sentinel bootstrap defaulted `IP` to `0.0.0.0` and unconditionally wrote:

`sentinel monitor <group> 0.0.0.0 6379 <quorum>`

That causes invalid Sentinel state on first boot or restart before runtime reconciliation repairs it.

## Changes

- stop defaulting bootstrap `IP` to `0.0.0.0`
- only emit `sentinel monitor` when `IP` is a real address
- only emit `sentinel announce-ip` when `IP` is valid
- add bootstrap tests for:
  - unset `IP`
  - `IP=0.0.0.0`
  - valid `IP`
- harden embedded Sentinel bootstrap env wiring in the replication controller by passing:
  - `MASTER_GROUP_NAME`
  - `PORT`
  - Sentinel timing/tuning env vars
  - hostname settings env vars

## Why

The source bug is in Sentinel bootstrap. Operator reconciliation can repair state later, but it should not need to undo invalid bootstrap config.

## Validation

- `go test ./internal/agent/bootstrap/sentinel`
- `go test ./internal/controller/redisreplication ./internal/controller/redissentinel`

## Scope

The real source fix belongs in Sentinel bootstrap/image behavior. The operator-side embedded Sentinel env change is additional hardening.