### PR TITLE
fix: multiple replicas per shard in RedisCluster

### DIFF
--- a/api/common/v1beta2/common_types.go
+++ b/api/common/v1beta2/common_types.go
@@ -217,8 +217,14 @@ type RedisLeader struct {
 // RedisFollower interface will have the redis follower configuration
 // +k8s:deepcopy-gen=true
 type RedisFollower struct {
-	// Replicas overrides clusterSize for follower nodes count. If not set, uses clusterSize value
-	Replicas                  *int32                            `json:"replicas,omitempty"`
+	// Replicas overrides clusterSize for follower nodes count. If not set, uses clusterSize value.
+	// Mutually exclusive with ReplicasPerShard.
+	Replicas *int32 `json:"replicas,omitempty"`
+	// ReplicasPerShard sets the number of follower replicas per leader shard.
+	// Total follower pods = ReplicasPerShard × leader count.
+	// Mutually exclusive with Replicas.
+	// +kubebuilder:validation:Minimum=1
+	ReplicasPerShard          *int32                            `json:"replicasPerShard,omitempty"`
 	RedisConfig               *RedisConfig                      `json:"redisConfig,omitempty"`
 	Affinity                  *corev1.Affinity                  `json:"affinity,omitempty"`
 	PodDisruptionBudget       *RedisPodDisruptionBudget         `json:"pdb,omitempty"`

--- a/api/common/v1beta2/zz_generated.deepcopy.go
+++ b/api/common/v1beta2/zz_generated.deepcopy.go
@@ -289,6 +289,11 @@ func (in *RedisFollower) DeepCopyInto(out *RedisFollower) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ReplicasPerShard != nil {
+		in, out := &in.ReplicasPerShard, &out.ReplicasPerShard
+		*out = new(int32)
+		**out = **in
+	}
 	if in.RedisConfig != nil {
 		in, out := &in.RedisConfig, &out.RedisConfig
 		*out = new(RedisConfig)

--- a/api/rediscluster/v1beta2/rediscluster_types.go
+++ b/api/rediscluster/v1beta2/rediscluster_types.go
@@ -68,13 +68,20 @@ type ClusterStorage struct {
 }
 
 func (cr *RedisClusterSpec) GetReplicaCounts(t string) int32 {
-	replica := cr.ClusterSize
-	if t == "leader" && cr.RedisLeader.Replicas != nil {
-		replica = cr.RedisLeader.Replicas
-	} else if t == "follower" && cr.RedisFollower.Replicas != nil {
-		replica = cr.RedisFollower.Replicas
+	if t == "leader" {
+		if cr.RedisLeader.Replicas != nil {
+			return *cr.RedisLeader.Replicas
+		}
+		return *cr.ClusterSize
 	}
-	return *replica
+	// follower
+	if cr.RedisFollower.Replicas != nil {
+		return *cr.RedisFollower.Replicas
+	}
+	if cr.RedisFollower.ReplicasPerShard != nil {
+		return *cr.RedisFollower.ReplicasPerShard * cr.GetReplicaCounts("leader")
+	}
+	return *cr.ClusterSize
 }
 
 // GetRedisLeaderResources returns the resources for the redis leader, if not set, it will return the default resources

--- a/api/rediscluster/v1beta2/rediscluster_types_test.go
+++ b/api/rediscluster/v1beta2/rediscluster_types_test.go
@@ -1,0 +1,101 @@
+package v1beta2_test
+
+import (
+	"testing"
+
+	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
+	v1beta2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetReplicaCounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     v1beta2.RedisClusterSpec
+		role     string
+		expected int32
+	}{
+		{
+			name: "leader uses clusterSize when no override",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+			},
+			role:     "leader",
+			expected: 3,
+		},
+		{
+			name: "leader uses RedisLeader.Replicas override",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+				RedisLeader: v1beta2.RedisLeader{
+					RedisLeader: common.RedisLeader{Replicas: ptr.To(int32(5))},
+				},
+			},
+			role:     "leader",
+			expected: 5,
+		},
+		{
+			name: "follower uses clusterSize when no override",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+			},
+			role:     "follower",
+			expected: 3,
+		},
+		{
+			name: "follower uses Replicas override (total pods)",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+				RedisFollower: v1beta2.RedisFollower{
+					RedisFollower: common.RedisFollower{Replicas: ptr.To(int32(9))},
+				},
+			},
+			role:     "follower",
+			expected: 9,
+		},
+		{
+			name: "follower uses ReplicasPerShard * clusterSize",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+				RedisFollower: v1beta2.RedisFollower{
+					RedisFollower: common.RedisFollower{ReplicasPerShard: ptr.To(int32(3))},
+				},
+			},
+			role:     "follower",
+			expected: 9,
+		},
+		{
+			name: "follower ReplicasPerShard respects leader Replicas override",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+				RedisLeader: v1beta2.RedisLeader{
+					RedisLeader: common.RedisLeader{Replicas: ptr.To(int32(4))},
+				},
+				RedisFollower: v1beta2.RedisFollower{
+					RedisFollower: common.RedisFollower{ReplicasPerShard: ptr.To(int32(2))},
+				},
+			},
+			role:     "follower",
+			expected: 8,
+		},
+		{
+			name: "follower ReplicasPerShard=1 gives 1x leaders",
+			spec: v1beta2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(3)),
+				RedisFollower: v1beta2.RedisFollower{
+					RedisFollower: common.RedisFollower{ReplicasPerShard: ptr.To(int32(1))},
+				},
+			},
+			role:     "follower",
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.GetReplicaCounts(tt.role)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/api/rediscluster/v1beta2/rediscluster_webhook.go
+++ b/api/rediscluster/v1beta2/rediscluster_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta2
 
 import (
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -91,6 +93,32 @@ func (r *RedisCluster) validate(_ *RedisCluster) (admission.Warnings, error) {
 				field.NewPath("spec").Child("acl"),
 				r.Spec.ACL,
 				err.Error(),
+			))
+		}
+	}
+
+	// redisFollower.replicas and replicasPerShard are mutually exclusive
+	if r.Spec.RedisFollower.Replicas != nil && r.Spec.RedisFollower.ReplicasPerShard != nil {
+		errors = append(errors, field.Invalid(
+			field.NewPath("spec").Child("redisFollower"),
+			r.Spec.RedisFollower,
+			"replicas and replicasPerShard are mutually exclusive; set only one",
+		))
+	}
+	if r.Spec.RedisFollower.ReplicasPerShard != nil && *r.Spec.RedisFollower.ReplicasPerShard < 1 {
+		errors = append(errors, field.Invalid(
+			field.NewPath("spec").Child("redisFollower").Child("replicasPerShard"),
+			*r.Spec.RedisFollower.ReplicasPerShard,
+			"replicasPerShard must be at least 1",
+		))
+	}
+	if r.Spec.RedisFollower.Replicas != nil && r.Spec.ClusterSize != nil {
+		leaderCount := r.Spec.GetReplicaCounts("leader")
+		if leaderCount > 0 && *r.Spec.RedisFollower.Replicas%leaderCount != 0 {
+			errors = append(errors, field.Invalid(
+				field.NewPath("spec").Child("redisFollower").Child("replicas"),
+				*r.Spec.RedisFollower.Replicas,
+				fmt.Sprintf("replicas (%d) must be divisible by leader count (%d); use replicasPerShard for per-shard control", *r.Spec.RedisFollower.Replicas, leaderCount),
 			))
 		}
 	}

