### PR TITLE
feat(chart): support helm templating in secret and service account names in redis-cluster

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.26.0
+version: 0.17.6
 appVersion: "0.26.0"
 home: https://github.com/ot-container-kit/redis-operator
 sources:

--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.17.5
-appVersion: "0.17.5"
+version: 0.26.0
+appVersion: "0.26.0"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -22,14 +22,14 @@ spec:
     redisConfig:
       additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
     {{- end }}
-  
+
   redisFollower: {{-  include "redis.role" .Values.redisCluster.follower | nindent 4 }}
     replicas: {{ .Values.redisCluster.follower.replicas | default .Values.redisCluster.clusterSize }}
     {{- if .Values.externalConfig.enabled }}
     redisConfig:
       additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
     {{- end }}
-  
+
   {{- if or (and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0)) (.Values.redisCluster.dynamicConfig) }}
   redisConfig:
     {{- if and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0) }}
@@ -53,7 +53,7 @@ spec:
     {{- if .Values.redisExporter.securityContext}}
     securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
     {{- end }}
-    
+
   kubernetesConfig:
     image: "{{ .Values.redisCluster.image }}:{{ .Values.redisCluster.tag }}"
     imagePullPolicy: "{{ .Values.redisCluster.imagePullPolicy }}"
@@ -69,8 +69,8 @@ spec:
     {{- end }}
     {{- if and .Values.redisCluster.redisSecret.secretName .Values.redisCluster.redisSecret.secretKey }}
     redisSecret:
-      name: {{ .Values.redisCluster.redisSecret.secretName | quote }}
-      key: {{ .Values.redisCluster.redisSecret.secretKey | quote }}
+      name: {{ tpl .Values.redisCluster.redisSecret.secretName $ | quote }}
+      key: {{ tpl .Values.redisCluster.redisSecret.secretKey $ | quote }}
     {{- end }}
     {{- if .Values.redisCluster.minReadySeconds }}
     minReadySeconds: {{ .Values.redisCluster.minReadySeconds}}
@@ -94,13 +94,13 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      secretName: {{ .Values.TLS.secret.secretName | quote }}
+      secretName: {{ tpl .Values.TLS.secret.secretName $ | quote }}
   {{- end }}
   {{- if or (and .Values.acl.secret (ne .Values.acl.secret.secretName "")) .Values.acl.persistentVolumeClaim }}
   acl:
     {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
     secret:
-      secretName: {{ .Values.acl.secret.secretName | quote }}
+      secretName: {{ tpl .Values.acl.secret.secretName $ | quote }}
     {{- end }}
     {{- if .Values.acl.persistentVolumeClaim }}
     persistentVolumeClaim: {{ .Values.acl.persistentVolumeClaim | quote }}
@@ -116,7 +116,7 @@ spec:
   env: {{ toYaml .Values.env | nindent 4 }}
   {{- end }}
   {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
-  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  serviceAccountName: "{{ tpl .Values.serviceAccountName $ }}"
   {{- end }}
   {{- if and .Values.podManagementPolicy (ne .Values.podManagementPolicy "") }}
   podManagementPolicy: "{{ .Values.podManagementPolicy }}"

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -22,14 +22,14 @@ spec:
     redisConfig:
       additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
     {{- end }}
-  
+
   redisFollower: {{-  include "redis.role" .Values.redisCluster.follower | nindent 4 }}
     replicas: {{ .Values.redisCluster.follower.replicas | default .Values.redisCluster.clusterSize }}
     {{- if .Values.externalConfig.enabled }}
     redisConfig:
       additionalRedisConfig: "{{ .Values.redisCluster.name | default .Release.Name }}-ext-config"
     {{- end }}
-  
+
   {{- if or (and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0)) (.Values.redisCluster.dynamicConfig) }}
   redisConfig:
     {{- if and .Values.redisCluster.maxMemoryPercentOfLimit (gt (int .Values.redisCluster.maxMemoryPercentOfLimit) 0) }}
@@ -53,7 +53,7 @@ spec:
     {{- if .Values.redisExporter.securityContext}}
     securityContext: {{ toYaml .Values.redisExporter.securityContext | nindent 6 }}
     {{- end }}
-    
+
   kubernetesConfig:
     image: "{{ .Values.redisCluster.image }}:{{ .Values.redisCluster.tag }}"
     imagePullPolicy: "{{ .Values.redisCluster.imagePullPolicy }}"
@@ -69,8 +69,8 @@ spec:
     {{- end }}
     {{- if and .Values.redisCluster.redisSecret.secretName .Values.redisCluster.redisSecret.secretKey }}
     redisSecret:
-      name: {{ .Values.redisCluster.redisSecret.secretName | quote }}
-      key: {{ .Values.redisCluster.redisSecret.secretKey | quote }}
+      name: {{ tpl .Values.redisCluster.redisSecret.secretName $ | quote }}
+      key: {{ tpl .Values.redisCluster.redisSecret.secretKey $ | quote }}
     {{- end }}
     {{- if .Values.redisCluster.minReadySeconds }}
     minReadySeconds: {{ .Values.redisCluster.minReadySeconds}}
@@ -94,13 +94,13 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      {{- toYaml .Values.TLS.secret | nindent 6 }}
+      {{- tpl (toYaml .Values.TLS.secret) $ | nindent 6 }}
   {{- end }}
   {{- if or (and .Values.acl.secret (ne .Values.acl.secret.secretName "")) .Values.acl.persistentVolumeClaim }}
   acl:
     {{- if and .Values.acl.secret (ne .Values.acl.secret.secretName "") }}
     secret:
-      secretName: {{ .Values.acl.secret.secretName | quote }}
+      secretName: {{ tpl .Values.acl.secret.secretName $ | quote }}
     {{- end }}
     {{- if .Values.acl.persistentVolumeClaim }}
     persistentVolumeClaim: {{ .Values.acl.persistentVolumeClaim | quote }}
@@ -116,7 +116,7 @@ spec:
   env: {{ toYaml .Values.env | nindent 4 }}
   {{- end }}
   {{- if and .Values.serviceAccountName (ne .Values.serviceAccountName "") }}
-  serviceAccountName: "{{ .Values.serviceAccountName }}"
+  serviceAccountName: "{{ tpl .Values.serviceAccountName $ }}"
   {{- end }}
   {{- if and .Values.podManagementPolicy (ne .Values.podManagementPolicy "") }}
   podManagementPolicy: "{{ .Values.podManagementPolicy }}"


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This change wraps the `secretName` and `serviceAccountName` values in the `tpl` function within the RedisCluster CRD template.

Previously, these fields only accepted literal strings. By passing them through `tpl`, users can now define dynamic names in their `values.yaml` utilizing standard Helm context variables (e.g., `{{ .Release.Name }}-redis-auth`). 

This is especially useful for deployments relying on dynamic release naming or automated CI/CD pipelines.

Fields updated to support templating:
- `kubernetesConfig.redisSecret.name`
- `kubernetesConfig.redisSecret.key`
- `TLS.secret`
- `acl.secret.secretName`
- `serviceAccountName`

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->
