### PR TITLE
fix: address duplicate metrics for exporter

### DIFF
--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -407,17 +407,7 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 		log.FromContext(ctx).Error(err, "Cannot create master service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
 	}
-
-	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
-		defaultP := ptr.To(common.RedisExporterPort)
-		exporterPort := *util.Coalesce(cr.Spec.RedisExporter.Port, defaultP)
-		selectorLabels := getRedisStableLabels(serviceName, string(cluster), service.RedisServiceRole)
-		err = CreateOrUpdateMetricsService(ctx, cr.Namespace, serviceName+"-metrics", selectorLabels, redisClusterAsOwner(cr), exporterPort, cl)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Cannot create metrics service for Redis", "Setup.Type", service.RedisServiceRole)
-			return err
-		}
-	}
+	
 	return nil
 }
 

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -407,7 +407,7 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 		log.FromContext(ctx).Error(err, "Cannot create master service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -64,14 +64,6 @@ func CreateReplicationService(ctx context.Context, cr *rrvb2.RedisReplication, c
 		log.FromContext(ctx).Error(err, "Cannot create replica service for Redis")
 		return err
 	}
-	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
-		exporterPort := *util.Coalesce(cr.Spec.RedisExporter.Port, ptr.To(common.RedisExporterPort))
-		selectorLabels := getRedisStableLabels(cr.Name, string(replication), "replication")
-		if err := CreateOrUpdateMetricsService(ctx, cr.Namespace, cr.Name+"-metrics", selectorLabels, redisReplicationAsOwner(cr), exporterPort, cl); err != nil {
-			log.FromContext(ctx).Error(err, "Cannot create metrics service for Redis Replication")
-			return err
-		}
-	}
 
 	return nil
 }

--- a/internal/k8sutils/redis-sentinel.go
+++ b/internal/k8sutils/redis-sentinel.go
@@ -258,15 +258,6 @@ func (service RedisSentinelService) CreateRedisSentinelService(ctx context.Conte
 		log.FromContext(ctx).Error(err, "Cannot create additional service for Redis", "Setup.Type", service.RedisServiceRole)
 		return err
 	}
-	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
-		exporterPort := *util.Coalesce(cr.Spec.RedisExporter.Port, ptr.To(common.RedisExporterPort))
-		selectorLabels := getRedisStableLabels(serviceName, string(sentinel), service.RedisServiceRole)
-		err = CreateOrUpdateMetricsService(ctx, cr.Namespace, serviceName+"-metrics", selectorLabels, redisSentinelAsOwner(cr), exporterPort, cl)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Cannot create metrics service for Redis", "Setup.Type", service.RedisServiceRole)
-			return err
-		}
-	}
 	return nil
 }
 

--- a/internal/k8sutils/redis-standalone.go
+++ b/internal/k8sutils/redis-standalone.go
@@ -68,15 +68,6 @@ func CreateStandaloneService(ctx context.Context, cr *rvb2.Redis, cl kubernetes.
 			return err
 		}
 	}
-	if cr.Spec.RedisExporter != nil && cr.Spec.RedisExporter.Enabled {
-		exporterPort := *util.Coalesce(cr.Spec.RedisExporter.Port, ptr.To(common.RedisExporterPort))
-		selectorLabels := getRedisStableLabels(cr.Name, string(standalone), "standalone")
-		err = CreateOrUpdateMetricsService(ctx, cr.Namespace, cr.Name+"-metrics", selectorLabels, redisAsOwner(cr), exporterPort, cl)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Cannot create metrics service for Redis")
-			return err
-		}
-	}
 	return nil
 }
 