--- a/charts/redis-operator/crds/crds.yaml
+++ b/charts/redis-operator/crds/crds.yaml
@@ -8115,9 +8115,18 @@ spec:
                         type: integer
                     type: object
                   replicas:
-                    description: Replicas overrides clusterSize for follower nodes
-                      count. If not set, uses clusterSize value
+                    description: |-
+                      Replicas overrides clusterSize for follower nodes count. If not set, uses clusterSize value.
+                      Mutually exclusive with ReplicasPerShard.
                     format: int32
+                    type: integer
+                  replicasPerShard:
+                    description: |-
+                      ReplicasPerShard sets the number of follower replicas per leader shard.
+                      Total follower pods = ReplicasPerShard × leader count.
+                      Mutually exclusive with Replicas.
+                    format: int32
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -2716,9 +2716,18 @@ spec:
                         type: integer
                     type: object
                   replicas:
-                    description: Replicas overrides clusterSize for follower nodes
-                      count. If not set, uses clusterSize value
+                    description: |-
+                      Replicas overrides clusterSize for follower nodes count. If not set, uses clusterSize value.
+                      Mutually exclusive with ReplicasPerShard.
                     format: int32
+                    type: integer
+                  replicasPerShard:
+                    description: |-
+                      ReplicasPerShard sets the number of follower replicas per leader shard.
+                      Total follower pods = ReplicasPerShard × leader count.
+                      Mutually exclusive with Replicas.
+                    format: int32
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource

