### PR TITLE
feat: Implement ConfigMap and Secret watchers for RedisReplication and RedisSentinel controllers

### DIFF
--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -242,29 +242,35 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, maxConcu
 	healer := redis.NewHealer(k8sClient)
 
 	if err := (&rediscontroller.Reconciler{
-		Client:      mgr.GetClient(),
-		K8sClient:   k8sClient,
-		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
+		Client:           mgr.GetClient(),
+		K8sClient:        k8sClient,
+		StatefulSet:      k8sutils.NewStatefulSetService(k8sClient),
+		ConfigMapWatcher: intctrlutil.NewResourceWatcher(),
+		SecretWatcher:    intctrlutil.NewResourceWatcher(),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Redis")
 		return err
 	}
 	if err := (&redisclustercontroller.Reconciler{
-		Client:      mgr.GetClient(),
-		K8sClient:   k8sClient,
-		Healer:      healer,
-		Checker:     redis.NewChecker(k8sClient),
-		Recorder:    mgr.GetEventRecorderFor("rediscluster-controller"),
-		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
+		Client:           mgr.GetClient(),
+		K8sClient:        k8sClient,
+		Healer:           healer,
+		Checker:          redis.NewChecker(k8sClient),
+		Recorder:         mgr.GetEventRecorderFor("rediscluster-controller"),
+		StatefulSet:      k8sutils.NewStatefulSetService(k8sClient),
+		ConfigMapWatcher: intctrlutil.NewResourceWatcher(),
+		SecretWatcher:    intctrlutil.NewResourceWatcher(),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisCluster")
 		return err
 	}
 	if err := (&redisreplicationcontroller.Reconciler{
-		Client:      mgr.GetClient(),
-		K8sClient:   k8sClient,
-		Healer:      healer,
-		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
+		Client:           mgr.GetClient(),
+		K8sClient:        k8sClient,
+		Healer:           healer,
+		StatefulSet:      k8sutils.NewStatefulSetService(k8sClient),
+		ConfigMapWatcher: intctrlutil.NewResourceWatcher(),
+		SecretWatcher:    intctrlutil.NewResourceWatcher(),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisReplication")
 		return err
@@ -275,6 +281,8 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, maxConcu
 		Healer:             healer,
 		K8sClient:          k8sClient,
 		ReplicationWatcher: intctrlutil.NewResourceWatcher(),
+		ConfigMapWatcher:   intctrlutil.NewResourceWatcher(),
+		SecretWatcher:      intctrlutil.NewResourceWatcher(),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisSentinel")
 		return err

--- a/internal/controller/common/constants.go
+++ b/internal/controller/common/constants.go
@@ -3,6 +3,20 @@ package common
 const (
 	AnnotationKeyRecreateStatefulset         = "redis.opstreelabs.in/recreate-statefulset"
 	AnnotationKeyRecreateStatefulsetStrategy = "redis.opstreelabs.in/recreate-statefulset-strategy"
+	// AnnotationKeyExternalConfigChecksum is set on the pod template and holds a
+	// checksum of the mounted external/additional config ConfigMap. Because
+	// Kubernetes does not restart pods when a mounted ConfigMap changes, encoding
+	// the content into the pod template makes the StatefulSet spec change whenever
+	// the config changes, which triggers a rolling update.
+	AnnotationKeyExternalConfigChecksum = "redis.opstreelabs.in/external-config-checksum"
+	// AnnotationKeyTLSSecretChecksum, AnnotationKeyACLSecretChecksum and
+	// AnnotationKeyPasswordSecretChecksum do the same for the user-provided Secrets
+	// the operator mounts or references (TLS certificates, ACL rules, and the
+	// password injected via secretKeyRef). Rotating any of them rolls the pods so
+	// the new material is actually picked up.
+	AnnotationKeyTLSSecretChecksum      = "redis.opstreelabs.in/tls-secret-checksum"
+	AnnotationKeyACLSecretChecksum      = "redis.opstreelabs.in/acl-secret-checksum"
+	AnnotationKeyPasswordSecretChecksum = "redis.opstreelabs.in/password-secret-checksum"
 )
 
 const (

--- a/internal/controller/common/source_refs.go
+++ b/internal/controller/common/source_refs.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+)
+
+// ReferencedSecretNames returns the names of the user-provided Secrets the operator
+// mounts or references for a Redis workload: the TLS certificate Secret, the ACL
+// Secret, and the password Secret (ExistingPasswordSecret). References that are not
+// set (or set with an empty name) are skipped, so the result only contains real
+// Secret names a controller should watch.
+func ReferencedSecretNames(tls *commonapi.TLSConfig, acl *commonapi.ACLConfig, password *commonapi.ExistingPasswordSecret) []string {
+	var names []string
+	if tls != nil && tls.Secret.SecretName != "" {
+		names = append(names, tls.Secret.SecretName)
+	}
+	if acl != nil && acl.Secret != nil && acl.Secret.SecretName != "" {
+		names = append(names, acl.Secret.SecretName)
+	}
+	if password != nil && password.Name != nil && *password.Name != "" {
+		names = append(names, *password.Name)
+	}
+	return names
+}

--- a/internal/controller/redis/redis_controller.go
+++ b/internal/controller/redis/redis_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +42,13 @@ type Reconciler struct {
 	client.Client
 	k8sutils.StatefulSet
 	K8sClient kubernetes.Interface
+	// ConfigMapWatcher and SecretWatcher enqueue this Redis when a referenced
+	// external config ConfigMap or mounted/referenced Secret (TLS, ACL, password)
+	// changes. The standalone controller has no periodic requeue, so without these
+	// such an edit would not trigger a reconcile (and therefore no checksum rollout)
+	// until the next informer resync.
+	ConfigMapWatcher *intctrlutil.ResourceWatcher
+	SecretWatcher    *intctrlutil.ResourceWatcher
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -62,6 +70,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err = k8sutils.AddFinalizer(ctx, instance, RedisFinalizer, r.Client); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "failed to add finalizer")
 	}
+	r.registerSourceWatches(ctx, instance)
 	err = k8sutils.CreateStandaloneRedis(ctx, instance, r.K8sClient)
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "failed to create redis")
@@ -86,6 +95,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return intctrlutil.Reconciled()
 }
 
+// registerSourceWatches registers the external config ConfigMap and the mounted/
+// referenced Secrets (TLS, ACL, password) so a change to any of them enqueues this
+// Redis and rolls the StatefulSet via the checksum annotation.
+func (r *Reconciler) registerSourceWatches(ctx context.Context, instance *rvb2.Redis) {
+	dependent := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	if r.ConfigMapWatcher != nil && instance.Spec.RedisConfig != nil && instance.Spec.RedisConfig.AdditionalRedisConfig != nil {
+		r.ConfigMapWatcher.WatchMany(ctx, dependent, *instance.Spec.RedisConfig.AdditionalRedisConfig)
+	}
+	if r.SecretWatcher != nil {
+		r.SecretWatcher.WatchMany(ctx, dependent, common.ReferencedSecretNames(instance.Spec.TLS, instance.Spec.ACL, instance.Spec.KubernetesConfig.ExistingPasswordSecret)...)
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 //
 // Unlike RedisCluster, RedisReplication, and RedisSentinel controllers, the Redis standalone
@@ -95,10 +117,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // controller only creates a StatefulSet and a Service with no ongoing distributed state to poll,
 // so a timed requeue is unnecessary.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	if r.ConfigMapWatcher == nil {
+		r.ConfigMapWatcher = intctrlutil.NewResourceWatcher()
+	}
+	if r.SecretWatcher == nil {
+		r.SecretWatcher = intctrlutil.NewResourceWatcher()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rvb2.Redis{}).
 		WithOptions(opts).
 		Owns(&corev1.Service{}).
 		Owns(&appsv1.StatefulSet{}).
+		Watches(&corev1.ConfigMap{}, r.ConfigMapWatcher).
+		Watches(&corev1.Secret{}, r.SecretWatcher).
 		Complete(r)
 }

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/events"
@@ -33,6 +34,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,6 +55,12 @@ type Reconciler struct {
 	Checker   redis.Checker
 	K8sClient kubernetes.Interface
 	Recorder  record.EventRecorder
+	// ConfigMapWatcher and SecretWatcher enqueue this RedisCluster when a referenced
+	// external config ConfigMap or mounted/referenced Secret (TLS, ACL, password)
+	// changes. Leader and follower may reference different ConfigMaps, so both are
+	// registered when set.
+	ConfigMapWatcher *intctrlutil.ResourceWatcher
+	SecretWatcher    *intctrlutil.ResourceWatcher
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -73,6 +81,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return intctrlutil.Reconciled()
 	}
 	instance.SetDefault()
+
+	// Watch the leader/follower external config ConfigMaps and the referenced Secrets
+	// so an edit triggers a prompt rollout rather than waiting for the next requeue.
+	r.registerSourceWatches(ctx, instance)
 
 	leaderReplicas := instance.Spec.GetReplicaCounts("leader")
 	followerReplicas := instance.Spec.GetReplicaCounts("follower")
@@ -493,11 +505,36 @@ func (r *Reconciler) getStatefulSetReadyReplicas(ctx context.Context, namespace,
 	return sts.Status.ReadyReplicas
 }
 
+// registerSourceWatches registers the leader/follower external config ConfigMaps and
+// the cluster-level Secrets (TLS, ACL, password) so a change to any of them enqueues
+// this RedisCluster and rolls the affected StatefulSets via the checksum annotation.
+func (r *Reconciler) registerSourceWatches(ctx context.Context, instance *rcvb2.RedisCluster) {
+	dependent := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	if r.ConfigMapWatcher != nil {
+		for _, cfg := range []*commonapi.RedisConfig{instance.Spec.RedisLeader.RedisConfig, instance.Spec.RedisFollower.RedisConfig} {
+			if cfg != nil && cfg.AdditionalRedisConfig != nil {
+				r.ConfigMapWatcher.WatchMany(ctx, dependent, *cfg.AdditionalRedisConfig)
+			}
+		}
+	}
+	if r.SecretWatcher != nil {
+		r.SecretWatcher.WatchMany(ctx, dependent, common.ReferencedSecretNames(instance.Spec.TLS, instance.Spec.ACL, instance.Spec.KubernetesConfig.ExistingPasswordSecret)...)
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	if r.ConfigMapWatcher == nil {
+		r.ConfigMapWatcher = intctrlutil.NewResourceWatcher()
+	}
+	if r.SecretWatcher == nil {
+		r.SecretWatcher = intctrlutil.NewResourceWatcher()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rcvb2.RedisCluster{}).
 		Owns(&appsv1.StatefulSet{}).
 		WithOptions(opts).
+		Watches(&corev1.ConfigMap{}, r.ConfigMapWatcher).
+		Watches(&corev1.Secret{}, r.SecretWatcher).
 		Complete(r)
 }

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +41,12 @@ type Reconciler struct {
 	RedisReplicationRealMaster func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string
 	CreateRedisReplicationLink func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error
 	ConfigureSentinel          func(context.Context, *rrvb2.RedisReplication, string) error
+	// ConfigMapWatcher and SecretWatcher enqueue this RedisReplication when a
+	// referenced external config ConfigMap or mounted/referenced Secret (TLS, ACL,
+	// password) changes, so an edit triggers a prompt rollout instead of waiting
+	// for the next periodic requeue.
+	ConfigMapWatcher *intctrlutil.ResourceWatcher
+	SecretWatcher    *intctrlutil.ResourceWatcher
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -60,6 +67,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
+
+	r.registerSourceWatches(ctx, instance)
 
 	reconcilers := []reconciler{
 		{typ: "finalizer", rec: r.reconcileFinalizer},
@@ -531,10 +540,31 @@ func (r *Reconciler) updateStatus(ctx context.Context, rr *rrvb2.RedisReplicatio
 	return common.UpdateStatus(ctx, r.Client, copy)
 }
 
+// registerSourceWatches registers the external config ConfigMap and the mounted/
+// referenced Secrets (TLS, ACL, password) so a change to any of them enqueues this
+// RedisReplication and rolls the StatefulSet via the checksum annotation.
+func (r *Reconciler) registerSourceWatches(ctx context.Context, instance *rrvb2.RedisReplication) {
+	dependent := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	if r.ConfigMapWatcher != nil && instance.Spec.RedisConfig != nil && instance.Spec.RedisConfig.AdditionalRedisConfig != nil {
+		r.ConfigMapWatcher.WatchMany(ctx, dependent, *instance.Spec.RedisConfig.AdditionalRedisConfig)
+	}
+	if r.SecretWatcher != nil {
+		r.SecretWatcher.WatchMany(ctx, dependent, common.ReferencedSecretNames(instance.Spec.TLS, instance.Spec.ACL, instance.Spec.KubernetesConfig.ExistingPasswordSecret)...)
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	if r.ConfigMapWatcher == nil {
+		r.ConfigMapWatcher = intctrlutil.NewResourceWatcher()
+	}
+	if r.SecretWatcher == nil {
+		r.SecretWatcher = intctrlutil.NewResourceWatcher()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rrvb2.RedisReplication{}).
 		WithOptions(opts).
+		Watches(&corev1.ConfigMap{}, r.ConfigMapWatcher).
+		Watches(&corev1.Secret{}, r.SecretWatcher).
 		Complete(r)
 }

--- a/internal/controller/redissentinel/redissentinel_controller.go
+++ b/internal/controller/redissentinel/redissentinel_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,6 +32,12 @@ type RedisSentinelReconciler struct {
 	Healer             redis.Healer
 	K8sClient          kubernetes.Interface
 	ReplicationWatcher *intctrlutil.ResourceWatcher
+	// ConfigMapWatcher and SecretWatcher enqueue this RedisSentinel when its
+	// referenced external (additional) Sentinel config ConfigMap or mounted/
+	// referenced Secret (TLS, password) changes, so an edit triggers a prompt
+	// rollout of the Sentinel StatefulSet.
+	ConfigMapWatcher *intctrlutil.ResourceWatcher
+	SecretWatcher    *intctrlutil.ResourceWatcher
 }
 
 func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -51,6 +58,10 @@ func (r *RedisSentinelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if common.ShouldSkipReconcile(ctx, instance) {
 		return intctrlutil.Reconciled()
 	}
+
+	// Register the source watches up front so they are wired regardless of whether
+	// later reconcile steps short-circuit (e.g. replication not yet ready).
+	r.registerSourceWatches(ctx, instance)
 
 	reconcilers := []reconciler{
 		{typ: "finalizer", rec: r.reconcileFinalizer},
@@ -164,12 +175,34 @@ func (r *RedisSentinelReconciler) reconcileService(ctx context.Context, instance
 	return intctrlutil.Reconciled()
 }
 
+// registerSourceWatches registers the external (additional) Sentinel config
+// ConfigMap and the referenced Secrets (TLS, password) so a change to any of them
+// enqueues this RedisSentinel and rolls the Sentinel StatefulSet via the checksum
+// annotation. Sentinel has no ACL configuration.
+func (r *RedisSentinelReconciler) registerSourceWatches(ctx context.Context, instance *rsvb2.RedisSentinel) {
+	dependent := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	if r.ConfigMapWatcher != nil && instance.Spec.RedisSentinelConfig != nil && instance.Spec.RedisSentinelConfig.AdditionalSentinelConfig != nil {
+		r.ConfigMapWatcher.WatchMany(ctx, dependent, *instance.Spec.RedisSentinelConfig.AdditionalSentinelConfig)
+	}
+	if r.SecretWatcher != nil {
+		r.SecretWatcher.WatchMany(ctx, dependent, common.ReferencedSecretNames(instance.Spec.TLS, nil, instance.Spec.KubernetesConfig.ExistingPasswordSecret)...)
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedisSentinelReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	if r.ConfigMapWatcher == nil {
+		r.ConfigMapWatcher = intctrlutil.NewResourceWatcher()
+	}
+	if r.SecretWatcher == nil {
+		r.SecretWatcher = intctrlutil.NewResourceWatcher()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rsvb2.RedisSentinel{}).
 		Owns(&appsv1.StatefulSet{}).
 		WithOptions(opts).
 		Watches(&rrvb2.RedisReplication{}, r.ReplicationWatcher).
+		Watches(&corev1.ConfigMap{}, r.ConfigMapWatcher).
+		Watches(&corev1.Secret{}, r.SecretWatcher).
 		Complete(r)
 }

--- a/internal/controllerutil/resource_watcher.go
+++ b/internal/controllerutil/resource_watcher.go
@@ -53,6 +53,18 @@ func (w *ResourceWatcher) Watch(ctx context.Context, watchedName, dependentName 
 	w.watched[watchedName] = append(existing, dependentName)
 }
 
+// WatchMany registers dependent to be reconciled whenever any of the named
+// objects in dependent's namespace changes. Empty names are ignored, so callers
+// can pass optional references directly without pre-filtering.
+func (w *ResourceWatcher) WatchMany(ctx context.Context, dependent types.NamespacedName, names ...string) {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		w.Watch(ctx, types.NamespacedName{Namespace: dependent.Namespace, Name: name}, dependent)
+	}
+}
+
 func (w *ResourceWatcher) Create(ctx context.Context, event event.CreateEvent, queue workqueue.RateLimitingInterface) {
 	w.handleEvent(event.Object, queue)
 }

--- a/internal/controllerutil/resource_watcher_test.go
+++ b/internal/controllerutil/resource_watcher_test.go
@@ -1,0 +1,68 @@
+package controllerutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func drain(queue workqueue.RateLimitingInterface) []reconcile.Request {
+	var got []reconcile.Request
+	for queue.Len() > 0 {
+		item, _ := queue.Get()
+		got = append(got, item.(reconcile.Request))
+		queue.Done(item)
+	}
+	return got
+}
+
+func configMapUpdate(namespace, name string) event.UpdateEvent {
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	return event.UpdateEvent{ObjectOld: obj, ObjectNew: obj}
+}
+
+func TestResourceWatcherEnqueuesDependentOnWatchedChange(t *testing.T) {
+	w := NewResourceWatcher()
+	dependent := types.NamespacedName{Namespace: "ns", Name: "my-redis"}
+	w.Watch(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "external-config"}, dependent)
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	w.Update(context.TODO(), configMapUpdate("ns", "external-config"), queue)
+
+	assert.Equal(t, []reconcile.Request{{NamespacedName: dependent}}, drain(queue))
+}
+
+func TestResourceWatcherIgnoresUnwatchedChange(t *testing.T) {
+	w := NewResourceWatcher()
+	w.Watch(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "external-config"}, types.NamespacedName{Namespace: "ns", Name: "my-redis"})
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	w.Update(context.TODO(), configMapUpdate("ns", "some-other-configmap"), queue)
+
+	assert.Empty(t, drain(queue))
+}
+
+func TestResourceWatcherWatchMany(t *testing.T) {
+	w := NewResourceWatcher()
+	dependent := types.NamespacedName{Namespace: "ns", Name: "my-redis"}
+	// Empty names must be ignored; the rest register under the dependent's namespace.
+	w.WatchMany(context.TODO(), dependent, "tls-secret", "", "password-secret")
+
+	for _, secret := range []string{"tls-secret", "password-secret"} {
+		queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		w.Update(context.TODO(), configMapUpdate("ns", secret), queue)
+		assert.Equal(t, []reconcile.Request{{NamespacedName: dependent}}, drain(queue), "expected enqueue for %s", secret)
+	}
+
+	// The skipped empty name must not have registered a watch for "".
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	w.Update(context.TODO(), configMapUpdate("ns", ""), queue)
+	assert.Empty(t, drain(queue))
+}

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -2,6 +2,9 @@ package k8sutils
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"path"
 	"sort"
@@ -110,6 +113,7 @@ type statefulSetParameters struct {
 	NodeConfPersistentVolumeClaim        corev1.PersistentVolumeClaim
 	ImagePullSecrets                     *[]corev1.LocalObjectReference
 	ExternalConfig                       *string
+	ConfigChecksums                      map[string]string
 	ServiceAccountName                   *string
 	UpdateStrategy                       appsv1.StatefulSetUpdateStrategy
 	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy
@@ -177,6 +181,18 @@ type initContainerParameters struct {
 // CreateOrUpdateStateFul method will create or update Redis service
 func CreateOrUpdateStateFul(ctx context.Context, cl kubernetes.Interface, namespace string, stsMeta metav1.ObjectMeta, params statefulSetParameters, ownerDef metav1.OwnerReference, initcontainerParams initContainerParameters, containerParams containerParameters, sidecars *[]commonapi.Sidecar) error {
 	storedStateful, err := GetStatefulSet(ctx, cl, namespace, stsMeta.Name)
+	// Encode the content of the referenced config/secret sources into the pod
+	// template so that editing any of them rolls the StatefulSet. Kubernetes does
+	// not restart pods when a mounted ConfigMap/Secret (or a secretKeyRef) changes,
+	// so without this the spec would be byte-identical and no rollout would happen.
+	// storedStateful (nil when the STS does not exist yet) lets us preserve the
+	// previous checksum on a transient lookup failure instead of rolling pods.
+	// checksumErr is non-nil when a source lookup failed transiently (not NotFound);
+	// we still apply the StatefulSet with the preserved checksum, then surface the
+	// error so the reconcile is retried and converges even on controllers that have
+	// no periodic requeue (e.g. standalone Redis).
+	checksums, checksumErr := computeReferencedChecksums(ctx, cl, namespace, params, containerParams, storedStateful)
+	params.ConfigChecksums = checksums
 	statefulSetDef := generateStatefulSetsDef(stsMeta, params, ownerDef, initcontainerParams, containerParams, getSidecars(sidecars))
 	if err != nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(statefulSetDef); err != nil { //nolint:gocritic
@@ -184,11 +200,17 @@ func CreateOrUpdateStateFul(ctx context.Context, cl kubernetes.Interface, namesp
 			return err
 		}
 		if apierrors.IsNotFound(err) {
-			return createStatefulSet(ctx, cl, namespace, statefulSetDef)
+			if err := createStatefulSet(ctx, cl, namespace, statefulSetDef); err != nil {
+				return err
+			}
+			return checksumErr
 		}
 		return err
 	}
-	return patchStatefulSet(ctx, storedStateful, statefulSetDef, namespace, params.RecreateStatefulSet, params.RecreateStatefulsetStrategy, cl)
+	if err := patchStatefulSet(ctx, storedStateful, statefulSetDef, namespace, params.RecreateStatefulSet, params.RecreateStatefulsetStrategy, cl); err != nil {
+		return err
+	}
+	return checksumErr
 }
 
 // patchStatefulSet patches the Redis StatefulSet by applying changes while maintaining atomicity.
@@ -301,6 +323,18 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 	// Generate stable selector labels (only core labels that won't change)
 	selectorLabels := extractStatefulSetSelectorLabels(stsMeta.GetLabels())
 
+	// Build the pod template annotations and stamp the checksums of any referenced
+	// config/secret sources so a change to their content alters the pod template
+	// and triggers a rolling update via the existing patch path. An absent key
+	// (e.g. a deleted source) is intentionally not stamped; an empty map leaves the
+	// template untouched. The checksums are layered on after generateStatefulSetsAnots
+	// (which applies IgnoreAnnotations), so they intentionally bypass IgnoreAnnotations
+	// — suppressing them would defeat the config-rollout behaviour.
+	podAnnotations := generateStatefulSetsAnots(stsMeta, params.IgnoreAnnotations)
+	for key, checksum := range params.ConfigChecksums {
+		podAnnotations[key] = checksum
+	}
+
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
@@ -314,7 +348,7 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      stsMeta.GetLabels(),
-					Annotations: generateStatefulSetsAnots(stsMeta, params.IgnoreAnnotations),
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					Containers: generateContainerDef(
@@ -437,6 +471,143 @@ func getExternalConfig(configMapName string) []corev1.Volume {
 			},
 		},
 	}
+}
+
+// computeReferencedChecksums returns the pod-template checksum annotations for the
+// user-provided config/secret sources this StatefulSet mounts or references
+// (external config ConfigMap, TLS Secret, ACL Secret and the password Secret).
+//
+// Each source is keyed by its annotation. The semantics of a lookup are:
+//   - success           -> stamp the content checksum
+//   - NotFound          -> leave the annotation unset, so a genuine deletion still
+//     rolls the StatefulSet
+//   - transient failure -> preserve the previously stored checksum (when the STS
+//     already exists) so a recoverable apiserver hiccup does not un-stamp the
+//     annotation and trigger a needless rolling restart
+//
+// The returned error is non-nil when at least one source hit a transient failure,
+// so the caller can requeue and converge once the source is reachable again.
+func computeReferencedChecksums(ctx context.Context, cl kubernetes.Interface, namespace string, params statefulSetParameters, containerParams containerParameters, stored *appsv1.StatefulSet) (map[string]string, error) {
+	checksums := map[string]string{}
+	var transientErr error
+
+	add := func(annotationKey, name string, fetch func() (string, error)) {
+		if name == "" {
+			return
+		}
+		sum, err := fetch()
+		if err != nil {
+			// Transient lookup error: keep the previously stored checksum (if any)
+			// rather than dropping the annotation and rolling pods for no reason, and
+			// remember the error so the caller can retry and pick up the real change.
+			transientErr = err
+			if stored != nil {
+				if prev, ok := stored.Spec.Template.Annotations[annotationKey]; ok {
+					checksums[annotationKey] = prev
+				}
+			}
+			return
+		}
+		// An empty sum means the source was definitively absent (NotFound); leave the
+		// annotation unset so a real deletion is reflected as a spec change.
+		if sum != "" {
+			checksums[annotationKey] = sum
+		}
+	}
+
+	if params.ExternalConfig != nil {
+		add(common.AnnotationKeyExternalConfigChecksum, *params.ExternalConfig, func() (string, error) {
+			return configMapChecksum(ctx, cl, namespace, *params.ExternalConfig)
+		})
+	}
+	if containerParams.TLSConfig != nil {
+		add(common.AnnotationKeyTLSSecretChecksum, containerParams.TLSConfig.Secret.SecretName, func() (string, error) {
+			return secretChecksum(ctx, cl, namespace, containerParams.TLSConfig.Secret.SecretName)
+		})
+	}
+	if containerParams.ACLConfig != nil && containerParams.ACLConfig.Secret != nil {
+		add(common.AnnotationKeyACLSecretChecksum, containerParams.ACLConfig.Secret.SecretName, func() (string, error) {
+			return secretChecksum(ctx, cl, namespace, containerParams.ACLConfig.Secret.SecretName)
+		})
+	}
+	if containerParams.EnabledPassword != nil && *containerParams.EnabledPassword && containerParams.SecretName != nil {
+		add(common.AnnotationKeyPasswordSecretChecksum, *containerParams.SecretName, func() (string, error) {
+			return secretChecksum(ctx, cl, namespace, *containerParams.SecretName)
+		})
+	}
+	return checksums, transientErr
+}
+
+// configMapChecksum fetches a ConfigMap and returns a checksum of its content.
+// A NotFound error yields ("", nil) so the caller drops the annotation; any other
+// error is returned so the caller can preserve the previously stored checksum.
+func configMapChecksum(ctx context.Context, cl kubernetes.Interface, namespace, name string) (string, error) {
+	cm, err := cl.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("external config ConfigMap not found; checksum annotation will not be set", "configMap", name, "namespace", namespace)
+			return "", nil
+		}
+		log.FromContext(ctx).Error(err, "failed to get external config ConfigMap for checksum", "configMap", name, "namespace", namespace)
+		return "", err
+	}
+	return computeConfigMapChecksum(cm), nil
+}
+
+// secretChecksum fetches a Secret and returns a checksum of its Data. NotFound and
+// transient errors follow the same convention as configMapChecksum.
+func secretChecksum(ctx context.Context, cl kubernetes.Interface, namespace, name string) (string, error) {
+	secret, err := cl.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("referenced Secret not found; checksum annotation will not be set", "secret", name, "namespace", namespace)
+			return "", nil
+		}
+		log.FromContext(ctx).Error(err, "failed to get referenced Secret for checksum", "secret", name, "namespace", namespace)
+		return "", err
+	}
+	return computeSecretChecksum(secret), nil
+}
+
+// computeConfigMapChecksum returns a deterministic sha256 hex digest over the
+// ConfigMap's Data and BinaryData. json.Marshal emits map keys in sorted order,
+// so the digest is stable across reconciles for identical content regardless of
+// map iteration order.
+func computeConfigMapChecksum(cm *corev1.ConfigMap) string {
+	if cm == nil {
+		return ""
+	}
+	payload, err := json.Marshal(struct {
+		Data       map[string]string `json:"data,omitempty"`
+		BinaryData map[string][]byte `json:"binaryData,omitempty"`
+	}{
+		Data:       cm.Data,
+		BinaryData: cm.BinaryData,
+	})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+// computeSecretChecksum returns a deterministic sha256 hex digest over the Secret's
+// Data (StringData is merged into Data by the apiserver on read, so it need not be
+// hashed separately).
+func computeSecretChecksum(secret *corev1.Secret) string {
+	if secret == nil {
+		return ""
+	}
+	payload, err := json.Marshal(struct {
+		Data map[string][]byte `json:"data,omitempty"`
+	}{
+		Data: secret.Data,
+	})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
 }
 
 // createPVCTemplate will create the persistent volume claim template

--- a/internal/k8sutils/statefulset_test.go
+++ b/internal/k8sutils/statefulset_test.go
@@ -16,8 +16,11 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -2469,4 +2472,270 @@ func TestStatefulSetSelectorLabels(t *testing.T) {
 			assert.Equal(t, tt.expectedSelectorLabels, selectorLabels, "StatefulSet selector labels should be filtered correctly")
 		})
 	}
