### PR TITLE
feat(config): maxConcurrentReconciles and execCommandTimeout configurations

### DIFF
--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -106,8 +106,10 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | issuer.solver.enabled | bool | `true` |  |
 | issuer.solver.ingressClass | string | `"nginx"` |  |
 | issuer.type | string | `"selfSigned"` |  |
+| manager.config.execCommandTimeout | string | `""` |  |
 | manager.config.kubeClientQPS | float | `0` | If value > 0, it will override the default value in the operator |
 | manager.config.kubeClientTimeout | string | `"60s"` |  |
+| manager.config.maxConcurrentReconciles | int | `3` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |

--- a/charts/redis-operator/templates/operator-deployment.yaml
+++ b/charts/redis-operator/templates/operator-deployment.yaml
@@ -65,6 +65,9 @@ spec:
         {{- if and .Values.manager.config.kubeClientQPS (gt (.Values.manager.config.kubeClientQPS | float64) 0.0) }}
         - --kube-client-qps={{ .Values.manager.config.kubeClientQPS }}
         {{- end }}
+        {{- if and .Values.manager.config.maxConcurrentReconciles (gt (int .Values.manager.config.maxConcurrentReconciles) 0) }}
+        - --max-concurrent-reconciles={{ .Values.manager.config.maxConcurrentReconciles }}
+        {{- end }}
         {{- range $arg := .Values.redisOperator.extraArgs }}
         - {{ $arg }}
         {{- end }}
@@ -103,6 +106,10 @@ spec:
         {{- if .Values.redisOperator.serviceDNSDomain }}
         - name: SERVICE_DNS_DOMAIN
           value: {{ .Values.redisOperator.serviceDNSDomain | quote }}
+        {{- end }}
+        {{- if .Values.manager.config.execCommandTimeout }}
+        - name: EXEC_COMMAND_TIMEOUT
+          value: {{ .Values.manager.config.execCommandTimeout | quote }}
         {{- end }}
         {{- range $env := .Values.redisOperator.env }}
         - name: {{ $env.name }}

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -136,3 +136,7 @@ manager:
     kubeClientTimeout: 60s
     # -- If value > 0, it will override the default value in the operator
     kubeClientQPS: 0.0
+    # Set to 0 to use the operator's built-in default.
+    maxConcurrentReconciles: 3
+    # Accepts a Go duration (e.g. "30s", "5m"). Empty uses the operator's built-in default.
+    execCommandTimeout: ""

