### PR TITLE
fix(chart): webhook cert SAN must use .Release.Namespace, not .Values.service.namespace

### DIFF
--- a/charts/redis-operator/templates/cert-manager.yaml
+++ b/charts/redis-operator/templates/cert-manager.yaml
@@ -31,8 +31,8 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
 spec:
   dnsNames:
-    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc
-    - {{ .Values.service.name }}.{{ .Values.service.namespace }}.svc.{{ .Values.redisOperator.serviceDNSDomain | default "cluster.local" }}
+    - {{ .Values.service.name }}.{{ .Release.Namespace }}.svc
+    - {{ .Values.service.name }}.{{ .Release.Namespace }}.svc.{{ .Values.redisOperator.serviceDNSDomain | default "cluster.local" }}
   issuerRef:
     kind: {{ .Values.issuer.kind }}
     name: {{ .Values.issuer.name }}


### PR DESCRIPTION
**Description**

The `redis-operator` chart builds the cert-manager `Certificate` `dnsNames` from `.Values.service.namespace` (default `redis-operator`), but the webhook `Service` and the `MutatingWebhookConfiguration` `clientConfig` both use `.Release.Namespace`:

| Template | Namespace source | Resolves to (release ns = `ot-operators`) |
|---|---|---|
| `templates/cert-manager.yaml` (Certificate SAN) | `.Values.service.namespace` | `webhook-service.redis-operator.svc` |
| `templates/service.yaml` (Service) | `.Release.Namespace` | `webhook-service.ot-operators.svc` |
| `templates/mutating-webhook-configuration.yaml` (clientConfig) | `.Release.Namespace` | `webhook-service.ot-operators.svc` |

When the chart is installed into **any namespace other than the `service.namespace` default**, the Certificate SAN no longer matches the DNS name the API server actually dials, so the webhook TLS handshake fails the SAN check. Because the mutating webhook is `failurePolicy: Fail`, this is **silent at install time** and only surfaces as a `503` (`x509`/SAN error) on the **first Redis CR admission**.

This PR pins the SAN to `.Release.Namespace` so it always matches the Service the webhook is reached at.

**Reproduction**

\`\`\`console
$ helm template redis-operator charts/redis-operator -n ot-operators \
    --set redisOperator.webhook=true --set certmanager.enabled=true
\`\`\`

Before — Certificate SAN vs. webhook Service disagree:
\`\`\`yaml
# Certificate
dnsNames:
  - webhook-service.redis-operator.svc       # .Values.service.namespace
# MutatingWebhookConfiguration -> clientConfig.service
  name: webhook-service
  namespace: ot-operators                    # .Release.Namespace
\`\`\`

After this change — they match:
\`\`\`yaml
dnsNames:
  - webhook-service.ot-operators.svc
  - webhook-service.ot-operators.svc.cluster.local
\`\`\`

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Functionality/bugs have been confirmed to be unchanged or fixed (verified via `helm template` into a non-default namespace).
- [x] I have performed a self-review of my own code.
- [ ] Tests have been added/modified and all tests pass. *(chart template change; no unit tests exist for the cert template — happy to add a `helm unittest` case if the maintainers want one.)*
- [ ] Documentation updated where necessary.

**Additional Context**

After this change `.Values.service.namespace` is no longer referenced by any template. I left the value in place to keep this a minimal, non-breaking fix — glad to remove it (and the README row) in a follow-up if you'd prefer.