### PR TITLE
feat: add redisreplication events recorder for replication events

### DIFF
--- a/internal/cmd/manager/cmd.go
+++ b/internal/cmd/manager/cmd.go
@@ -264,6 +264,7 @@ func setupControllers(mgr ctrl.Manager, k8sClient kubernetes.Interface, maxConcu
 		Client:      mgr.GetClient(),
 		K8sClient:   k8sClient,
 		Healer:      healer,
+		Recorder:    mgr.GetEventRecorderFor("redisreplication-controller"),
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisReplication")

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	RedisReplicationRealMaster func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string
 	CreateRedisReplicationLink func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error
 	ConfigureSentinel          func(context.Context, *rrvb2.RedisReplication, string) error
+	Recorder                   record.EventRecorder
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -100,6 +102,7 @@ func (r *Reconciler) UpdateRedisReplicationMaster(ctx context.Context, instance 
 		logger.Info("Updating master node",
 			"previous", instance.Status.MasterNode,
 			"new", masterNode)
+		r.Recorder.Event(instance, corev1.EventTypeNormal, "MasterNodeUpdated", fmt.Sprintf("Master node updated from %s to %s", instance.Status.MasterNode, masterNode))
 	}
 	return r.updateStatus(ctx, instance, rrvb2.RedisReplicationStatus{
 		MasterNode:     masterNode,
@@ -383,6 +386,8 @@ func (r *Reconciler) sentinelResetIfNeed(ctx context.Context, inst *rrvb2.RedisR
 		if err := redisService.SentinelReset(ctx, masterGroupName); err != nil {
 			return fmt.Errorf("reset sentinel: %w", err)
 		}
+		logger.Info("Sentinel reset completed")
+		r.Recorder.Event(inst, corev1.EventTypeNormal, "SentinelReset", "Triggered Sentinel reset due to slave/sentinel count mismatch")
 	}
 
 	return nil
@@ -429,6 +434,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 				log.FromContext(ctx).Info("No master with attached slaves found, falling back to Status.MasterNode",
 					"statusMasterNode", instance.Status.MasterNode)
 				realMaster = instance.Status.MasterNode
+				r.Recorder.Event(instance, corev1.EventTypeNormal, "MasterElected from: Status.MasterNode", fmt.Sprintf("Elected master: %s", realMaster))
 			}
 
 			// Elect a new master based on redis offset. This is a best-effort attempt to pick the most up-to-date master.
@@ -438,6 +444,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 					log.FromContext(ctx).Info("No master with attached slaves found, falling back to best master based on Redis offset",
 						"bestMaster", bestMaster)
 					realMaster = bestMaster
+					r.Recorder.Event(instance, corev1.EventTypeNormal, "MasterElected from: offset", fmt.Sprintf("Elected master: %s", realMaster))
 				}
 			}
 
@@ -449,14 +456,17 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 				log.FromContext(ctx).Info("No real master found via slave count or Status.MasterNode; "+
 					"electing first master node as bootstrap master", "podName", masterNodes[0])
 				realMaster = masterNodes[0]
+				r.Recorder.Event(instance, corev1.EventTypeNormal, "MasterElected from: bootstrap", fmt.Sprintf("Elected master: %s", realMaster))
 			}
 		}
 		if incompleteTopology {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the observed topology is incomplete",
 				"observedPods", observedPods,
 				"expectedPods", *instance.Spec.Size)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "IncompleteTopology", fmt.Sprintf("Observed topology is incomplete: %d/%d pods observed", observedPods, *instance.Spec.Size))
 		} else if realMaster == "" {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the current master could not be identified")
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "MasterNotFound", "Could not identify a real master to configure replication")
 		} else if err := r.createRedisReplicationLink(ctx, instance, masterNodes, realMaster); err != nil {
 			return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
 		}