--- a/internal/k8sutils/cluster-scaling.go
+++ b/internal/k8sutils/cluster-scaling.go
@@ -397,7 +397,7 @@ func RebalanceRedisClusterEmptyMasters(ctx context.Context, client kubernetes.In
 }
 
 func CheckIfEmptyMasters(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) {
-	totalRedisLeaderNodes := CheckRedisNodeCount(ctx, client, cr, "leader")
+	totalRedisLeaderNodes := cr.Spec.GetReplicaCounts("leader")
 	redisClient := configureRedisClient(ctx, client, cr, cr.Name+"-leader-0")
 	defer redisClient.Close()
 

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -397,11 +397,12 @@ func getRedisTLSArgs(tlsConfig *commonapi.TLSConfig, clientHost string) []string
 }
 
 // createRedisReplicationCommand will create redis replication creation command
-func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, leaderPod RedisDetails, followerPod RedisDetails) []string {
+func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, leaderPod RedisDetails, followerPod RedisDetails, masterNodeID string) []string {
 	cmd := []string{"redis-cli", "--cluster", "add-node"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, followerPod))
 	cmd = append(cmd, getEndpoint(ctx, client, cr, leaderPod))
 	cmd = append(cmd, "--cluster-slave")
+	cmd = append(cmd, "--cluster-master-id", masterNodeID)
 	if cr.Spec.KubernetesConfig.ExistingPasswordSecret != nil {
 		pass, err := getRedisPassword(ctx, client, cr.Namespace, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Name, *cr.Spec.KubernetesConfig.ExistingPasswordSecret.Key)
 		if err != nil {
@@ -428,20 +429,34 @@ func ExecuteRedisReplicationCommand(ctx context.Context, client kubernetes.Inter
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to get cluster nodes")
 	}
+
+	leaderNodeIDs := make(map[int]string, int(leaderCounts))
+
 	for followerIdx := 0; followerIdx <= int(followerCounts)-1; {
 		for i := 0; i < int(followerPerLeader) && followerIdx <= int(followerCounts)-1; i++ {
 			followerPod := RedisDetails{
 				PodName:   cr.Name + "-follower-" + strconv.Itoa(followerIdx),
 				Namespace: cr.Namespace,
 			}
+			leaderIdx := followerIdx % int(leaderCounts)
 			leaderPod := RedisDetails{
-				PodName:   cr.Name + "-leader-" + strconv.Itoa((followerIdx)%int(leaderCounts)),
+				PodName:   cr.Name + "-leader-" + strconv.Itoa(leaderIdx),
 				Namespace: cr.Namespace,
 			}
 			podIP = getRedisServerIP(ctx, client, followerPod)
 			if !checkRedisNodePresence(ctx, nodes, podIP) {
+				if _, ok := leaderNodeIDs[leaderIdx]; !ok {
+					leaderNodeIDs[leaderIdx] = getRedisNodeID(ctx, client, cr, leaderPod)
+				}
+				masterNodeID := leaderNodeIDs[leaderIdx]
+				if masterNodeID == "" {
+					log.FromContext(ctx).Error(fmt.Errorf("empty node ID"), "Skipping follower, cannot resolve leader node ID",
+						"Follower", followerPod.PodName, "Leader", leaderPod.PodName)
+					followerIdx++
+					continue
+				}
 				log.FromContext(ctx).V(1).Info("Adding node to cluster.", "Node.IP", podIP, "Follower.Pod", followerPod)
-				cmd := createRedisReplicationCommand(ctx, client, cr, leaderPod, followerPod)
+				cmd := createRedisReplicationCommand(ctx, client, cr, leaderPod, followerPod, masterNodeID)
 				redisClient := configureRedisClient(ctx, client, cr, followerPod.PodName)
 				pong, err := redisClient.Ping(ctx).Result()
 				redisClient.Close()

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -668,6 +668,7 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 		secret
 		leaderPod       RedisDetails
 		followerPod     RedisDetails
+		masterNodeID    string
 		expectedCommand []string
 	}{
 		{
@@ -702,11 +703,13 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 				PodName:   "redis-cluster-follower-0",
 				Namespace: "default",
 			},
+			masterNodeID: "test-leader-node-id",
 			expectedCommand: []string{
 				"redis-cli", "--cluster", "add-node",
 				"redis-cluster-follower-0.redis-cluster-follower-headless.default.svc.cluster.local:6379",
 				"redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local:6379",
 				"--cluster-slave",
+				"--cluster-master-id", "test-leader-node-id",
 				"-a", "password",
 			},
 		},
@@ -742,11 +745,13 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 				PodName:   "redis-cluster-follower-0",
 				Namespace: "default",
 			},
+			masterNodeID: "test-leader-node-id",
 			expectedCommand: []string{
 				"redis-cli", "--cluster", "add-node",
 				"redis-cluster-follower-0.redis-cluster-follower-headless.default.svc.cluster.local:6379",
 				"redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local:6379",
 				"--cluster-slave",
+				"--cluster-master-id", "test-leader-node-id",
 			},
 		},
 		{
@@ -769,11 +774,13 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 				PodName:   "redis-cluster-follower-0",
 				Namespace: "default",
 			},
+			masterNodeID: "test-leader-node-id",
 			expectedCommand: []string{
 				"redis-cli", "--cluster", "add-node",
 				"192.168.2.1:6379",
 				"192.168.1.1:6379",
 				"--cluster-slave",
+				"--cluster-master-id", "test-leader-node-id",
 			},
 		},
 		{
@@ -796,11 +803,13 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 				PodName:   "redis-cluster-follower-0",
 				Namespace: "default",
 			},
+			masterNodeID: "test-leader-node-id",
 			expectedCommand: []string{
 				"redis-cli", "--cluster", "add-node",
 				"2001:db8:42:2::200:6379",
 				"2001:db8:42:1::100:6379",
 				"--cluster-slave",
+				"--cluster-master-id", "test-leader-node-id",
 			},
 		},
 	}