--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -99,7 +99,7 @@ func addFlags(cmd *cobra.Command, opts *managerOptions) {
 	cmd.Flags().StringVar(&opts.pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to. If empty, pprof is disabled. Example: ':6060'")
 	cmd.Flags().BoolVar(&opts.enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().BoolVar(&opts.enableWebhooks, "enable-webhooks", envs.IsWebhookEnabled(), "Enable webhooks")
-	cmd.Flags().IntVar(&opts.maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Max concurrent reconciles")
+	cmd.Flags().IntVar(&opts.maxConcurrentReconciles, "max-concurrent-reconciles", 3, "Maximum number of concurrent reconciles per controller. Reconciles for distinct objects run in parallel (controller-runtime still serializes per object), so a single slow or stuck reconcile cannot starve other Redis resources across namespaces.")
 	cmd.Flags().StringVar(&opts.featureGatesString, "feature-gates", envs.GetFeatureGates(), "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n  GenerateConfigInInitContainer=true|false: enables using init container for config generation")
 	cmd.Flags().Duration(

--- a/internal/envs/envs.go
+++ b/internal/envs/envs.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 )
@@ -32,6 +33,9 @@ const (
 
 	// MaxConcurrentReconcilesEnv defines the maximum number of concurrent reconciles
 	MaxConcurrentReconcilesEnv = "MAX_CONCURRENT_RECONCILES"
+
+	// ExecCommandTimeoutEnv defines the timeout for commands executed inside redis pods via the Kubernetes exec API
+	ExecCommandTimeoutEnv = "EXEC_COMMAND_TIMEOUT"
 
 	// EnableWebhooksEnv defines whether webhooks are enabled
 	EnableWebhooksEnv = "ENABLE_WEBHOOKS"
@@ -85,6 +89,17 @@ func GetWatchNamespaces() []string {
 func GetMaxConcurrentReconciles(defaultValue int) int {
 	if valueStr := os.Getenv(MaxConcurrentReconcilesEnv); valueStr != "" {
 		if value, err := strconv.Atoi(valueStr); err == nil {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+// GetExecCommandTimeout returns the timeout applied to commands executed inside redis pods
+// via the Kubernetes exec API.
+func GetExecCommandTimeout(defaultValue time.Duration) time.Duration {
+	if valueStr := os.Getenv(ExecCommandTimeoutEnv); valueStr != "" {
+		if value, err := time.ParseDuration(valueStr); err == nil && value > 0 {
 			return value
 		}
 	}

--- a/internal/envs/envs_test.go
+++ b/internal/envs/envs_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestGetWatchNamespaces(t *testing.T) {
@@ -98,6 +99,57 @@ func TestGetMaxConcurrentReconciles(t *testing.T) {
 			// Compare results
 			if actualValue != tt.expectedValue {
 				t.Errorf("GetMaxConcurrentReconciles() = %v, want %v", actualValue, tt.expectedValue)
+			}
+		})
+	}
+}
+
+func TestGetExecCommandTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		envValue      string
+		defaultValue  time.Duration
+		expectedValue time.Duration
+	}{
+		{
+			name:          "empty value with default",
+			envValue:      "",
+			defaultValue:  5 * time.Minute,
+			expectedValue: 5 * time.Minute,
+		},
+		{
+			name:          "valid duration",
+			envValue:      "30s",
+			defaultValue:  5 * time.Minute,
+			expectedValue: 30 * time.Second,
+		},
+		{
+			name:          "invalid value with default",
+			envValue:      "not-a-duration",
+			defaultValue:  2 * time.Minute,
+			expectedValue: 2 * time.Minute,
+		},
+		{
+			name:          "non-positive value with default",
+			envValue:      "0s",
+			defaultValue:  3 * time.Minute,
+			expectedValue: 3 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(ExecCommandTimeoutEnv, tt.envValue)
+				defer os.Unsetenv(ExecCommandTimeoutEnv)
+			} else {
+				os.Unsetenv(ExecCommandTimeoutEnv)
+			}
+
+			actualValue := GetExecCommandTimeout(tt.defaultValue)
+
+			if actualValue != tt.expectedValue {
+				t.Errorf("GetExecCommandTimeout() = %v, want %v", actualValue, tt.expectedValue)
 			}
 		})
 	}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -687,9 +687,12 @@ func configureRedisClient(ctx context.Context, client kubernetes.Interface, cr *
 		}
 	}
 	opts := &redis.Options{
-		Addr:     getRedisServerAddress(ctx, client, redisInfo, *cr.Spec.Port),
-		Password: pass,
-		DB:       0,
+		Addr:         getRedisServerAddress(ctx, client, redisInfo, *cr.Spec.Port),
+		Password:     pass,
+		DB:           0,
+		DialTimeout:  defaultRedisClientTimeout,
+		ReadTimeout:  defaultRedisClientTimeout,
+		WriteTimeout: defaultRedisClientTimeout,
 	}
 	if cr.Spec.TLS != nil {
 		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS)
@@ -731,6 +734,15 @@ func executeCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.
 	log.FromContext(ctx).V(1).Info("Successfully executed the command", "Command", cmd, "Output", execOut)
 }
 
+// defaultExecCommandTimeout bounds a single exec stream against a redis pod. It is generous
+// enough for a legitimate slow `redis-cli --cluster create` while still guaranteeing the stream
+// (and therefore the reconcile worker) cannot block forever. Override with EXEC_COMMAND_TIMEOUT.
+const defaultExecCommandTimeout = 5 * time.Minute
+
+// defaultRedisClientTimeout bounds dial/read/write operations of the go-redis clients the
+// reconciler opens against redis pods, so an unreachable pod cannot stall a reconcile.
+const defaultRedisClientTimeout = 5 * time.Second
+
 func executeCommand1(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) (stdout string, stderr error) {
 	var (
 		execOut bytes.Buffer
@@ -760,7 +772,13 @@ func executeCommand1(ctx context.Context, client kubernetes.Interface, cr *rcvb2
 		return "", err
 	}
 
-	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+	// Bound the exec stream with the reconcile ctx and a timeout so a blocked command (e.g. a
+	// `redis-cli --cluster create` against pods that cannot yet form a cluster) returns an error
+	// and requeues instead of pinning the reconcile worker forever, which would starve every
+	// other Redis resource across all namespaces.
+	execCtx, cancel := context.WithTimeout(ctx, envs.GetExecCommandTimeout(defaultExecCommandTimeout))
+	defer cancel()
+	err = exec.StreamWithContext(execCtx, remotecommand.StreamOptions{
 		Stdout: &execOut,
 		Stderr: &execErr,
 		Tty:    false,
@@ -773,7 +791,7 @@ func executeCommand1(ctx context.Context, client kubernetes.Interface, cr *rcvb2
 
 // getContainerID will return the id of container from pod
 func getContainerID(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName string) (int, *corev1.Pod) {
-	pod, err := client.CoreV1().Pods(cr.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := client.CoreV1().Pods(cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Could not get pod info", "Pod Name", podName, "Namespace", cr.Namespace)
 		return -1, nil
@@ -852,9 +870,12 @@ func configureRedisReplicationClientForAddress(ctx context.Context, client kuber
 		addr = formatRedisAddress(podIP, 6379)
 	}
 	opts := &redis.Options{
-		Addr:     addr,
-		Password: pass,
-		DB:       0,
+		Addr:         addr,
+		Password:     pass,
+		DB:           0,
+		DialTimeout:  defaultRedisClientTimeout,
+		ReadTimeout:  defaultRedisClientTimeout,
+		WriteTimeout: defaultRedisClientTimeout,
 	}
 	if cr.Spec.TLS != nil {
 		opts.TLSConfig = getRedisTLSConfig(ctx, client, cr.Namespace, cr.Spec.TLS)


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1377

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

1. Set MAX_CONCURRENT_RECONCILES=3 in default
2. Added the timeout for the redis cmd to prevent the cluster getting stuck. 