+}
+
+func TestComputeConfigMapChecksum(t *testing.T) {
+	// nil ConfigMap yields an empty checksum.
+	assert.Empty(t, computeConfigMapChecksum(nil))
+
+	base := &corev1.ConfigMap{Data: map[string]string{"redis.conf": "maxmemory 100mb", "extra.conf": "appendonly yes"}}
+	// Reordered keys must produce an identical checksum (map iteration order
+	// must not affect the digest).
+	reordered := &corev1.ConfigMap{Data: map[string]string{"extra.conf": "appendonly yes", "redis.conf": "maxmemory 100mb"}}
+	assert.Equal(t, computeConfigMapChecksum(base), computeConfigMapChecksum(reordered))
+	assert.NotEmpty(t, computeConfigMapChecksum(base))
+
+	// Changing a value changes the checksum.
+	changed := &corev1.ConfigMap{Data: map[string]string{"redis.conf": "maxmemory 200mb", "extra.conf": "appendonly yes"}}
+	assert.NotEqual(t, computeConfigMapChecksum(base), computeConfigMapChecksum(changed))
+
+	// BinaryData is included in the checksum.
+	withBinary := &corev1.ConfigMap{
+		Data:       map[string]string{"redis.conf": "maxmemory 100mb", "extra.conf": "appendonly yes"},
+		BinaryData: map[string][]byte{"blob": []byte("payload")},
+	}
+	assert.NotEqual(t, computeConfigMapChecksum(base), computeConfigMapChecksum(withBinary))
+}
+
+func TestComputeSecretChecksum(t *testing.T) {
+	assert.Empty(t, computeSecretChecksum(nil))
+
+	base := &corev1.Secret{Data: map[string][]byte{"password": []byte("s3cr3t")}}
+	reordered := &corev1.Secret{Data: map[string][]byte{"password": []byte("s3cr3t")}}
+	assert.Equal(t, computeSecretChecksum(base), computeSecretChecksum(reordered))
+	assert.NotEmpty(t, computeSecretChecksum(base))
+
+	changed := &corev1.Secret{Data: map[string][]byte{"password": []byte("rotated")}}
+	assert.NotEqual(t, computeSecretChecksum(base), computeSecretChecksum(changed))
+}
+
+func TestConfigMapChecksum(t *testing.T) {
+	t.Run("missing ConfigMap returns empty checksum and no error", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset()
+		sum, err := configMapChecksum(context.TODO(), client, "test-ns", "does-not-exist")
+		require.NoError(t, err)
+		assert.Empty(t, sum)
+	})
+
+	t.Run("present ConfigMap returns content checksum", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-external-config", Namespace: "test-ns"},
+			Data:       map[string]string{"redis.conf": "maxmemory 100mb"},
+		}
+		client := k8sClientFake.NewSimpleClientset(cm)
+		sum, err := configMapChecksum(context.TODO(), client, "test-ns", "redis-external-config")
+		require.NoError(t, err)
+		assert.Equal(t, computeConfigMapChecksum(cm), sum)
+	})
+}
+
+func TestSecretChecksum(t *testing.T) {
+	t.Run("missing Secret returns empty checksum and no error", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset()
+		sum, err := secretChecksum(context.TODO(), client, "test-ns", "does-not-exist")
+		require.NoError(t, err)
+		assert.Empty(t, sum)
+	})
+
+	t.Run("present Secret returns content checksum", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-password", Namespace: "test-ns"},
+			Data:       map[string][]byte{"password": []byte("s3cr3t")},
+		}
+		client := k8sClientFake.NewSimpleClientset(secret)
+		sum, err := secretChecksum(context.TODO(), client, "test-ns", "redis-password")
+		require.NoError(t, err)
+		assert.Equal(t, computeSecretChecksum(secret), sum)
+	})
+}
+
+// TestComputeReferencedChecksumsPreservesOnTransientError verifies that a transient
+// (non-NotFound) lookup failure keeps the previously stored checksum rather than
+// dropping the annotation, which would otherwise roll the pods needlessly.
+func TestComputeReferencedChecksumsPreservesOnTransientError(t *testing.T) {
+	ns := "test-ns"
+	client := k8sClientFake.NewSimpleClientset()
+	// Force every ConfigMap GET to fail with a transient (non-NotFound) error.
+	client.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, kerrors.NewServiceUnavailable("apiserver is having a moment")
+	})
+
+	stored := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{externalConfigChecksumAnnotation: "previously-stored-checksum"},
+				},
+			},
+		},
+	}
+	params := statefulSetParameters{ExternalConfig: ptr.To("redis-external-config")}
+
+	got, err := computeReferencedChecksums(context.TODO(), client, ns, params, containerParameters{}, stored)
+	require.Error(t, err, "a transient lookup error must be surfaced so the caller can requeue")
+	assert.Equal(t, "previously-stored-checksum", got[externalConfigChecksumAnnotation],
+		"transient error must preserve the previously stored checksum")
+
+	// With no stored StatefulSet, a transient error simply omits the annotation
+	// (it will be stamped on the next successful reconcile) but is still surfaced.
+	gotNoStored, err := computeReferencedChecksums(context.TODO(), client, ns, params, containerParameters{}, nil)
+	require.Error(t, err)
+	_, ok := gotNoStored[externalConfigChecksumAnnotation]
+	assert.False(t, ok, "transient error with no stored STS should omit the annotation")
+}
+
+// externalConfigChecksumAnnotation mirrors common.AnnotationKeyExternalConfigChecksum.
+// It is duplicated as a literal here on purpose so the test fails if the wire value
+// of the annotation key ever changes unintentionally.
+const externalConfigChecksumAnnotation = "redis.opstreelabs.in/external-config-checksum"
+
+func TestCreateOrUpdateStateFulExternalConfigChecksum(t *testing.T) {
+	ns := "test-ns"
+	cmName := "redis-external-config"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns},
+		Data:       map[string]string{"redis.conf": "maxmemory 100mb"},
+	}
+	client := k8sClientFake.NewSimpleClientset(cm)
+
+	stsMeta := metav1.ObjectMeta{Name: "test-sts", Namespace: ns}
+	params := statefulSetParameters{
+		Replicas:       ptr.To(int32(1)),
+		ExternalConfig: ptr.To(cmName),
+	}
+	ownerDef := metav1.OwnerReference{Name: "test-sts", UID: "test-uid"}
+	containerParams := containerParameters{Image: "redis:latest"}
+
+	// First reconcile creates the StatefulSet with a checksum annotation on the pod template.
+	require.NoError(t, CreateOrUpdateStateFul(context.TODO(), client, ns, stsMeta, params, ownerDef, initContainerParameters{}, containerParams, nil))
+
+	sts, err := client.AppsV1().StatefulSets(ns).Get(context.TODO(), "test-sts", metav1.GetOptions{})
+	require.NoError(t, err)
+	firstChecksum := sts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	assert.NotEmpty(t, firstChecksum, "expected external config checksum annotation on pod template")
+
+	// Editing the ConfigMap must change the checksum and roll the StatefulSet.
+	cm.Data["redis.conf"] = "maxmemory 200mb"
+	_, err = client.CoreV1().ConfigMaps(ns).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, CreateOrUpdateStateFul(context.TODO(), client, ns, stsMeta, params, ownerDef, initContainerParameters{}, containerParams, nil))
+
+	sts, err = client.AppsV1().StatefulSets(ns).Get(context.TODO(), "test-sts", metav1.GetOptions{})
+	require.NoError(t, err)
+	secondChecksum := sts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	assert.NotEmpty(t, secondChecksum)
+	assert.NotEqual(t, firstChecksum, secondChecksum, "checksum annotation must change when the ConfigMap content changes")
+}
+
+func TestCreateOrUpdateStateFulNoExternalConfigChecksum(t *testing.T) {
+	ns := "test-ns"
+	client := k8sClientFake.NewSimpleClientset()
+
+	stsMeta := metav1.ObjectMeta{Name: "test-sts", Namespace: ns}
+	params := statefulSetParameters{Replicas: ptr.To(int32(1))} // ExternalConfig nil
+	containerParams := containerParameters{Image: "redis:latest"}
+
+	require.NoError(t, CreateOrUpdateStateFul(context.TODO(), client, ns, stsMeta, params, metav1.OwnerReference{Name: "test-sts"}, initContainerParameters{}, containerParams, nil))
+
+	sts, err := client.AppsV1().StatefulSets(ns).Get(context.TODO(), "test-sts", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok := sts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	assert.False(t, ok, "no checksum annotation should be set when ExternalConfig is nil")
+}
+
+// TestCreateOrUpdateStateFulClusterPerStatefulSetChecksum mirrors the cluster path,
+// where leader and follower are generated as separate StatefulSets each with their
+// own external config ConfigMap, and asserts they get independent checksums.
+func TestCreateOrUpdateStateFulClusterPerStatefulSetChecksum(t *testing.T) {
+	ns := "test-ns"
+	leaderCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "leader-config", Namespace: ns},
+		Data:       map[string]string{"redis.conf": "maxmemory 100mb"},
+	}
+	followerCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "follower-config", Namespace: ns},
+		Data:       map[string]string{"redis.conf": "maxmemory 200mb"},
+	}
+	client := k8sClientFake.NewSimpleClientset(leaderCM, followerCM)
+	containerParams := containerParameters{Image: "redis:latest"}
+
+	create := func(name, cmName string) *appsv1.StatefulSet {
+		meta := metav1.ObjectMeta{Name: name, Namespace: ns}
+		params := statefulSetParameters{Replicas: ptr.To(int32(1)), ExternalConfig: ptr.To(cmName)}
+		require.NoError(t, CreateOrUpdateStateFul(context.TODO(), client, ns, meta, params, metav1.OwnerReference{Name: name, UID: apimachinerytypes.UID("uid-" + name)}, initContainerParameters{}, containerParams, nil))
+		sts, err := client.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return sts
+	}
+
+	leaderSts := create("test-leader", "leader-config")
+	followerSts := create("test-follower", "follower-config")
+
+	leaderChecksum := leaderSts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	followerChecksum := followerSts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	assert.NotEmpty(t, leaderChecksum)
+	assert.NotEmpty(t, followerChecksum)
+	assert.NotEqual(t, leaderChecksum, followerChecksum, "leader and follower reference different ConfigMaps and must get different checksums")
+}
+
+// TestCreateOrUpdateStateFulSecretChecksums verifies that referenced TLS/ACL/password
+// Secrets are stamped as their own pod-template checksum annotations.
+func TestCreateOrUpdateStateFulSecretChecksums(t *testing.T) {
+	const (
+		tlsSecretChecksumAnnotation      = "redis.opstreelabs.in/tls-secret-checksum"
+		passwordSecretChecksumAnnotation = "redis.opstreelabs.in/password-secret-checksum"
+	)
+	ns := "test-ns"
+	tlsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-tls", Namespace: ns},
+		Data:       map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
+	}
+	passwordSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-password", Namespace: ns},
+		Data:       map[string][]byte{"password": []byte("s3cr3t")},
+	}
+	client := k8sClientFake.NewSimpleClientset(tlsSecret, passwordSecret)
+
+	meta := metav1.ObjectMeta{Name: "test-sts", Namespace: ns}
+	params := statefulSetParameters{Replicas: ptr.To(int32(1))}
+	containerParams := containerParameters{
+		Image:           "redis:latest",
+		TLSConfig:       &common.TLSConfig{Secret: corev1.SecretVolumeSource{SecretName: "redis-tls"}},
+		EnabledPassword: ptr.To(true),
+		SecretName:      ptr.To("redis-password"),
+		SecretKey:       ptr.To("password"),
+	}
+
+	require.NoError(t, CreateOrUpdateStateFul(context.TODO(), client, ns, meta, params, metav1.OwnerReference{Name: "test-sts", UID: "test-uid"}, initContainerParameters{}, containerParams, nil))
+
+	sts, err := client.AppsV1().StatefulSets(ns).Get(context.TODO(), "test-sts", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, computeSecretChecksum(tlsSecret), sts.Spec.Template.Annotations[tlsSecretChecksumAnnotation])
+	assert.Equal(t, computeSecretChecksum(passwordSecret), sts.Spec.Template.Annotations[passwordSecretChecksumAnnotation])
+}
+
+// TestCreateOrUpdateStateFulRequeuesOnTransientChecksumError verifies that a transient
+// source-lookup failure still applies the StatefulSet but surfaces an error, so the
+// controller requeues and converges (important for the standalone controller, which
+// has no periodic requeue).
+func TestCreateOrUpdateStateFulRequeuesOnTransientChecksumError(t *testing.T) {
+	ns := "test-ns"
+	client := k8sClientFake.NewSimpleClientset()
+	client.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, kerrors.NewServiceUnavailable("apiserver is having a moment")
+	})
+
+	meta := metav1.ObjectMeta{Name: "test-sts", Namespace: ns}
+	params := statefulSetParameters{Replicas: ptr.To(int32(1)), ExternalConfig: ptr.To("redis-external-config")}
+	containerParams := containerParameters{Image: "redis:latest"}
+
+	err := CreateOrUpdateStateFul(context.TODO(), client, ns, meta, params, metav1.OwnerReference{Name: "test-sts", UID: "test-uid"}, initContainerParameters{}, containerParams, nil)
+	require.Error(t, err, "a transient checksum lookup error must be surfaced so the reconcile requeues")
+
+	// The StatefulSet is still applied (without the checksum, which will be stamped on retry).
+	sts, getErr := client.AppsV1().StatefulSets(ns).Get(context.TODO(), "test-sts", metav1.GetOptions{})
+	require.NoError(t, getErr)
+	_, ok := sts.Spec.Template.Annotations[externalConfigChecksumAnnotation]
+	assert.False(t, ok, "no checksum should be stamped when the source could not be read")
 }