@@ -823,7 +832,7 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 			objects = append(objects, secret...)
 
 			client := k8sClientFake.NewSimpleClientset(objects...)
-			cmd := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod)
+			cmd := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod, tt.masterNodeID)
 
 			// Assert the command is as expected using testify
 			assert.Equal(t, tt.expectedCommand, cmd)


### PR DESCRIPTION
**Description**

Fixes two bugs that prevent multiple followers per shard in RedisCluster, and adds a \`replicasPerShard\` API field for intuitive per-shard replica control.

**Bug 1 — followers join as empty masters (root cause)**

\`redis-cli --cluster add-node --cluster-slave\` without \`--cluster-master-id\` uses a "fewest replicas" heuristic. Works for round 1 (all masters at 0 replicas) but fails for round 2+ — Redis assigns new nodes as masters instead of slaves.

Fix: fetch each leader's cluster node ID via \`CLUSTER MYID\` and pass \`--cluster-master-id\` explicitly. Leader IDs are cached per-shard to avoid redundant Redis calls.

**Bug 2 — operator error loop after bug 1**

\`CheckIfEmptyMasters\` used \`CheckRedisNodeCount\` (live Redis master count) as its loop bound. When followers incorrectly became masters, this count inflated (e.g. 9 instead of 3), causing iteration over non-existent pods (\`leader-3\`..\`leader-8\`) → operator error-looped every 4 minutes.

Fix: use \`cr.Spec.GetReplicaCounts(\"leader\")\` (desired spec count) instead of live cluster count.

**New field: \`replicasPerShard\`**

\`spec.redisFollower.replicas: 9\` for 3 shards is ambiguous — uneven follower distribution is possible and not caught at admission. The new field expresses per-shard intent directly:

\`\`\`yaml
spec:
  clusterSize: 3
  redisFollower:
    replicasPerShard: 3   # 3 replicas per master → 9 follower pods total
\`\`\`

Mirrors ElastiCache \`NumReplicasPerNodeGroup\` semantics. Webhook validation enforces mutual exclusivity with \`replicas\`, minimum value of 1, and divisibility of \`replicas\` by leader count.

Fixes #1837

**Type of change**

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Validated on k3d (3-node cluster) with \`clusterSize:3\` + \`replicasPerShard:3\`:
- Correct topology: 3 masters × 3 replicas = 9 followers, 0 spurious masters
- leader-0 (slots 0–5460) → follower-0, follower-3, follower-6
- leader-1 (slots 5461–10922) → follower-1, follower-4, follower-7
- leader-2 (slots 10923–16383) → follower-2, follower-5, follower-8

Without the fix, same config produces 9 masters + 3 slaves (confirmed on production cluster).

All 382 unit tests pass. CRDs regenerated via \`make manifests\` and \`make sync-crds\`.