--- a/internal/controller/redisreplication/redisreplication_controller_suite_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_suite_test.go
@@ -100,6 +100,7 @@ var _ = BeforeSuite(func() {
 	err = (&Reconciler{
 		Client:      k8sManager.GetClient(),
 		K8sClient:   k8sClient,
+		Recorder:    k8sManager.GetEventRecorderFor("redisreplication-controller"),
 		Healer:      healer,
 		StatefulSet: k8sutils.NewStatefulSetService(k8sClient),
 	}).SetupWithManager(k8sManager, controller.Options{})

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +24,7 @@ func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testin
 	createCalled := false
 	r := &Reconciler{
 		K8sClient: fake.NewSimpleClientset(),
+		Recorder:  record.NewFakeRecorder(10),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
 				return []string{"example-replication-0"}, nil
@@ -48,6 +50,7 @@ func TestReconcileRedisSkipsReplicationChangesWhenMultipleMastersAreObservedButT
 	createCalled := false
 	r := &Reconciler{
 		K8sClient: fake.NewSimpleClientset(),
+		Recorder:  record.NewFakeRecorder(10),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
 				return []string{"example-replication-0", "example-replication-1"}, nil
@@ -76,6 +79,7 @@ func TestReconcileRedisKeepsHealthyBehaviorWhenTopologyIsComplete(t *testing.T) 
 	var gotMaster string
 	r := &Reconciler{
 		K8sClient: fake.NewSimpleClientset(),
+		Recorder:  record.NewFakeRecorder(10),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
 				return []string{"example-replication-0", "example-replication-1"}, nil
@@ -119,6 +123,7 @@ func TestReconcileStatusStillRunsWhenOnePodIsUnobserved(t *testing.T) {
 	r := &Reconciler{
 		Client:    ctrlClient,
 		K8sClient: fake.NewSimpleClientset(),
+		Recorder:  record.NewFakeRecorder(10),
 		Healer:    healer,
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
@@ -148,6 +153,7 @@ func TestReconcileRedisSkipsSentinelReconfigurationWhenTopologyIsIncompleteAndMa
 	r := &Reconciler{
 		StatefulSet: &fakeStatefulSetService{},
 		K8sClient:   fake.NewSimpleClientset(),
+		Recorder:    record.NewFakeRecorder(10),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
 				return []string{"example-replication-0", "example-replication-1"}, nil
@@ -181,6 +187,7 @@ func TestReconcileRedisConfiguresSentinelForSingleObservedMaster(t *testing.T) {
 	r := &Reconciler{
 		StatefulSet: &fakeStatefulSetService{},
 		K8sClient:   fake.NewSimpleClientset(),
+		Recorder:    record.NewFakeRecorder(10),
 		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
 			if role == "master" {
 				return []string{"example-replication-1"}, nil


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Add redisreplication events recorder for replication events

I found this very helpful and very informative on what's going on 

```
k describe redisreplication -A | egrep -A10 Event
Events:  <none>


Name:         redis-cache-shared-replication
Namespace:    redis-clusters-dev
Labels:       <none>
Annotations:  <none>
API Version:  redis.redis.opstreelabs.in/v1beta2
Kind:         RedisReplication
Metadata:
  Creation Timestamp:  2024-04-05T10:12:18Z
--
Events:         <none>


Name:         redis-replication
Namespace:    redis-clusters-dev
Labels:       <none>
Annotations:  <none>
API Version:  redis.redis.opstreelabs.in/v1beta2
Kind:         RedisReplication
Metadata:
  Creation Timestamp:  2024-02-23T05:04:41Z
--
Events:
  Type    Reason                                 Age    From                         Message
  ----    ------                                 ----   ----                         -------
  Normal  MasterElected from: Status.MasterNode  5m58s  redisreplication-controller  Elected master: redis-replication-2


Name:         redis-replication-ap-earn
Namespace:    redis-clusters-dev
Labels:       app.kubernetes.io/owner=partnership-investment
              app.kubernetes.io/redis-version=7.0.5
Annotations:  <none>
--
Events:
  Type    Reason                                 Age    From                         Message
  ----    ------                                 ----   ----                         -------
  Normal  MasterElected from: Status.MasterNode  7m17s  redisreplication-controller  Elected master: redis-replication-ap-earn-0


Name:         redis-replication-billing-repayment-engine
Namespace:    redis-clusters-dev
Labels:       app.kubernetes.io/owner=lending-platform
              app.kubernetes.io/redis-version=7.0.5
Annotations:  <none>
--
Events:         <none>


Name:         redis-replication-core-order
Namespace:    redis-clusters-dev
Labels:       app.kubernetes.io/owner=partnership-investment
              app.kubernetes.io/redis-version=7.0.5
Annotations:  <none>
API Version:  redis.redis.opstreelabs.in/v1beta2
Kind:         RedisReplication
Metadata:
--
Events:
  Type     Reason             Age                 From                         Message
  ----     ------             ----                ----                         -------
  Normal   MasterNodeUpdated  5m55s               redisreplication-controller  Master node updated from redis-replication-core-order-1 to
  Warning  MasterNotFound     40s (x8 over 6m1s)  redisreplication-controller  Could not identify a real master to configure replication


Name:         redis-replication-krakend
Namespace:    redis-clusters-dev
Labels:       app.kubernetes.io/owner=core-platform
              app.kubernetes.io/redis-version=7.0.5
--
Events:
  Type    Reason                                 Age    From                         Message
  ----    ------                                 ----   ----                         -------
  Normal  MasterElected from: Status.MasterNode  7m24s  redisreplication-controller  Elected master: redis-replication-krakend-0
```
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