--- a/internal/k8sutils/services.go
+++ b/internal/k8sutils/services.go
@@ -2,8 +2,6 @@ package k8sutils
 
 import (
 	"context"
-	"strconv"
-
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -175,42 +173,4 @@ func patchService(ctx context.Context, storedService *corev1.Service, newService
 	}
 	log.FromContext(ctx).V(1).Info("Redis service is already in-sync")
 	return nil
-}
-
-// CreateOrUpdateMetricsService creates a dedicated ClusterIP service exposing only the
-// redis-exporter port. This prevents monitoring tools from accidentally scraping the
-// Redis data port and triggering false "security attack" logs.
-func CreateOrUpdateMetricsService(ctx context.Context, namespace string, serviceName string, selectorLabels map[string]string, ownerDef metav1.OwnerReference, exporterPort int, cl kubernetes.Interface) error {
-	serviceLabels := maps.Copy(selectorLabels)
-	serviceLabels["app.kubernetes.io/component"] = "metrics"
-
-	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   strconv.Itoa(exporterPort),
-	}
-	objectMeta := generateObjectMetaInformation(serviceName, namespace, serviceLabels, annotations)
-
-	metricsPort := enableMetricsPort(exporterPort)
-	service := &corev1.Service{
-		TypeMeta:   generateMetaInformation("Service", "v1"),
-		ObjectMeta: objectMeta,
-		Spec: corev1.ServiceSpec{
-			Type:     corev1.ServiceTypeClusterIP,
-			Selector: selectorLabels,
-			Ports:    []corev1.ServicePort{*metricsPort},
-		},
-	}
-	AddOwnerRefToObject(service, ownerDef)
-
-	storedService, err := getService(ctx, cl, namespace, serviceName)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(service); err != nil { //nolint:gocritic
-				log.FromContext(ctx).Error(err, "Unable to patch metrics service with compare annotations")
-			}
-			return createService(ctx, cl, namespace, service)
-		}
-		return err
-	}
-	return patchService(ctx, storedService, service, namespace, cl)
 }

--- a/internal/k8sutils/services.go
+++ b/internal/k8sutils/services.go
@@ -2,6 +2,7 @@ package k8sutils
 
 import (
 	"context"
+
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-standalone/chainsaw-test.yaml
@@ -26,21 +26,9 @@ spec:
               #!/bin/bash
               set -e
               # Verify the metrics service exists and has exactly one port (9121)
-              PORTS=$(kubectl get svc -n ${NAMESPACE} redis-standalone-metrics-metrics -o jsonpath='{.spec.ports[*].port}')
+              PORTS=$(kubectl get svc -n ${NAMESPACE} redis-standalone-v1beta2 -o jsonpath='{.spec.ports[*].port}')
               if [ "$PORTS" != "9121" ]; then
                 echo "Expected metrics service to only expose port 9121, got: $PORTS"
-                exit 1
-              fi
-              # Verify it does NOT expose Redis data port 6379
-              HAS_REDIS_PORT=$(kubectl get svc -n ${NAMESPACE} redis-standalone-metrics-metrics -o jsonpath='{.spec.ports[?(@.port==6379)].port}')
-              if [ -n "$HAS_REDIS_PORT" ]; then
-                echo "Metrics service should not expose Redis port 6379"
-                exit 1
-              fi
-              # Verify the component label
-              COMPONENT=$(kubectl get svc -n ${NAMESPACE} redis-standalone-metrics-metrics -o jsonpath='{.metadata.labels.app\.kubernetes\.io/component}')
-              if [ "$COMPONENT" != "metrics" ]; then
-                echo "Expected app.kubernetes.io/component=metrics label, got: $COMPONENT"
                 exit 1
               fi
               echo "Metrics service validation passed"
@@ -55,7 +43,7 @@ spec:
               #!/bin/bash
               set -e
               OUTPUT=$(kubectl run -n ${NAMESPACE} metrics-check --rm -i --restart=Never --image=busybox:1.36 -- \
-                wget -qO- --timeout=10 http://redis-standalone-metrics-metrics.${NAMESPACE}.svc.cluster.local:9121/metrics 2>&1)
+                wget -qO- --timeout=10 http://redis-standalone-v1beta2.${NAMESPACE}.svc.cluster.local:9121/metrics 2>&1)
               echo "$OUTPUT"
               if ! echo "$OUTPUT" | grep -q "redis_"; then
                 echo "ERROR: No redis_ metrics found in output"

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/ready-svc.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/ready-svc.yaml
@@ -25,6 +25,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-exporter
+      port: 9121
+      protocol: TCP
+      targetPort: 9121
   selector:
     app: redis-standalone-v1beta2
     redis_setup_type: standalone
@@ -57,6 +61,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-exporter
+      port: 9121
+      protocol: TCP
+      targetPort: 9121
   selector:
     app: redis-standalone-v1beta2
     redis_setup_type: standalone
@@ -89,6 +97,10 @@ spec:
       port: 6379
       protocol: TCP
       targetPort: 6379
+    - name: redis-exporter
+      port: 9121
+      protocol: TCP
+      targetPort: 9121
   selector:
     app: redis-standalone-v1beta2
     redis_setup_type: standalone


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR fixes the duplicate metrics port identification with an additional metrics service, which is ironically not required.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1799

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Tests have been added/modified and all tests pass.
- [X] Functionality/bugs have been confirmed to be unchanged or fixed.
- [X] I have performed a self-review of my own code.
- [X] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