--- a/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/chainsaw-test.yaml
@@ -1,0 +1,101 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: config-reload-redis-standalone
+# Verifies the fix for issue #960: editing the external/additional config ConfigMap
+# must roll the StatefulSet so pods pick up the new config. The standalone controller
+# has no periodic requeue, so a passing run also proves the ConfigMap watch fired.
+spec:
+  timeouts:
+    apply: 30s
+    assert: 5m
+    exec: 5m
+  steps:
+    - name: Deploy standalone with an external config ConfigMap
+      try:
+        - apply:
+            file: standalone.yaml
+        - assert:
+            file: ready-sts.yaml
+
+    - name: The external-config checksum annotation is stamped on the pod template
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              #!/bin/sh
+              set -eu
+              CK=$(kubectl get statefulset redis-standalone-config-reload -n "${NAMESPACE}" \
+                -o jsonpath='{.spec.template.metadata.annotations.redis\.opstreelabs\.in/external-config-checksum}')
+              echo "checksum=${CK}"
+              test -n "${CK}"
+            check:
+              ($error == null): true
+
+    - name: Editing the ConfigMap changes the checksum and rolls the StatefulSet
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              #!/bin/sh
+              set -eu
+              NS="${NAMESPACE}"
+              STS=redis-standalone-config-reload
+              ANN='{.spec.template.metadata.annotations.redis\.opstreelabs\.in/external-config-checksum}'
+
+              before=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath="$ANN")
+              echo "checksum before=$before"
+
+              kubectl patch configmap redis-external-config -n "$NS" --type merge \
+                -p '{"data":{"redis-additional.conf":"tcp-keepalive 500\nmaxmemory 256mb\n"}}'
+
+              # The controller must observe the ConfigMap change and re-stamp the
+              # pod template. Without the watch + checksum annotation this never happens.
+              after="$before"
+              for _ in $(seq 1 60); do
+                after=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath="$ANN")
+                if [ "$after" != "$before" ]; then
+                  echo "checksum after=$after"
+                  break
+                fi
+                sleep 5
+              done
+
+              if [ "$after" = "$before" ]; then
+                echo "ERROR: checksum annotation did not change after ConfigMap edit"
+                exit 1
+              fi
+
+              # The annotation change must produce an actual rolling update.
+              kubectl rollout status statefulset/"$STS" -n "$NS" --timeout=180s
+            check:
+              ($error == null): true
+
+    - name: Editing an unrelated ConfigMap does not roll the StatefulSet
+      try:
+        - script:
+            timeout: 90s
+            content: |
+              #!/bin/sh
+              set -eu
+              NS="${NAMESPACE}"
+              STS=redis-standalone-config-reload
+              ANN='{.spec.template.metadata.annotations.redis\.opstreelabs\.in/external-config-checksum}'
+
+              kubectl create configmap unrelated-config -n "$NS" --from-literal=foo=bar
+
+              before=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath="$ANN")
+              kubectl patch configmap unrelated-config -n "$NS" --type merge \
+                -p '{"data":{"foo":"baz"}}'
+              sleep 20
+              after=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath="$ANN")
+
+              if [ "$after" != "$before" ]; then
+                echo "ERROR: unrelated ConfigMap change altered the checksum annotation"
+                exit 1
+              fi
+              echo "checksum unchanged as expected: $after"
+            check:
+              ($error == null): true

--- a/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/ready-sts.yaml
+++ b/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/ready-sts.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-standalone-config-reload
+  labels:
+    app: redis-standalone-config-reload
+    redis_setup_type: standalone
+    role: standalone
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/config-reload/redis-standalone/standalone.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-external-config
+data:
+  redis-additional.conf: |
+    tcp-keepalive 400
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: redis-standalone-config-reload
+spec:
+  redisConfig:
+    additionalRedisConfig: redis-external-config
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  kubernetesConfig:
+    image: quay.io/opstree/redis:latest
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi


### PR DESCRIPTION

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

- Added ConfigMapWatcher and SecretWatcher to Reconciler structs for RedisReplication and RedisSentinel.
- Registered source watches for external config ConfigMaps and referenced Secrets to trigger rollouts on changes.
- Introduced WatchMany method in ResourceWatcher to handle multiple resource watches efficiently.
- Enhanced CreateOrUpdateStateFul function to compute and stamp checksums for referenced ConfigMaps and Secrets in StatefulSet annotations.
- Added tests for checksum computation and resource watching functionality.
- Created e2e tests to verify that changes to external ConfigMaps trigger StatefulSet rollouts as expected.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

Fixes https://github.com/OT-CONTAINER-KIT/redis-operator/issues/960

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.



