### PR TITLE
fix: skip unreachable RedisReplication pods during role discovery

### DIFF
--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -78,6 +78,16 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 		isMaster, err := h.redis.Connect(connInfo).IsMaster(ctx)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed to check redis role, skipping pod", "pod", pod.Name)
+			if oldRole := pod.Labels[common.RedisRoleLabelKey]; oldRole != "" {
+				patch := []byte(fmt.Sprintf(`[{"op": "remove", "path": "/metadata/labels/%s"}]`, common.RedisRoleLabelKey))
+				if rErr := retry.RetryOnConflict(retry.DefaultRetry, patchFunc(pod.Name, patch)); rErr != nil {
+					return fmt.Errorf("failed to remove stale pod role label: %w", rErr)
+				}
+				log.FromContext(ctx).Info("removed stale pod role label after probe failure",
+					"pod", pod.Name,
+					"oldRole", oldRole,
+				)
+			}
 			continue
 		}
 		role := common.RedisRoleLabelSlave

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -39,11 +39,13 @@ type Healer interface {
 	// label to match the pod's real role.
 	//
 	// If a pod can't be reached, its label is normally left as is. The one exception is a pod
-	// labeled as master that is unreachable while another pod already answers as master and has
-	// replicas attached. In that case the old master label is removed, because keeping it could
-	// point the master service at a dead pod. If that removal fails, an error is returned so the
-	// caller retries.
-	UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig) error
+	// labeled as master that is unreachable while another pod already answers as master and
+	// either has replicas attached or is masterPod, the pod the caller has positively identified
+	// as the master (through Sentinel, say, after a failover that left it no replica to attach).
+	// In that case the old master label is removed, because keeping it could point the master
+	// service at a dead pod. If that removal fails, an error is returned so the caller retries.
+	// Pass an empty masterPod when no master has been identified.
+	UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig, masterPod string) error
 }
 
 type healer struct {
@@ -58,7 +60,7 @@ func NewHealer(clientset kubernetes.Interface) Healer {
 	}
 }
 
-func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig) error {
+func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig, masterPod string) error {
 	selector := make([]string, 0, len(labels))
 	for key, value := range labels {
 		selector = append(selector, fmt.Sprintf("%s=%s", key, value))
@@ -127,6 +129,12 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 		role := common.RedisRoleLabelSlave
 		if isMaster {
 			role = common.RedisRoleLabelMaster
+			// The pod the caller identified as the master needs no further proof: a
+			// survivor promoted by Sentinel after its only peer was lost has no replica
+			// left to attach, yet it is the master and the lost peer's label is stale.
+			if !masterConfirmed && pod.Name == masterPod {
+				masterConfirmed = true
+			}
 			if !masterConfirmed {
 				replicas, rErr := redisService.GetAttachedReplicaCount(ctx)
 				switch {
@@ -160,8 +168,9 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 		return nil
 	}
 	if !masterConfirmed {
-		log.FromContext(ctx).Info("keeping master role label of unreachable pods, no other pod answered as a master with attached replicas",
+		log.FromContext(ctx).Info("keeping master role label of unreachable pods, no other pod answered as the identified master or as a master with attached replicas",
 			"pods", unreachableMasterPods,
+			"identifiedMaster", masterPod,
 		)
 		return nil
 	}

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/cryptutil"
 	rediscli "github.com/redis/go-redis/v9"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -34,9 +35,14 @@ type Healer interface {
 	SentinelSet(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error
 	SentinelReset(ctx context.Context, rs *rsvb2.RedisSentinel) error
 
-	// UpdateRedisRoleLabel probes Running and Ready pods and updates their `redis-role` label
-	// based on their reported role. Pods that fail to probe keep their current label, except
-	// master labels are removed on network errors if another pod reported as master with replicas.
+	// UpdateRedisRoleLabel checks each Running and Ready pod and updates its `redis-role`
+	// label to match the pod's real role.
+	//
+	// If a pod can't be reached, its label is normally left as is. The one exception is a pod
+	// labeled as master that is unreachable while another pod already answers as master and has
+	// replicas attached. In that case the old master label is removed, because keeping it could
+	// point the master service at a dead pod. If that removal fails, an error is returned so the
+	// caller retries.
 	UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig) error
 }
 
@@ -159,18 +165,23 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 		)
 		return nil
 	}
+	var removeErrs []error
 	for _, podName := range unreachableMasterPods {
-		if rErr := retry.RetryOnConflict(retry.DefaultRetry, removeRoleLabelFunc(podName)); rErr != nil {
-			// The pod may have been deleted since the List. Skip it rather than
-			// abandoning the remaining pods; the next reconcile retries.
-			log.FromContext(ctx).Error(rErr, "failed to remove stale master role label, skipping pod", "pod", podName)
-			continue
+		rErr := retry.RetryOnConflict(retry.DefaultRetry, removeRoleLabelFunc(podName))
+		switch {
+		case rErr == nil:
+			log.FromContext(ctx).Info("removed stale master role label after probe failure",
+				"pod", podName,
+			)
+		case apierrors.IsNotFound(rErr):
+			log.FromContext(ctx).V(1).Info("pod was deleted before its stale master role label could be removed",
+				"pod", podName,
+			)
+		default:
+			removeErrs = append(removeErrs, fmt.Errorf("failed to remove stale master role label from pod %s: %w", podName, rErr))
 		}
-		log.FromContext(ctx).Info("removed stale master role label after probe failure",
-			"pod", podName,
-		)
 	}
-	return nil
+	return errors.Join(removeErrs...)
 }
 
 // isConnectivityError reports whether err means the pod was unreachable.

--- a/internal/controller/common/redis/heal.go
+++ b/internal/controller/common/redis/heal.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"os"
 	"strings"
 
 	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
@@ -14,6 +18,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/cryptutil"
+	rediscli "github.com/redis/go-redis/v9"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,12 +29,14 @@ import (
 
 type Healer interface {
 	SentinelMonitor(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error
-	// SentinelSet set the config for specific master
-	// reference: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#reconfiguring-sentinel-at-runtime
+	// SentinelSet sets the config for a specific master
+	// See: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#reconfiguring-sentinel-at-runtime
 	SentinelSet(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error
 	SentinelReset(ctx context.Context, rs *rsvb2.RedisSentinel) error
 
-	// UpdatePodRoleLabel connect to all redis pods and update pod role label `redis-role` to `master` or `slave` according to their role.
+	// UpdateRedisRoleLabel probes Running and Ready pods and updates their `redis-role` label
+	// based on their reported role. Pods that fail to probe keep their current label, except
+	// master labels are removed on network errors if another pod reported as master with replicas.
 	UpdateRedisRoleLabel(ctx context.Context, ns string, labels map[string]string, secret *commonapi.ExistingPasswordSecret, tlsConfig *commonapi.TLSConfig) error
 }
 
@@ -69,30 +76,66 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 			return err
 		}
 	}
+	removeRoleLabelFunc := func(pod string) func() error {
+		patchBs := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":null}}}`, common.RedisRoleLabelKey))
+		return func() error {
+			_, err := h.k8s.
+				CoreV1().
+				Pods(ns).
+				Patch(ctx, pod, types.MergePatchType, patchBs, metav1.PatchOptions{})
+			return err
+		}
+	}
+
+	var masterConfirmed bool
+	var unreachableMasterPods []string
 	for _, pod := range pods.Items {
 		if !k8sutils.IsRedisPodProbeable(&pod) {
 			continue
 		}
 
 		connInfo := createConnectionInfo(ctx, pod, password, tlsConfig, h.k8s, ns, "6379")
-		isMaster, err := h.redis.Connect(connInfo).IsMaster(ctx)
+		redisService := h.redis.Connect(connInfo)
+		isMaster, err := redisService.IsMaster(ctx)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			log.FromContext(ctx).Error(err, "failed to check redis role, skipping pod", "pod", pod.Name)
-			if oldRole := pod.Labels[common.RedisRoleLabelKey]; oldRole != "" {
-				patch := []byte(fmt.Sprintf(`[{"op": "remove", "path": "/metadata/labels/%s"}]`, common.RedisRoleLabelKey))
-				if rErr := retry.RetryOnConflict(retry.DefaultRetry, patchFunc(pod.Name, patch)); rErr != nil {
-					return fmt.Errorf("failed to remove stale pod role label: %w", rErr)
+			// A probe failure doesn't prove the pod lost its master role. Only a pod
+			// with a master label can cause split-brain, so collect unreachable pods
+			// and remove their master labels only if another master with replicas
+			// answers. This avoids removing labels due to operator-side issues like
+			// authentication or network policy. Stale slave labels are left alone.
+			if pod.Labels[common.RedisRoleLabelKey] == common.RedisRoleLabelMaster {
+				if isConnectivityError(err) {
+					unreachableMasterPods = append(unreachableMasterPods, pod.Name)
+				} else {
+					log.FromContext(ctx).Info("keeping master role label, the probe failed without evidence that the pod is unreachable",
+						"pod", pod.Name,
+					)
 				}
-				log.FromContext(ctx).Info("removed stale pod role label after probe failure",
-					"pod", pod.Name,
-					"oldRole", oldRole,
-				)
 			}
 			continue
 		}
 		role := common.RedisRoleLabelSlave
 		if isMaster {
 			role = common.RedisRoleLabelMaster
+			if !masterConfirmed {
+				replicas, rErr := redisService.GetAttachedReplicaCount(ctx)
+				switch {
+				case rErr != nil:
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return ctxErr
+					}
+					log.FromContext(ctx).V(1).Info("failed to count attached replicas, not using the pod as evidence of a stale master",
+						"pod", pod.Name,
+						"error", rErr,
+					)
+				case replicas > 0:
+					masterConfirmed = true
+				}
+			}
 		}
 		if oldRole := pod.Labels[common.RedisRoleLabelKey]; oldRole != role {
 			patch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/metadata/labels/%s", "value": "%s"}]`, common.RedisRoleLabelKey, role))
@@ -107,7 +150,68 @@ func (h *healer) UpdateRedisRoleLabel(ctx context.Context, ns string, labels map
 			)
 		}
 	}
+	if len(unreachableMasterPods) == 0 {
+		return nil
+	}
+	if !masterConfirmed {
+		log.FromContext(ctx).Info("keeping master role label of unreachable pods, no other pod answered as a master with attached replicas",
+			"pods", unreachableMasterPods,
+		)
+		return nil
+	}
+	for _, podName := range unreachableMasterPods {
+		if rErr := retry.RetryOnConflict(retry.DefaultRetry, removeRoleLabelFunc(podName)); rErr != nil {
+			// The pod may have been deleted since the List. Skip it rather than
+			// abandoning the remaining pods; the next reconcile retries.
+			log.FromContext(ctx).Error(rErr, "failed to remove stale master role label, skipping pod", "pod", podName)
+			continue
+		}
+		log.FromContext(ctx).Info("removed stale master role label after probe failure",
+			"pod", podName,
+		)
+	}
 	return nil
+}
+
+// isConnectivityError reports whether err means the pod was unreachable.
+// Redis server errors, TLS alerts, and cert failures prove the pod responded,
+// so they return false. Unrecognized errors are treated as inconclusive.
+func isConnectivityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var serverErr rediscli.Error
+	if errors.As(err, &serverErr) {
+		return false
+	}
+	var (
+		certErr             *tls.CertificateVerificationError
+		recordErr           tls.RecordHeaderError
+		unknownAuthorityErr x509.UnknownAuthorityError
+		hostnameErr         x509.HostnameError
+		certInvalidErr      x509.CertificateInvalidError
+	)
+	if errors.As(err, &certErr) || errors.As(err, &recordErr) ||
+		errors.As(err, &unknownAuthorityErr) || errors.As(err, &hostnameErr) ||
+		errors.As(err, &certInvalidErr) {
+		return false
+	}
+	// TLS alerts surface as OpError with Op "remote error"/"local error" and
+	// mean the pod answered; any other Op (dial, read, write) is a real failure.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op != "remote error" && opErr.Op != "local error"
+	}
+	// Bare context errors belong to the reconcile, not the pod.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, os.ErrDeadlineExceeded)
 }
 
 func (h *healer) SentinelSet(ctx context.Context, rs *rsvb2.RedisSentinel, master string) error {

--- a/internal/controller/common/redis/heal_test.go
+++ b/internal/controller/common/redis/heal_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
@@ -47,9 +48,43 @@ func TestUpdateRedisRoleLabelSkipsUnprobeablePods(t *testing.T) {
 	}
 }
 
+func TestUpdateRedisRoleLabelRemovesStaleLabelOnUnreachablePod(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	staleMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	staleMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	healthySlave := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(staleMaster, healthySlave)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": false,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": errors.New("connection refused"),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, unreachablePod.Labels[common.RedisRoleLabelKey])
+
+	healthyPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelSlave, healthyPod.Labels[common.RedisRoleLabelKey])
+}
+
 type fakeRedisClient struct {
 	connectHosts   []string
 	isMasterByHost map[string]bool
+	errByHost      map[string]error
 }
 
 func (f *fakeRedisClient) Connect(info *redisservice.ConnectionInfo) redisservice.Service {
@@ -57,15 +92,20 @@ func (f *fakeRedisClient) Connect(info *redisservice.ConnectionInfo) redisservic
 	return &fakeRedisService{
 		host:           info.Host,
 		isMasterByHost: f.isMasterByHost,
+		errByHost:      f.errByHost,
 	}
 }
 
 type fakeRedisService struct {
 	host           string
 	isMasterByHost map[string]bool
+	errByHost      map[string]error
 }
 
 func (f *fakeRedisService) IsMaster(context.Context) (bool, error) {
+	if err := f.errByHost[f.host]; err != nil {
+		return false, err
+	}
 	return f.isMasterByHost[f.host], nil
 }
 

--- a/internal/controller/common/redis/heal_test.go
+++ b/internal/controller/common/redis/heal_test.go
@@ -2,16 +2,28 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
 	"testing"
+	"time"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	redisservice "github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestUpdateRedisRoleLabelSkipsUnprobeablePods(t *testing.T) {
@@ -48,19 +60,22 @@ func TestUpdateRedisRoleLabelSkipsUnprobeablePods(t *testing.T) {
 	}
 }
 
-func TestUpdateRedisRoleLabelRemovesStaleLabelOnUnreachablePod(t *testing.T) {
+func TestUpdateRedisRoleLabelRemovesStaleMasterLabelWhenAMasterWithReplicasIsConfirmed(t *testing.T) {
 	labels := map[string]string{"app": "redis"}
 	staleMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
 	staleMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
-	healthySlave := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	newMaster := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
 
-	clientset := k8sfake.NewSimpleClientset(staleMaster, healthySlave)
+	clientset := k8sfake.NewSimpleClientset(staleMaster, newMaster)
 	redisClient := &fakeRedisClient{
 		isMasterByHost: map[string]bool{
-			"10.0.0.11": false,
+			"10.0.0.11": true,
+		},
+		replicasByHost: map[string]int{
+			"10.0.0.11": 1,
 		},
 		errByHost: map[string]error{
-			"10.0.0.10": errors.New("connection refused"),
+			"10.0.0.10": dialError(),
 		},
 	}
 	h := &healer{
@@ -74,32 +89,419 @@ func TestUpdateRedisRoleLabelRemovesStaleLabelOnUnreachablePod(t *testing.T) {
 
 	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Empty(t, unreachablePod.Labels[common.RedisRoleLabelKey])
+	assert.NotContains(t, unreachablePod.Labels, common.RedisRoleLabelKey)
+
+	masterPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, masterPod.Labels[common.RedisRoleLabelKey])
+
+	// A merge patch with a null value is idempotent, unlike a JSON Patch "remove"
+	// op, which returns 422 once the label is gone.
+	var removePatches int
+	for _, action := range clientset.Actions() {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok || patchAction.GetName() != "redis-0" {
+			continue
+		}
+		removePatches++
+		assert.Equal(t, types.MergePatchType, patchAction.GetPatchType())
+		assert.JSONEq(t, `{"metadata":{"labels":{"redis-role":null}}}`, string(patchAction.GetPatch()))
+	}
+	assert.Equal(t, 1, removePatches)
+}
+
+func TestUpdateRedisRoleLabelKeepsStaleMasterLabelWhenNoMasterIsConfirmed(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	unreachableMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	unreachableMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	healthySlave := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(unreachableMaster, healthySlave)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": false,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, unreachablePod.Labels[common.RedisRoleLabelKey])
 
 	healthyPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, common.RedisRoleLabelSlave, healthyPod.Labels[common.RedisRoleLabelKey])
 }
 
+// An operator-side fault - a rotated password, a TLS change, a network policy -
+// fails every probe while the pods stay Ready and keep serving. Stripping their
+// labels would take the master and replica services to zero endpoints.
+func TestUpdateRedisRoleLabelKeepsRoleLabelsWhenEveryProbeFails(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	master := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	master.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	slave := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	slave.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelSlave
+
+	clientset := k8sfake.NewSimpleClientset(master, slave)
+	redisClient := &fakeRedisClient{
+		errByHost: map[string]error{
+			"10.0.0.10": redisServerError("WRONGPASS invalid username-password pair"),
+			"10.0.0.11": redisServerError("WRONGPASS invalid username-password pair"),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	for podName, role := range map[string]string{
+		"redis-0": common.RedisRoleLabelMaster,
+		"redis-1": common.RedisRoleLabelSlave,
+	} {
+		pod, getErr := clientset.CoreV1().Pods("default").Get(context.Background(), podName, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.Equal(t, role, pod.Labels[common.RedisRoleLabelKey])
+	}
+}
+
+// A stale slave label is never removed: doing so on an operator-side fault would
+// empty the replica service, and a genuinely dead pod leaves that service once
+// the node lifecycle controller marks it NotReady.
+func TestUpdateRedisRoleLabelKeepsSlaveLabelOnUnreachablePod(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	unreachableSlave := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	unreachableSlave.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelSlave
+	master := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	master.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+
+	clientset := k8sfake.NewSimpleClientset(unreachableSlave, master)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		replicasByHost: map[string]int{
+			"10.0.0.11": 1,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelSlave, unreachablePod.Labels[common.RedisRoleLabelKey])
+}
+
+// The pods this branch exists for are the ones most likely to be deleted between
+// the List and the Patch, so a failed removal must not abandon the rest.
+func TestUpdateRedisRoleLabelContinuesWhenStaleLabelRemovalFails(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	goneMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	goneMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	staleMaster := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	staleMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	newMaster := newLabeledRedisPod("redis-2", labels, "10.0.0.12", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(goneMaster, staleMaster, newMaster)
+	clientset.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.PatchAction).GetName() == "redis-0" {
+			return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "redis-0")
+		}
+		return false, nil, nil
+	})
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.12": true,
+		},
+		replicasByHost: map[string]int{
+			"10.0.0.12": 1,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+			"10.0.0.11": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	stillLabelled, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, stillLabelled.Labels, common.RedisRoleLabelKey)
+}
+
+// dialError is what an unreachable pod actually produces: a dial failure or, for
+// a blackholed node, a timeout. Both satisfy net.Error.
+func dialError() error {
+	return &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
+}
+
+// netDialTimeoutError returns the error net.Dialer reports for its own dial
+// timeout, obtained deterministically by dialing with an already-expired
+// deadline. Its inner error satisfies errors.Is(err, context.DeadlineExceeded)
+// even though no caller context expired, which is what makes it worth pinning.
+func netDialTimeoutError(t *testing.T) error {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	_, err := (&net.Dialer{}).DialContext(ctx, "tcp", "127.0.0.1:1")
+	require.Error(t, err)
+	var opErr *net.OpError
+	require.True(t, errors.As(err, &opErr), "expected *net.OpError, got %T", err)
+	require.Equal(t, "dial", opErr.Op)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	return err
+}
+
+// redisServerError stands in for a reply from a reachable Redis, which is what
+// go-redis returns for WRONGPASS/NOAUTH/NOPERM/LOADING.
+type redisServerError string
+
+func (e redisServerError) Error() string { return string(e) }
+
+func (e redisServerError) RedisError() {}
+
+// An auth failure means the pod answered, so it is not evidence that the pod is
+// unreachable - even when another pod does report itself as master.
+func TestUpdateRedisRoleLabelKeepsMasterLabelOnAuthFailure(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	staleMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	staleMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	otherMaster := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(staleMaster, otherMaster)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		replicasByHost: map[string]int{
+			"10.0.0.11": 1,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": redisServerError("WRONGPASS invalid username-password pair"),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, unreachablePod.Labels[common.RedisRoleLabelKey])
+}
+
+// A replica pod recreated while the master is unreachable boots as a standalone
+// master, because replication is only attached at runtime. It answers as master
+// but has no replicas, so it is not evidence that the unreachable master was
+// replaced; stripping the label would route the master service to an empty pod.
+func TestUpdateRedisRoleLabelKeepsMasterLabelWhenOnlyAStandaloneMasterAnswers(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	unreachableMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	unreachableMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	standalone := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	standalone.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelSlave
+
+	clientset := k8sfake.NewSimpleClientset(unreachableMaster, standalone)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+	// One connection per pod: the replica count is read on the handle that
+	// answered the role probe.
+	assert.Equal(t, []string{"10.0.0.10", "10.0.0.11"}, redisClient.connectHosts)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, unreachablePod.Labels[common.RedisRoleLabelKey])
+
+	standalonePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, standalonePod.Labels[common.RedisRoleLabelKey])
+}
+
+// A master whose replica count cannot be read is not evidence either way.
+func TestUpdateRedisRoleLabelKeepsMasterLabelWhenReplicaCountCannotBeRead(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	unreachableMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	unreachableMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	otherMaster := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(unreachableMaster, otherMaster)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		replicaErrByHost: map[string]error{
+			"10.0.0.11": errors.New("read tcp: i/o timeout"),
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, unreachablePod.Labels[common.RedisRoleLabelKey])
+}
+
+// A cancelled reconcile - a manager shutdown, say - fails every probe. That is
+// not evidence about any pod, so the sweep must abort and report it rather than
+// deciding labels from a view it could not build.
+func TestUpdateRedisRoleLabelPropagatesContextCancellation(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	master := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	master.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	slave := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	slave.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelSlave
+
+	clientset := k8sfake.NewSimpleClientset(master, slave)
+	ctx, cancel := context.WithCancel(context.Background())
+	redisClient := &fakeRedisClient{
+		errByHost: map[string]error{
+			"10.0.0.10": context.Canceled,
+			"10.0.0.11": context.Canceled,
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+	cancel()
+
+	err := h.UpdateRedisRoleLabel(ctx, "default", labels, nil, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+
+	for podName, role := range map[string]string{
+		"redis-0": common.RedisRoleLabelMaster,
+		"redis-1": common.RedisRoleLabelSlave,
+	} {
+		pod, getErr := clientset.CoreV1().Pods("default").Get(context.Background(), podName, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.Equal(t, role, pod.Labels[common.RedisRoleLabelKey])
+	}
+}
+
+func TestIsConnectivityError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"dial failure", dialError(), true},
+		{"timeout", &net.OpError{Op: "dial", Net: "tcp", Err: os.ErrDeadlineExceeded}, true},
+		// net.Dialer reports its own dial timeout with an inner error that
+		// satisfies errors.Is(err, context.DeadlineExceeded); the OpError has to
+		// win over the context check or a blackholed node is never recognised.
+		{"dial timeout reported by net.Dialer", netDialTimeoutError(t), true},
+		{"connection reset", &net.OpError{Op: "read", Net: "tcp", Err: errors.New("connection reset by peer")}, true},
+		{"dns failure", &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Err: "no such host"}}, true},
+		{"socket deadline", os.ErrDeadlineExceeded, true},
+		{"eof", io.EOF, true},
+		// Context errors belong to the reconcile, not the pod; the caller handles
+		// them before any label decision is made.
+		{"context deadline", context.DeadlineExceeded, false},
+		{"context cancelled", context.Canceled, false},
+		{"wrong password", redisServerError("WRONGPASS invalid username-password pair"), false},
+		{"no auth", redisServerError("NOAUTH Authentication required."), false},
+		{"loading", redisServerError("LOADING Redis is loading the dataset in memory"), false},
+		{"wrapped server reply", fmt.Errorf("probe: %w", redisServerError("NOPERM")), false},
+		{"unknown certificate authority", x509.UnknownAuthorityError{}, false},
+		{"certificate verification", &tls.CertificateVerificationError{Err: errors.New("expired")}, false},
+		// crypto/tls surfaces a TLS alert sent by the peer, and a handshake it
+		// aborted itself, as *net.OpError; both mean the pod answered on the socket.
+		{"remote tls alert", &net.OpError{Op: "remote error", Net: "tcp", Err: errors.New("tls: bad certificate")}, false},
+		{"wrapped remote tls alert", fmt.Errorf("probe: %w", &net.OpError{Op: "remote error", Net: "tcp", Err: errors.New("tls: unknown certificate authority")}), false},
+		{"local tls handshake abort", &net.OpError{Op: "local error", Net: "tcp", Err: errors.New("tls: handshake failure")}, false},
+		{"unrecognised error is inconclusive", errors.New("something went wrong"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isConnectivityError(tt.err))
+		})
+	}
+}
+
 type fakeRedisClient struct {
-	connectHosts   []string
-	isMasterByHost map[string]bool
-	errByHost      map[string]error
+	connectHosts     []string
+	isMasterByHost   map[string]bool
+	replicasByHost   map[string]int
+	errByHost        map[string]error
+	replicaErrByHost map[string]error
 }
 
 func (f *fakeRedisClient) Connect(info *redisservice.ConnectionInfo) redisservice.Service {
 	f.connectHosts = append(f.connectHosts, info.Host)
 	return &fakeRedisService{
-		host:           info.Host,
-		isMasterByHost: f.isMasterByHost,
-		errByHost:      f.errByHost,
+		host:             info.Host,
+		isMasterByHost:   f.isMasterByHost,
+		replicasByHost:   f.replicasByHost,
+		errByHost:        f.errByHost,
+		replicaErrByHost: f.replicaErrByHost,
 	}
 }
 
 type fakeRedisService struct {
-	host           string
-	isMasterByHost map[string]bool
-	errByHost      map[string]error
+	host             string
+	isMasterByHost   map[string]bool
+	replicasByHost   map[string]int
+	errByHost        map[string]error
+	replicaErrByHost map[string]error
 }
 
 func (f *fakeRedisService) IsMaster(context.Context) (bool, error) {
@@ -110,7 +512,10 @@ func (f *fakeRedisService) IsMaster(context.Context) (bool, error) {
 }
 
 func (f *fakeRedisService) GetAttachedReplicaCount(context.Context) (int, error) {
-	return 0, nil
+	if err := f.replicaErrByHost[f.host]; err != nil {
+		return 0, err
+	}
+	return f.replicasByHost[f.host], nil
 }
 
 func (f *fakeRedisService) SentinelMonitor(context.Context, *redisservice.ConnectionInfo, string, string) error {

--- a/internal/controller/common/redis/heal_test.go
+++ b/internal/controller/common/redis/heal_test.go
@@ -44,7 +44,7 @@ func TestUpdateRedisRoleLabelSkipsUnprobeablePods(t *testing.T) {
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"10.0.0.10"}, redisClient.connectHosts)
@@ -83,7 +83,7 @@ func TestUpdateRedisRoleLabelRemovesStaleMasterLabelWhenAMasterWithReplicasIsCon
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -130,7 +130,7 @@ func TestUpdateRedisRoleLabelKeepsStaleMasterLabelWhenNoMasterIsConfirmed(t *tes
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -165,7 +165,7 @@ func TestUpdateRedisRoleLabelKeepsRoleLabelsWhenEveryProbeFails(t *testing.T) {
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestUpdateRedisRoleLabelKeepsSlaveLabelOnUnreachablePod(t *testing.T) {
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -250,7 +250,7 @@ func TestUpdateRedisRoleLabelPassesOverPodDeletedBeforeStaleLabelRemoval(t *test
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -293,7 +293,7 @@ func TestUpdateRedisRoleLabelReturnsErrorWhenStaleLabelRemovalFails(t *testing.T
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.Error(t, err)
 	assert.True(t, apierrors.IsForbidden(err), "expected the API error to be preserved, got %v", err)
@@ -368,7 +368,7 @@ func TestUpdateRedisRoleLabelKeepsMasterLabelOnAuthFailure(t *testing.T) {
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -402,7 +402,7 @@ func TestUpdateRedisRoleLabelKeepsMasterLabelWhenOnlyAStandaloneMasterAnswers(t 
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 	// One connection per pod: the replica count is read on the handle that
@@ -416,6 +416,74 @@ func TestUpdateRedisRoleLabelKeepsMasterLabelWhenOnlyAStandaloneMasterAnswers(t 
 	standalonePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, common.RedisRoleLabelMaster, standalonePod.Labels[common.RedisRoleLabelKey])
+}
+
+// After a two-pod failover the promoted survivor has no replica left to attach,
+// so it cannot prove itself here. The controller has confirmed it through
+// Sentinel, and passes it in; the lost master's label is then stale and removed.
+func TestUpdateRedisRoleLabelRemovesStaleMasterLabelWhenTheIdentifiedMasterHasNoReplicas(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	lostMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	lostMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	survivor := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	survivor.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelSlave
+
+	clientset := k8sfake.NewSimpleClientset(lostMaster, survivor)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "redis-1")
+
+	require.NoError(t, err)
+
+	lostPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, lostPod.Labels, common.RedisRoleLabelKey)
+
+	survivorPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, survivorPod.Labels[common.RedisRoleLabelKey])
+}
+
+// The identified master only counts once it answers as master here; naming a
+// pod that cannot be reached changes nothing.
+func TestUpdateRedisRoleLabelKeepsMasterLabelWhenTheIdentifiedMasterDoesNotAnswer(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	unreachableMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	unreachableMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	standalone := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(unreachableMaster, standalone)
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.11": true,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "redis-0")
+
+	require.NoError(t, err)
+
+	unreachablePod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, unreachablePod.Labels[common.RedisRoleLabelKey])
 }
 
 // A master whose replica count cannot be read is not evidence either way.
@@ -442,7 +510,7 @@ func TestUpdateRedisRoleLabelKeepsMasterLabelWhenReplicaCountCannotBeRead(t *tes
 		redis: redisClient,
 	}
 
-	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil, "")
 
 	require.NoError(t, err)
 
@@ -475,7 +543,7 @@ func TestUpdateRedisRoleLabelPropagatesContextCancellation(t *testing.T) {
 	}
 	cancel()
 
-	err := h.UpdateRedisRoleLabel(ctx, "default", labels, nil, nil)
+	err := h.UpdateRedisRoleLabel(ctx, "default", labels, nil, nil, "")
 
 	require.ErrorIs(t, err, context.Canceled)
 

--- a/internal/controller/common/redis/heal_test.go
+++ b/internal/controller/common/redis/heal_test.go
@@ -216,8 +216,9 @@ func TestUpdateRedisRoleLabelKeepsSlaveLabelOnUnreachablePod(t *testing.T) {
 }
 
 // The pods this branch exists for are the ones most likely to be deleted between
-// the List and the Patch, so a failed removal must not abandon the rest.
-func TestUpdateRedisRoleLabelContinuesWhenStaleLabelRemovalFails(t *testing.T) {
+// the List and the Patch. A deleted pod took its label with it, so it is passed
+// over without abandoning the rest and without failing the reconcile.
+func TestUpdateRedisRoleLabelPassesOverPodDeletedBeforeStaleLabelRemoval(t *testing.T) {
 	labels := map[string]string{"app": "redis"}
 	goneMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
 	goneMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
@@ -256,6 +257,59 @@ func TestUpdateRedisRoleLabelContinuesWhenStaleLabelRemovalFails(t *testing.T) {
 	stillLabelled, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.NotContains(t, stillLabelled.Labels, common.RedisRoleLabelKey)
+}
+
+// Any other failure leaves a dead pod behind the master service, so it must fail
+// the reconcile - after the remaining removals have still been attempted.
+func TestUpdateRedisRoleLabelReturnsErrorWhenStaleLabelRemovalFails(t *testing.T) {
+	labels := map[string]string{"app": "redis"}
+	forbiddenMaster := newLabeledRedisPod("redis-0", labels, "10.0.0.10", corev1.PodRunning, true)
+	forbiddenMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	staleMaster := newLabeledRedisPod("redis-1", labels, "10.0.0.11", corev1.PodRunning, true)
+	staleMaster.Labels[common.RedisRoleLabelKey] = common.RedisRoleLabelMaster
+	newMaster := newLabeledRedisPod("redis-2", labels, "10.0.0.12", corev1.PodRunning, true)
+
+	clientset := k8sfake.NewSimpleClientset(forbiddenMaster, staleMaster, newMaster)
+	clientset.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.PatchAction).GetName() == "redis-0" {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "redis-0", errors.New("patch denied"))
+		}
+		return false, nil, nil
+	})
+	redisClient := &fakeRedisClient{
+		isMasterByHost: map[string]bool{
+			"10.0.0.12": true,
+		},
+		replicasByHost: map[string]int{
+			"10.0.0.12": 1,
+		},
+		errByHost: map[string]error{
+			"10.0.0.10": dialError(),
+			"10.0.0.11": dialError(),
+		},
+	}
+	h := &healer{
+		k8s:   clientset,
+		redis: redisClient,
+	}
+
+	err := h.UpdateRedisRoleLabel(context.Background(), "default", labels, nil, nil)
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err), "expected the API error to be preserved, got %v", err)
+	assert.ErrorContains(t, err, "redis-0")
+
+	stillForbidden, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, stillForbidden.Labels[common.RedisRoleLabelKey])
+
+	removed, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, removed.Labels, common.RedisRoleLabelKey)
+
+	masterPod, err := clientset.CoreV1().Pods("default").Get(context.Background(), "redis-2", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, common.RedisRoleLabelMaster, masterPod.Labels[common.RedisRoleLabelKey])
 }
 
 // dialError is what an unreachable pod actually produces: a dial failure or, for

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -435,7 +435,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	for _, fakeRole := range []string{"leader", "follower"} {
 		labels := common.GetRedisLabels(instance.GetName()+"-"+fakeRole, common.SetupTypeCluster, fakeRole, instance.GetLabels())
-		if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret, instance.Spec.TLS); err != nil {
+		if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret, instance.Spec.TLS, ""); err != nil {
 			return intctrlutil.RequeueE(ctx, err, "")
 		}
 	}

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -36,10 +36,11 @@ type Reconciler struct {
 	k8sutils.StatefulSet
 	Healer                     redishealer.Healer
 	K8sClient                  kubernetes.Interface
-	RedisNodesByRole           func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, string) ([]string, error)
+	RedisReplicationTopology   func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication) (k8sutils.RedisReplicationTopology, error)
 	RedisReplicationRealMaster func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string
 	CreateRedisReplicationLink func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error
 	ConfigureSentinel          func(context.Context, *rrvb2.RedisReplication, string) error
+	SentinelMonitoredMaster    func(context.Context, *rrvb2.RedisReplication, []string) (string, error)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -130,11 +131,11 @@ func connectionInfoEqual(a, b *rrvb2.ConnectionInfo) bool {
 	return a.Host == b.Host && a.Port == b.Port && a.MasterName == b.MasterName
 }
 
-func (r *Reconciler) redisNodesByRole(ctx context.Context, instance *rrvb2.RedisReplication, role string) ([]string, error) {
-	if r.RedisNodesByRole != nil {
-		return r.RedisNodesByRole(ctx, r.K8sClient, instance, role)
+func (r *Reconciler) redisReplicationTopology(ctx context.Context, instance *rrvb2.RedisReplication) (k8sutils.RedisReplicationTopology, error) {
+	if r.RedisReplicationTopology != nil {
+		return r.RedisReplicationTopology(ctx, r.K8sClient, instance)
 	}
-	return k8sutils.GetRedisNodesByRole(ctx, r.K8sClient, instance, role)
+	return k8sutils.GetRedisReplicationTopology(ctx, r.K8sClient, instance)
 }
 
 func (r *Reconciler) redisReplicationRealMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterPods []string) string {
@@ -158,14 +159,57 @@ func (r *Reconciler) configureReplicationSentinel(ctx context.Context, instance 
 	return r.configureSentinel(ctx, instance, masterPodName)
 }
 
-func (r *Reconciler) observedRedisReplicationMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterPods []string) (string, bool) {
-	switch len(masterPods) {
+// Read PR description for context: https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1843
+func (r *Reconciler) observedRedisReplicationMaster(ctx context.Context, instance *rrvb2.RedisReplication, topology k8sutils.RedisReplicationTopology) (string, bool) {
+	switch len(topology.Masters) {
 	case 0:
 		return "", false
 	case 1:
-		return masterPods[0], true
+		candidate := topology.Masters[0]
+		if topology.Complete() {
+			return candidate, true
+		}
+		if r.redisReplicationRealMaster(ctx, instance, topology.Masters) == candidate {
+			return candidate, true
+		}
+		if instance.EnableSentinel() {
+			monitored, err := r.sentinelMonitoredMaster(ctx, instance, topology.Masters)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "Not trusting the only observed master: the topology is incomplete, the pod has no attached replicas and sentinel could not be asked",
+					"candidate", candidate,
+					"unobservedPods", topology.Unobserved)
+				return "", false
+			}
+			if monitored == candidate {
+				return candidate, true
+			}
+			log.FromContext(ctx).Info("Not trusting the only observed master: the topology is incomplete, the pod has no attached replicas and sentinel does not report it as master",
+				"candidate", candidate,
+				"statusMasterNode", instance.Status.MasterNode,
+				"unobservedPods", topology.Unobserved)
+			return "", false
+		}
+		if candidate == instance.Status.MasterNode {
+			return candidate, true
+		}
+		log.FromContext(ctx).Info("Not trusting the only observed master: the topology is incomplete, the pod has no attached replicas and it is not the recorded master",
+			"candidate", candidate,
+			"statusMasterNode", instance.Status.MasterNode,
+			"unobservedPods", topology.Unobserved)
+		return "", false
 	default:
-		realMaster := r.redisReplicationRealMaster(ctx, instance, masterPods)
+		realMaster := r.redisReplicationRealMaster(ctx, instance, topology.Masters)
+		if realMaster == "" && instance.EnableSentinel() {
+			monitored, err := r.sentinelMonitoredMaster(ctx, instance, topology.Masters)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "Could not ask sentinel which of the observed masters it monitors",
+					"masters", topology.Masters)
+			} else if monitored != "" {
+				log.FromContext(ctx).Info("No master with attached replicas found, using the master monitored by sentinel",
+					"master", monitored)
+				realMaster = monitored
+			}
+		}
 		return realMaster, realMaster != ""
 	}
 }
@@ -223,13 +267,7 @@ func (r *Reconciler) configureSentinel(ctx context.Context, inst *rrvb2.RedisRep
 	}
 	var monitorAddr string
 	if inst.Spec.Sentinel.ResolveHostnames == "yes" {
-		monitorAddr = fmt.Sprintf(
-			"%s.%s.%s.svc.%s",
-			masterPodName,
-			common.GetHeadlessServiceNameFromPodName(masterPodName),
-			inst.Namespace,
-			envs.GetServiceDNSDomain(),
-		)
+		monitorAddr = replicationPodHostname(inst, masterPodName)
 	} else {
 		monitorAddr = masterPod.Status.PodIP
 	}
@@ -297,17 +335,9 @@ func (r *Reconciler) configureSentinelPod(
 	masterAddr string,
 	masterPassword string,
 ) error {
-	var sentinelPassword string
-	if inst.Spec.Sentinel.ExistingPasswordSecret != nil {
-		secret, err := r.K8sClient.CoreV1().Secrets(inst.Namespace).Get(
-			ctx,
-			*inst.Spec.Sentinel.ExistingPasswordSecret.Name,
-			metav1.GetOptions{},
-		)
-		if err != nil {
-			return err
-		}
-		sentinelPassword = string(secret.Data[*inst.Spec.Sentinel.ExistingPasswordSecret.Key])
+	sentinelPassword, err := r.sentinelPassword(ctx, inst)
+	if err != nil {
+		return err
 	}
 
 	sentinelConnInfo := &redis.ConnectionInfo{
@@ -418,17 +448,14 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 	}
 
 	var realMaster string
-	masterNodes, err := r.redisNodesByRole(ctx, instance, "master")
+	topology, err := r.redisReplicationTopology(ctx, instance)
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	slaveNodes, err := r.redisNodesByRole(ctx, instance, "slave")
-	if err != nil {
-		return intctrlutil.RequeueE(ctx, err, "")
-	}
-	observedPods := len(masterNodes) + len(slaveNodes)
-	incompleteTopology := instance.Spec.Size != nil && observedPods < int(*instance.Spec.Size)
-	realMaster, masterPositivelyIdentified := r.observedRedisReplicationMaster(ctx, instance, masterNodes)
+	masterNodes, slaveNodes := topology.Masters, topology.Slaves
+	observedPods := topology.Observed()
+	incompleteTopology := !topology.Complete()
+	realMaster, masterPositivelyIdentified := r.observedRedisReplicationMaster(ctx, instance, topology)
 	if len(masterNodes) > 1 {
 		log.FromContext(ctx).Info("Creating redis replication by executing replication creation commands")
 
@@ -467,7 +494,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 		if incompleteTopology {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the observed topology is incomplete",
 				"observedPods", observedPods,
-				"expectedPods", *instance.Spec.Size)
+				"unobservedPods", topology.Unobserved)
 		} else if realMaster == "" {
 			log.FromContext(ctx).Info("Skipping replication reconfiguration because the current master could not be identified")
 		} else if err := r.createRedisReplicationLink(ctx, instance, masterNodes, realMaster); err != nil {
@@ -483,7 +510,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 			if incompleteTopology {
 				log.FromContext(ctx).Info("Skipping master-slave reconfiguration because the observed topology is incomplete",
 					"observedPods", observedPods,
-					"expectedPods", *instance.Spec.Size)
+					"unobservedPods", topology.Unobserved)
 			} else {
 				allPods := append(masterNodes, slaveNodes...)
 				if err := r.createRedisReplicationLink(ctx, instance, allPods, realMaster); err != nil {
@@ -508,7 +535,7 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 		if incompleteTopology && !masterPositivelyIdentified {
 			log.FromContext(ctx).Info("Skipping sentinel reconfiguration because topology is incomplete and the master is ambiguous",
 				"observedPods", observedPods,
-				"expectedPods", *instance.Spec.Size)
+				"unobservedPods", topology.Unobserved)
 		} else if err := r.configureReplicationSentinel(ctx, instance, realMaster); err != nil {
 			log.FromContext(ctx).Error(err, "failed to configure sentinel")
 		}
@@ -519,14 +546,12 @@ func (r *Reconciler) reconcileRedis(ctx context.Context, instance *rrvb2.RedisRe
 
 // reconcileStatus update status and label.
 func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisReplication) (ctrl.Result, error) {
-	var err error
-	var realMaster string
-
-	masterNodes, err := r.redisNodesByRole(ctx, instance, "master")
+	topology, err := r.redisReplicationTopology(ctx, instance)
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	realMaster, _ = r.observedRedisReplicationMaster(ctx, instance, masterNodes)
+	// An unidentified master yields "", which keeps the last known master.
+	realMaster, _ := r.observedRedisReplicationMaster(ctx, instance, topology)
 	if err = r.UpdateRedisReplicationMaster(ctx, instance, realMaster); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
@@ -535,12 +560,8 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisR
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
 
-	slaveNodes, err := r.redisNodesByRole(ctx, instance, "slave")
-	if err != nil {
-		return intctrlutil.RequeueE(ctx, err, "")
-	}
 	if realMaster != "" {
-		monitoring.RedisReplicationConnectedSlavesTotal.WithLabelValues(instance.Namespace, instance.Name).Set(float64(len(slaveNodes)))
+		monitoring.RedisReplicationConnectedSlavesTotal.WithLabelValues(instance.Namespace, instance.Name).Set(float64(len(topology.Slaves)))
 	} else {
 		monitoring.RedisReplicationConnectedSlavesTotal.WithLabelValues(instance.Namespace, instance.Name).Set(float64(0))
 	}

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -82,24 +82,33 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return intctrlutil.RequeueAfter(ctx, time.Second*30, "")
 }
 
-func (r *Reconciler) UpdateRedisReplicationMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterNode string) error {
+// UpdateRedisReplicationMaster records masterNode as the master of the
+// replication. An empty masterNode means no master was identified in this
+// reconcile, which the RedisReplicationHasMaster gauge reports either way.
+//
+// Whether the recorded master is then cleared depends on why none was
+// identified. masterAbsent says every pod was observed and none of them is a
+// master: that is conclusive, and a recorded master that is provably not the
+// master must not feed the bootstrap election or the sentinel controller's
+// fallback, so it is cleared. Anything else - pods that could not be probed, or
+// masters that could not be told apart - is not evidence that the recorded
+// master changed, so the last known master is kept for those fallbacks.
+func (r *Reconciler) UpdateRedisReplicationMaster(ctx context.Context, instance *rrvb2.RedisReplication, masterNode string, masterAbsent bool) error {
 	if masterNode == "" {
 		monitoring.RedisReplicationHasMaster.WithLabelValues(instance.Namespace, instance.Name).Set(0)
 	} else {
 		monitoring.RedisReplicationHasMaster.WithLabelValues(instance.Namespace, instance.Name).Set(1)
 	}
 
-	// No master could be observed in this reconcile, for example because every
-	// pod was skipped by the role probe. Keep the last known master rather than
-	// clearing it: a transient probe failure is not a master role change, and both
-	// this controller and the sentinel controller fall back to Status.MasterNode
-	// (guarded by IsPodRunning) when no master has attached slaves. The
-	// RedisReplicationHasMaster gauge above still reports 0, so the "no master is
-	// currently observable" signal is not lost.
 	if masterNode == "" && instance.Status.MasterNode != "" {
-		log.FromContext(ctx).Info("No master observed, keeping the last known master node",
-			"statusMasterNode", instance.Status.MasterNode)
-		masterNode = instance.Status.MasterNode
+		if masterAbsent {
+			log.FromContext(ctx).Info("Every pod answered and none is a master, clearing the recorded master node",
+				"statusMasterNode", instance.Status.MasterNode)
+		} else {
+			log.FromContext(ctx).Info("No master identified in a partial or ambiguous view, keeping the last known master node",
+				"statusMasterNode", instance.Status.MasterNode)
+			masterNode = instance.Status.MasterNode
+		}
 	}
 
 	connectionInfo := instance.GetConnectionInfo(envs.GetServiceDNSDomain())
@@ -550,13 +559,15 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, instance *rrvb2.RedisR
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
-	// An unidentified master yields "", which keeps the last known master.
 	realMaster, _ := r.observedRedisReplicationMaster(ctx, instance, topology)
-	if err = r.UpdateRedisReplicationMaster(ctx, instance, realMaster); err != nil {
+	// Every pod answered and none is a master: there is no master to record, as
+	// opposed to a master that could not be identified.
+	masterAbsent := topology.Complete() && len(topology.Masters) == 0
+	if err = r.UpdateRedisReplicationMaster(ctx, instance, realMaster, masterAbsent); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
 	labels := common.GetRedisLabels(instance.GetName(), common.SetupTypeReplication, "replication", instance.GetLabels())
-	if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret, instance.Spec.TLS); err != nil {
+	if err = r.Healer.UpdateRedisRoleLabel(ctx, instance.GetNamespace(), labels, instance.Spec.KubernetesConfig.ExistingPasswordSecret, instance.Spec.TLS, realMaster); err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
 	}
 

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -88,6 +88,19 @@ func (r *Reconciler) UpdateRedisReplicationMaster(ctx context.Context, instance 
 		monitoring.RedisReplicationHasMaster.WithLabelValues(instance.Namespace, instance.Name).Set(1)
 	}
 
+	// No master could be observed in this reconcile, for example because every
+	// pod was skipped by the role probe. Keep the last known master rather than
+	// clearing it: a transient probe failure is not a master role change, and both
+	// this controller and the sentinel controller fall back to Status.MasterNode
+	// (guarded by IsPodRunning) when no master has attached slaves. The
+	// RedisReplicationHasMaster gauge above still reports 0, so the "no master is
+	// currently observable" signal is not lost.
+	if masterNode == "" && instance.Status.MasterNode != "" {
+		log.FromContext(ctx).Info("No master observed, keeping the last known master node",
+			"statusMasterNode", instance.Status.MasterNode)
+		masterNode = instance.Status.MasterNode
+	}
+
 	connectionInfo := instance.GetConnectionInfo(envs.GetServiceDNSDomain())
 
 	if instance.Status.MasterNode == masterNode && connectionInfoEqual(instance.Status.ConnectionInfo, connectionInfo) {

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -2,13 +2,19 @@ package redisreplication
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	rsvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redissentinel/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -22,13 +28,8 @@ import (
 func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testing.T) {
 	createCalled := false
 	r := &Reconciler{
-		K8sClient: fake.NewSimpleClientset(),
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-0"}, nil
-			}
-			return []string{"example-replication-1"}, nil
-		},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0"}, []string{"example-replication-1"}, []string{"example-replication-2"}),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
@@ -47,13 +48,8 @@ func TestReconcileRedisSkipsReplicationChangesWhenTopologyIsIncomplete(t *testin
 func TestReconcileRedisSkipsReplicationChangesWhenMultipleMastersAreObservedButTopologyIsIncomplete(t *testing.T) {
 	createCalled := false
 	r := &Reconciler{
-		K8sClient: fake.NewSimpleClientset(),
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-0", "example-replication-1"}, nil
-			}
-			return nil, nil
-		},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0", "example-replication-1"}, nil, []string{"example-replication-2"}),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return "example-replication-1"
 		},
@@ -75,13 +71,8 @@ func TestReconcileRedisKeepsHealthyBehaviorWhenTopologyIsComplete(t *testing.T) 
 	var gotPods []string
 	var gotMaster string
 	r := &Reconciler{
-		K8sClient: fake.NewSimpleClientset(),
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-0", "example-replication-1"}, nil
-			}
-			return []string{"example-replication-2"}, nil
-		},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0", "example-replication-1"}, []string{"example-replication-2"}, nil),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return "example-replication-1"
 		},
@@ -101,59 +92,13 @@ func TestReconcileRedisKeepsHealthyBehaviorWhenTopologyIsComplete(t *testing.T) 
 	assert.Equal(t, "example-replication-1", gotMaster)
 }
 
-func TestReconcileStatusStillRunsWhenOnePodIsUnobserved(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, rrvb2.AddToScheme(scheme))
-
-	seedInstance := newReplicationInstanceForTest()
-	ctrlClient := clientfake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(seedInstance).
-		WithObjects(seedInstance.DeepCopy()).
-		Build()
-
-	instance := &rrvb2.RedisReplication{}
-	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
-
-	healer := &fakeHealer{}
-	r := &Reconciler{
-		Client:    ctrlClient,
-		K8sClient: fake.NewSimpleClientset(),
-		Healer:    healer,
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-1"}, nil
-			}
-			return nil, nil
-		},
-		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
-			return ""
-		},
-	}
-
-	result, err := r.reconcileStatus(context.Background(), instance)
-
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-	assert.True(t, healer.updateCalled)
-
-	updated := &rrvb2.RedisReplication{}
-	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
-	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
-}
-
 func TestReconcileRedisSkipsSentinelReconfigurationWhenTopologyIsIncompleteAndMasterIsAmbiguous(t *testing.T) {
 	createCalled := false
 	sentinelCalled := false
 	r := &Reconciler{
-		StatefulSet: &fakeStatefulSetService{},
-		K8sClient:   fake.NewSimpleClientset(),
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-0", "example-replication-1"}, nil
-			}
-			return nil, nil
-		},
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0", "example-replication-1"}, nil, []string{"example-replication-2"}),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
@@ -175,18 +120,186 @@ func TestReconcileRedisSkipsSentinelReconfigurationWhenTopologyIsIncompleteAndMa
 	assert.False(t, sentinelCalled)
 }
 
-func TestReconcileRedisConfiguresSentinelForSingleObservedMaster(t *testing.T) {
+// The master is unreachable and a replica pod has been recreated: it boots as a
+// standalone master with no replicas, while the pod still replicating from the
+// unreachable master reports as slave. The standalone node is the only master
+// observed, but it is not the master; repointing Sentinel at it would replicate
+// an empty dataset over the surviving replica.
+func TestReconcileRedisSkipsSentinelReconfigurationForLoneStandaloneMasterWhenTopologyIsIncomplete(t *testing.T) {
+	createCalled := false
+	sentinelCalled := false
+	var askedSentinelAbout []string
+	r := &Reconciler{
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, []string{"example-replication-2"}, []string{"example-replication-0"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		CreateRedisReplicationLink: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string, string) error {
+			createCalled = true
+			return nil
+		},
+		ConfigureSentinel: func(context.Context, *rrvb2.RedisReplication, string) error {
+			sentinelCalled = true
+			return nil
+		},
+		SentinelMonitoredMaster: func(_ context.Context, _ *rrvb2.RedisReplication, candidates []string) (string, error) {
+			askedSentinelAbout = candidates
+			return "", nil
+		},
+	}
+	instance := newSentinelReplicationInstanceForTest()
+	instance.Status.MasterNode = "example-replication-0"
+
+	result, err := r.reconcileRedis(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.False(t, createCalled)
+	assert.False(t, sentinelCalled)
+	assert.Equal(t, []string{"example-replication-1"}, askedSentinelAbout)
+}
+
+// Sentinel has failed over: the promoted pod has the surviving replica attached,
+// which a standalone node cannot show. It is the master even though the old
+// master is still unobserved, and Sentinel is kept in sync with it.
+func TestReconcileRedisConfiguresSentinelForLoneMasterWithAttachedReplicasWhenTopologyIsIncomplete(t *testing.T) {
 	sentinelCalled := false
 	var gotMaster string
 	r := &Reconciler{
-		StatefulSet: &fakeStatefulSetService{},
-		K8sClient:   fake.NewSimpleClientset(),
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-1"}, nil
-			}
-			return nil, nil
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-2"}, []string{"example-replication-1"}, []string{"example-replication-0"}),
+		RedisReplicationRealMaster: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, masterPods []string) string {
+			require.Equal(t, []string{"example-replication-2"}, masterPods)
+			return "example-replication-2"
 		},
+		ConfigureSentinel: func(_ context.Context, _ *rrvb2.RedisReplication, master string) error {
+			sentinelCalled = true
+			gotMaster = master
+			return nil
+		},
+	}
+	instance := newSentinelReplicationInstanceForTest()
+	instance.Status.MasterNode = "example-replication-0"
+
+	result, err := r.reconcileRedis(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, sentinelCalled)
+	assert.Equal(t, "example-replication-2", gotMaster)
+}
+
+// A two-pod replication has lost its master. Sentinel promoted the survivor,
+// which has no replica left to prove itself with, and the recorded master is
+// the pod that is gone. Sentinel's own view is what settles this: the promoted
+// pod is recorded so that the old master, once back, is attached under it and
+// not the other way round.
+func TestReconcileRedisConfiguresSentinelForLoneMasterThatSentinelReports(t *testing.T) {
+	sentinelCalled := false
+	var gotMaster string
+	r := &Reconciler{
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, nil, []string{"example-replication-0"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		ConfigureSentinel: func(_ context.Context, _ *rrvb2.RedisReplication, master string) error {
+			sentinelCalled = true
+			gotMaster = master
+			return nil
+		},
+		SentinelMonitoredMaster: sentinelMonitoring("example-replication-1"),
+	}
+	instance := newSentinelReplicationInstanceForTest()
+	instance.Spec.Size = ptr.To(int32(2))
+	instance.Status.MasterNode = "example-replication-0"
+
+	result, err := r.reconcileRedis(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, sentinelCalled)
+	assert.Equal(t, "example-replication-1", gotMaster)
+}
+
+// If Sentinel cannot be asked, the candidate stays unconfirmed; the reconcile
+// itself still succeeds and retries on its normal cadence.
+func TestReconcileRedisSkipsSentinelReconfigurationWhenSentinelCannotBeAsked(t *testing.T) {
+	sentinelCalled := false
+	r := &Reconciler{
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, nil, []string{"example-replication-0", "example-replication-2"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		ConfigureSentinel: func(context.Context, *rrvb2.RedisReplication, string) error {
+			sentinelCalled = true
+			return nil
+		},
+		SentinelMonitoredMaster: func(context.Context, *rrvb2.RedisReplication, []string) (string, error) {
+			return "", errors.New("sentinel unreachable")
+		},
+	}
+
+	result, err := r.reconcileRedis(context.Background(), newSentinelReplicationInstanceForTest())
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.False(t, sentinelCalled)
+}
+
+// The recorded master was lost, Sentinel promoted the other pod, and the old
+// master is back as an empty standalone master before the promotion was ever
+// recorded. Two replica-less masters and a stale Status.MasterNode are exactly
+// what the bootstrap election would resolve the wrong way round; Sentinel's
+// pick takes precedence so the returning pod is attached under the promoted one.
+func TestReconcileRedisAttachesReturningMasterUnderTheMasterSentinelMonitors(t *testing.T) {
+	var gotPods []string
+	var gotMaster, gotSentinelMaster string
+	r := &Reconciler{
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0", "example-replication-1"}, nil, nil),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		CreateRedisReplicationLink: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, pods []string, realMaster string) error {
+			gotPods = append([]string{}, pods...)
+			gotMaster = realMaster
+			return nil
+		},
+		ConfigureSentinel: func(_ context.Context, _ *rrvb2.RedisReplication, master string) error {
+			gotSentinelMaster = master
+			return nil
+		},
+		SentinelMonitoredMaster: sentinelMonitoring("example-replication-1"),
+	}
+	instance := newSentinelReplicationInstanceForTest()
+	instance.Spec.Size = ptr.To(int32(2))
+	instance.Status.MasterNode = "example-replication-0"
+
+	result, err := r.reconcileRedis(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.ElementsMatch(t, []string{"example-replication-0", "example-replication-1"}, gotPods)
+	assert.Equal(t, "example-replication-1", gotMaster)
+	assert.Equal(t, "example-replication-1", gotSentinelMaster)
+}
+
+// With every pod observed a lone master is conclusive on its own.
+func TestReconcileRedisConfiguresSentinelForLoneMasterWhenTopologyIsComplete(t *testing.T) {
+	sentinelCalled := false
+	var gotMaster string
+	r := &Reconciler{
+		StatefulSet:              &fakeStatefulSetService{},
+		K8sClient:                fake.NewSimpleClientset(),
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, []string{"example-replication-0", "example-replication-2"}, nil),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
@@ -223,12 +336,10 @@ func TestReconcileStatusKeepsLastKnownMasterWhenNoMasterIsObserved(t *testing.T)
 	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
 
 	r := &Reconciler{
-		Client:    ctrlClient,
-		K8sClient: fake.NewSimpleClientset(),
-		Healer:    &fakeHealer{},
-		RedisNodesByRole: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, string) ([]string, error) {
-			return nil, nil
-		},
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf(nil, nil, []string{"example-replication-0", "example-replication-1", "example-replication-2"}),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
@@ -245,7 +356,8 @@ func TestReconcileStatusKeepsLastKnownMasterWhenNoMasterIsObserved(t *testing.T)
 }
 
 // ... but a real promotion is still recorded, so the guard cannot pin the status
-// to a master that has been replaced.
+// to a master that has been replaced. Here the old master has rejoined as a
+// replica, so every pod is observed and the lone master is conclusive.
 func TestReconcileStatusUpdatesMasterWhenANewMasterIsObserved(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, rrvb2.AddToScheme(scheme))
@@ -262,15 +374,10 @@ func TestReconcileStatusUpdatesMasterWhenANewMasterIsObserved(t *testing.T) {
 	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
 
 	r := &Reconciler{
-		Client:    ctrlClient,
-		K8sClient: fake.NewSimpleClientset(),
-		Healer:    &fakeHealer{},
-		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
-			if role == "master" {
-				return []string{"example-replication-1"}, nil
-			}
-			return nil, nil
-		},
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, []string{"example-replication-0", "example-replication-2"}, nil),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
 		},
@@ -284,6 +391,609 @@ func TestReconcileStatusUpdatesMasterWhenANewMasterIsObserved(t *testing.T) {
 	updated := &rrvb2.RedisReplication{}
 	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
 	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
+}
+
+// A promotion is also recorded while the old master is still unobserved, as
+// long as the promoted pod shows attached replicas; the role labels are
+// refreshed in the same pass, so one unreachable pod never stalls them.
+func TestReconcileStatusUpdatesMasterWhenANewMasterWithAttachedReplicasIsObservedInAnIncompleteTopology(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	healer := &fakeHealer{}
+	r := &Reconciler{
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   healer,
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, []string{"example-replication-2"}, []string{"example-replication-0"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return "example-replication-1"
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.True(t, healer.updateCalled)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
+}
+
+// The master is unreachable and a recreated replica answers as a standalone
+// master with no replicas. It is the only master observed, but recording it
+// would make every later bootstrap election attach the real master under an
+// empty node.
+func TestReconcileStatusKeepsLastKnownMasterWhenOnlyAStandaloneMasterIsObserved(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance func() *rrvb2.RedisReplication
+	}{
+		{
+			name:     "without sentinel the standalone pod is not the recorded master",
+			instance: newReplicationInstanceForTest,
+		},
+		{
+			name:     "with sentinel the standalone pod is not the monitored master",
+			instance: newSentinelReplicationInstanceForTest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, rrvb2.AddToScheme(scheme))
+
+			seedInstance := tt.instance()
+			seedInstance.Status.MasterNode = "example-replication-0"
+			ctrlClient := clientfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(seedInstance).
+				WithObjects(seedInstance.DeepCopy()).
+				Build()
+
+			instance := &rrvb2.RedisReplication{}
+			require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+			healer := &fakeHealer{}
+			r := &Reconciler{
+				Client:                   ctrlClient,
+				K8sClient:                fake.NewSimpleClientset(),
+				Healer:                   healer,
+				RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, []string{"example-replication-2"}, []string{"example-replication-0"}),
+				RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+					return ""
+				},
+				SentinelMonitoredMaster: sentinelMonitoring(""),
+			}
+
+			result, err := r.reconcileStatus(context.Background(), instance)
+
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+			assert.True(t, healer.updateCalled)
+
+			updated := &rrvb2.RedisReplication{}
+			require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+			assert.Equal(t, "example-replication-0", updated.Status.MasterNode)
+		})
+	}
+}
+
+// A two-pod replication lost its master and Sentinel promoted the survivor. It
+// has no replica to prove itself with, so Sentinel's word is what records it.
+func TestReconcileStatusRecordsPromotedMasterReportedBySentinel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newSentinelReplicationInstanceForTest()
+	seedInstance.Spec.Size = ptr.To(int32(2))
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, nil, []string{"example-replication-0"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+		SentinelMonitoredMaster: sentinelMonitoring("example-replication-1"),
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
+}
+
+// A fresh replication has no recorded master to fall back on. Until every pod
+// is observed, a lone standalone master is still only a candidate.
+func TestReconcileStatusLeavesMasterUnsetWhenOnlyAStandaloneMasterIsObservedDuringBootstrap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0"}, nil, []string{"example-replication-1", "example-replication-2"}),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Empty(t, updated.Status.MasterNode)
+}
+
+// The rule itself, branch by branch, including which checks settle the answer
+// before Sentinel has to be asked.
+func TestObservedRedisReplicationMaster(t *testing.T) {
+	const (
+		pod0 = "example-replication-0"
+		pod1 = "example-replication-1"
+		pod2 = "example-replication-2"
+	)
+	tests := []struct {
+		name           string
+		sentinel       bool
+		recorded       string
+		topology       k8sutils.RedisReplicationTopology
+		realMaster     string
+		sentinelMaster string
+		sentinelErr    error
+		wantMaster     string
+		wantConfirmed  bool
+		wantAsked      bool
+	}{
+		{
+			name:     "no master observed",
+			topology: k8sutils.RedisReplicationTopology{Slaves: []string{pod1, pod2}, Unobserved: []string{pod0}},
+		},
+		{
+			name:          "lone master in a complete topology",
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Slaves: []string{pod0, pod2}},
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:          "lone master with attached replicas in a partial view",
+			recorded:      pod0,
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Slaves: []string{pod2}, Unobserved: []string{pod0}},
+			realMaster:    pod1,
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:          "without sentinel the recorded master is still the master",
+			recorded:      pod0,
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod0}, Unobserved: []string{pod1, pod2}},
+			wantMaster:    pod0,
+			wantConfirmed: true,
+		},
+		{
+			name:     "without sentinel a standalone pod that is not the recorded master is a candidate only",
+			recorded: pod0,
+			topology: k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Slaves: []string{pod2}, Unobserved: []string{pod0}},
+		},
+		{
+			name:     "without sentinel a standalone pod during bootstrap is a candidate only",
+			topology: k8sutils.RedisReplicationTopology{Masters: []string{pod0}, Unobserved: []string{pod1, pod2}},
+		},
+		{
+			name:          "with sentinel a complete topology is conclusive without asking",
+			sentinel:      true,
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Slaves: []string{pod0, pod2}},
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:          "with sentinel attached replicas settle it without asking",
+			sentinel:      true,
+			recorded:      pod0,
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Slaves: []string{pod2}, Unobserved: []string{pod0}},
+			realMaster:    pod1,
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:           "with sentinel the pod sentinel monitors is the master",
+			sentinel:       true,
+			recorded:       pod0,
+			topology:       k8sutils.RedisReplicationTopology{Masters: []string{pod1}, Unobserved: []string{pod0}},
+			sentinelMaster: pod1,
+			wantMaster:     pod1,
+			wantConfirmed:  true,
+			wantAsked:      true,
+		},
+		{
+			// The recorded master was replaced by a failover this controller
+			// never saw and came back as an empty standalone master; being
+			// recorded proves nothing under Sentinel.
+			name:      "with sentinel the recorded master proves nothing on its own",
+			sentinel:  true,
+			recorded:  pod0,
+			topology:  k8sutils.RedisReplicationTopology{Masters: []string{pod0}, Slaves: []string{pod1}, Unobserved: []string{pod2}},
+			wantAsked: true,
+		},
+		{
+			name:        "with sentinel an unanswered question leaves the candidate unconfirmed",
+			sentinel:    true,
+			recorded:    pod0,
+			topology:    k8sutils.RedisReplicationTopology{Masters: []string{pod0}, Unobserved: []string{pod1, pod2}},
+			sentinelErr: errors.New("sentinel unreachable"),
+			wantAsked:   true,
+		},
+		{
+			name:          "several masters resolve through attached replicas",
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1}, Slaves: []string{pod2}},
+			realMaster:    pod1,
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:     "several masters without replicas are unresolved",
+			recorded: pod0,
+			topology: k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1, pod2}},
+		},
+		{
+			name:          "with sentinel several masters with replicas settle without asking",
+			sentinel:      true,
+			topology:      k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1}, Slaves: []string{pod2}},
+			realMaster:    pod1,
+			wantMaster:    pod1,
+			wantConfirmed: true,
+		},
+		{
+			name:           "with sentinel several replica-less masters resolve through sentinel",
+			sentinel:       true,
+			recorded:       pod0,
+			topology:       k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1}},
+			sentinelMaster: pod1,
+			wantMaster:     pod1,
+			wantConfirmed:  true,
+			wantAsked:      true,
+		},
+		{
+			name:      "with sentinel several replica-less masters stay unresolved when sentinel monitors none of them",
+			sentinel:  true,
+			recorded:  pod0,
+			topology:  k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1}, Unobserved: []string{pod2}},
+			wantAsked: true,
+		},
+		{
+			name:        "with sentinel several replica-less masters stay unresolved when sentinel cannot be asked",
+			sentinel:    true,
+			recorded:    pod0,
+			topology:    k8sutils.RedisReplicationTopology{Masters: []string{pod0, pod1}},
+			sentinelErr: errors.New("sentinel unreachable"),
+			wantAsked:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sentinelAsked := false
+			r := &Reconciler{
+				K8sClient: fake.NewSimpleClientset(),
+				RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+					return tt.realMaster
+				},
+				SentinelMonitoredMaster: func(_ context.Context, _ *rrvb2.RedisReplication, candidates []string) (string, error) {
+					sentinelAsked = true
+					assert.Equal(t, tt.topology.Masters, candidates)
+					return tt.sentinelMaster, tt.sentinelErr
+				},
+			}
+			instance := newReplicationInstanceForTest()
+			if tt.sentinel {
+				instance = newSentinelReplicationInstanceForTest()
+			}
+			instance.Status.MasterNode = tt.recorded
+
+			master, confirmed := r.observedRedisReplicationMaster(context.Background(), instance, tt.topology)
+
+			assert.Equal(t, tt.wantMaster, master)
+			assert.Equal(t, tt.wantConfirmed, confirmed)
+			assert.Equal(t, master != "", confirmed, "a master is returned exactly when it is confirmed")
+			assert.Equal(t, tt.wantAsked, sentinelAsked, "sentinel is asked only when completeness and attached replicas cannot settle it")
+		})
+	}
+}
+
+func TestQuerySentinelMonitoredMaster(t *testing.T) {
+	const (
+		pod0 = "example-replication-0"
+		pod1 = "example-replication-1"
+	)
+	instance := newSentinelReplicationInstanceForTest()
+	pod1Hostname := replicationPodHostname(instance, pod1)
+
+	tests := []struct {
+		name         string
+		candidates   []string
+		pod1IP       string
+		sentinelInfo map[string]*redis.InfoSentinelResult
+		sentinelErr  map[string]error
+		want         string
+	}{
+		{
+			name:       "a quorum reports the candidate by IP",
+			candidates: []string{pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.12": sentinelInfoMonitoring("10.0.0.10:6379"),
+			},
+			want: pod1,
+		},
+		{
+			name:       "a single sentinel is not a quorum",
+			candidates: []string{pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("10.0.0.10:6379"),
+				"10.0.1.12": sentinelInfoMonitoring("10.0.0.10:6379"),
+			},
+			want: "",
+		},
+		{
+			name:       "a quorum reports the candidate by hostname",
+			candidates: []string{pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring(pod1Hostname + ":6379"),
+				"10.0.1.11": sentinelInfoMonitoring(pod1Hostname + ":6379"),
+				"10.0.1.12": sentinelInfoMonitoring(pod1Hostname + ":6379"),
+			},
+			want: pod1,
+		},
+		{
+			// INFO sentinel prints IPv6 addresses without brackets.
+			name:       "a quorum reports the candidate by unbracketed IPv6",
+			candidates: []string{pod1},
+			pod1IP:     "fd00::11",
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("fd00::11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("fd00::11:6379"),
+				"10.0.1.12": sentinelInfoMonitoring("fd00::11:6379"),
+			},
+			want: pod1,
+		},
+		{
+			name:       "another master group is ignored",
+			candidates: []string{pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": {Masters: []redis.SentinelMasterInfo{{Name: "othermaster", Address: "10.0.0.11:6379"}}},
+				"10.0.1.11": {Masters: []redis.SentinelMasterInfo{{Name: "othermaster", Address: "10.0.0.11:6379"}}},
+				"10.0.1.12": {Masters: []redis.SentinelMasterInfo{{Name: "othermaster", Address: "10.0.0.11:6379"}}},
+			},
+			want: "",
+		},
+		{
+			name:       "an unreachable sentinel is skipped and the rest can still form a quorum",
+			candidates: []string{pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("10.0.0.11:6379"),
+			},
+			sentinelErr: map[string]error{"10.0.1.12": errors.New("dial tcp: i/o timeout")},
+			want:        pod1,
+		},
+		{
+			name:       "among several candidates the one with a quorum is returned",
+			candidates: []string{pod0, pod1},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.12": sentinelInfoMonitoring("10.0.0.10:6379"),
+			},
+			want: pod1,
+		},
+		{
+			name:       "a monitored pod that is not a candidate elects nobody",
+			candidates: []string{pod0},
+			sentinelInfo: map[string]*redis.InfoSentinelResult{
+				"10.0.1.10": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.11": sentinelInfoMonitoring("10.0.0.11:6379"),
+				"10.0.1.12": sentinelInfoMonitoring("10.0.0.11:6379"),
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod1IP := tt.pod1IP
+			if pod1IP == "" {
+				pod1IP = "10.0.0.11"
+			}
+			objects := []runtime.Object{
+				newRunningPodForTest(instance.Namespace, pod0, "10.0.0.10", nil, true),
+				newRunningPodForTest(instance.Namespace, pod1, pod1IP, nil, true),
+			}
+			sentinelLabels := common.GetRedisLabels(instance.SentinelStatefulSet(), common.SetupTypeSentinel, "sentinel", instance.GetLabels())
+			for i, ip := range []string{"10.0.1.10", "10.0.1.11", "10.0.1.12"} {
+				objects = append(objects, newRunningPodForTest(instance.Namespace, fmt.Sprintf("%s-%d", instance.SentinelStatefulSet(), i), ip, sentinelLabels, true))
+			}
+			// A sentinel pod that is not Ready is never asked.
+			objects = append(objects, newRunningPodForTest(instance.Namespace, instance.SentinelStatefulSet()+"-3", "10.0.1.13", sentinelLabels, false))
+
+			redisClient := &fakeSentinelInfoClient{infoByHost: tt.sentinelInfo, errByHost: tt.sentinelErr}
+			r := &Reconciler{K8sClient: fake.NewSimpleClientset(objects...)}
+
+			got, err := r.querySentinelMonitoredMaster(context.Background(), redisClient, instance, tt.candidates)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.ElementsMatch(t, []string{"10.0.1.10", "10.0.1.11", "10.0.1.12"}, redisClient.connectedHosts)
+		})
+	}
+}
+
+func TestQuerySentinelMonitoredMasterFailsWhenACandidateCannotBeFetched(t *testing.T) {
+	r := &Reconciler{K8sClient: fake.NewSimpleClientset()}
+
+	_, err := r.querySentinelMonitoredMaster(context.Background(), &fakeSentinelInfoClient{}, newSentinelReplicationInstanceForTest(), []string{"example-replication-1"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "example-replication-1")
+}
+
+func TestSentinelAddressHost(t *testing.T) {
+	tests := map[string]string{
+		"10.0.0.11:6379":  "10.0.0.11",
+		"fd00::11:6379":   "fd00::11",
+		"[fd00::11]:6379": "fd00::11",
+		"example-replication-1.example-replication-headless.default.svc.cluster.local:6379": "example-replication-1.example-replication-headless.default.svc.cluster.local",
+		"10.0.0.11": "10.0.0.11",
+	}
+	for address, want := range tests {
+		assert.Equal(t, want, sentinelAddressHost(address), address)
+	}
+}
+
+func sentinelInfoMonitoring(address string) *redis.InfoSentinelResult {
+	return &redis.InfoSentinelResult{
+		Masters: []redis.SentinelMasterInfo{{Name: masterGroupName, Status: "ok", Address: address, Slaves: 1, Sentinels: 3}},
+	}
+}
+
+// sentinelMonitoring stands in for a Sentinel quorum that monitors master, or
+// nobody when master is empty; it only ever answers with one of the candidates.
+func sentinelMonitoring(master string) func(context.Context, *rrvb2.RedisReplication, []string) (string, error) {
+	return func(_ context.Context, _ *rrvb2.RedisReplication, candidates []string) (string, error) {
+		for _, candidate := range candidates {
+			if candidate == master {
+				return master, nil
+			}
+		}
+		return "", nil
+	}
+}
+
+func newRunningPodForTest(namespace, name, podIP string, labels map[string]string, ready bool) *corev1.Pod {
+	readyStatus := corev1.ConditionFalse
+	if ready {
+		readyStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			PodIP:      podIP,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}},
+		},
+	}
+}
+
+type fakeSentinelInfoClient struct {
+	connectedHosts []string
+	infoByHost     map[string]*redis.InfoSentinelResult
+	errByHost      map[string]error
+}
+
+func (f *fakeSentinelInfoClient) Connect(info *redis.ConnectionInfo) redis.Service {
+	f.connectedHosts = append(f.connectedHosts, info.Host)
+	return &fakeSentinelInfoService{info: f.infoByHost[info.Host], err: f.errByHost[info.Host]}
+}
+
+type fakeSentinelInfoService struct {
+	info *redis.InfoSentinelResult
+	err  error
+}
+
+func (f *fakeSentinelInfoService) IsMaster(context.Context) (bool, error) { return false, nil }
+
+func (f *fakeSentinelInfoService) GetAttachedReplicaCount(context.Context) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeSentinelInfoService) SentinelMonitor(context.Context, *redis.ConnectionInfo, string, string) error {
+	return nil
+}
+
+func (f *fakeSentinelInfoService) SentinelSet(context.Context, string, string, string) error {
+	return nil
+}
+
+func (f *fakeSentinelInfoService) SentinelReset(context.Context, string) error { return nil }
+
+func (f *fakeSentinelInfoService) GetInfoSentinel(context.Context) (*redis.InfoSentinelResult, error) {
+	return f.info, f.err
+}
+
+func (f *fakeSentinelInfoService) GetClusterInfo(context.Context) (*redis.ClusterStatus, error) {
+	return &redis.ClusterStatus{}, nil
+}
+
+func TestReconcileStatusRequeuesWhenTopologyCannotBeObserved(t *testing.T) {
+	healer := &fakeHealer{}
+	r := &Reconciler{
+		K8sClient: fake.NewSimpleClientset(),
+		Healer:    healer,
+		RedisReplicationTopology: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication) (k8sutils.RedisReplicationTopology, error) {
+			return k8sutils.RedisReplicationTopology{}, context.Canceled
+		},
+	}
+
+	_, err := r.reconcileStatus(context.Background(), newReplicationInstanceForTest())
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, healer.updateCalled)
+}
+
+// topologyOf stands in for a role sweep that observed the given masters and
+// slaves and could not observe the remaining pods.
+func topologyOf(masters, slaves, unobserved []string) func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication) (k8sutils.RedisReplicationTopology, error) {
+	return func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication) (k8sutils.RedisReplicationTopology, error) {
+		return k8sutils.RedisReplicationTopology{
+			Masters:    masters,
+			Slaves:     slaves,
+			Unobserved: unobserved,
+		}, nil
+	}
 }
 
 func newReplicationInstanceForTest() *rrvb2.RedisReplication {

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -318,6 +318,81 @@ func TestReconcileRedisConfiguresSentinelForLoneMasterWhenTopologyIsComplete(t *
 	assert.Equal(t, "example-replication-1", gotMaster)
 }
 
+// Every pod answered and every one of them is a replica: there is no master,
+// and the recorded one is provably not it. Keeping it would feed a stale name
+// to the bootstrap election and the sentinel controller's fallback.
+func TestReconcileStatusClearsMasterWhenEveryPodReportsSlave(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf(nil, []string{"example-replication-0", "example-replication-1", "example-replication-2"}, nil),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Empty(t, updated.Status.MasterNode)
+}
+
+// Several masters that cannot be told apart are an ambiguous view, not an
+// absent master, so the recorded master survives it.
+func TestReconcileStatusKeepsLastKnownMasterWhenMastersCannotBeToldApart(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:                   ctrlClient,
+		K8sClient:                fake.NewSimpleClientset(),
+		Healer:                   &fakeHealer{},
+		RedisReplicationTopology: topologyOf([]string{"example-replication-0", "example-replication-1", "example-replication-2"}, nil, nil),
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-0", updated.Status.MasterNode)
+}
+
 // A probe blip that hides every master must not clear the recorded master: both
 // this controller and the sentinel controller fall back to Status.MasterNode.
 func TestReconcileStatusKeepsLastKnownMasterWhenNoMasterIsObserved(t *testing.T) {
@@ -485,6 +560,9 @@ func TestReconcileStatusKeepsLastKnownMasterWhenOnlyAStandaloneMasterIsObserved(
 			require.NoError(t, err)
 			assert.Equal(t, ctrl.Result{}, result)
 			assert.True(t, healer.updateCalled)
+			// The kept Status.MasterNode is a fallback, not an identification; the
+			// healer must not take it as proof against other master labels.
+			assert.Empty(t, healer.master)
 
 			updated := &rrvb2.RedisReplication{}
 			require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
@@ -511,10 +589,11 @@ func TestReconcileStatusRecordsPromotedMasterReportedBySentinel(t *testing.T) {
 	instance := &rrvb2.RedisReplication{}
 	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
 
+	healer := &fakeHealer{}
 	r := &Reconciler{
 		Client:                   ctrlClient,
 		K8sClient:                fake.NewSimpleClientset(),
-		Healer:                   &fakeHealer{},
+		Healer:                   healer,
 		RedisReplicationTopology: topologyOf([]string{"example-replication-1"}, nil, []string{"example-replication-0"}),
 		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
 			return ""
@@ -526,6 +605,9 @@ func TestReconcileStatusRecordsPromotedMasterReportedBySentinel(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
+	// The healer is told which pod is the master, so it can drop the lost
+	// master's label even though the survivor has no replicas to show.
+	assert.Equal(t, "example-replication-1", healer.master)
 
 	updated := &rrvb2.RedisReplication{}
 	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
@@ -1030,6 +1112,7 @@ func (f *fakeStatefulSetService) GetStatefulSetReplicas(context.Context, string,
 
 type fakeHealer struct {
 	updateCalled bool
+	master       string
 }
 
 func (f *fakeHealer) SentinelMonitor(context.Context, *rsvb2.RedisSentinel, string) error {
@@ -1044,7 +1127,8 @@ func (f *fakeHealer) SentinelReset(context.Context, *rsvb2.RedisSentinel) error 
 	return nil
 }
 
-func (f *fakeHealer) UpdateRedisRoleLabel(context.Context, string, map[string]string, *commonapi.ExistingPasswordSecret, *commonapi.TLSConfig) error {
+func (f *fakeHealer) UpdateRedisRoleLabel(_ context.Context, _ string, _ map[string]string, _ *commonapi.ExistingPasswordSecret, _ *commonapi.TLSConfig, masterPod string) error {
 	f.updateCalled = true
+	f.master = masterPod
 	return nil
 }

--- a/internal/controller/redisreplication/redisreplication_controller_unit_test.go
+++ b/internal/controller/redisreplication/redisreplication_controller_unit_test.go
@@ -205,6 +205,87 @@ func TestReconcileRedisConfiguresSentinelForSingleObservedMaster(t *testing.T) {
 	assert.Equal(t, "example-replication-1", gotMaster)
 }
 
+// A probe blip that hides every master must not clear the recorded master: both
+// this controller and the sentinel controller fall back to Status.MasterNode.
+func TestReconcileStatusKeepsLastKnownMasterWhenNoMasterIsObserved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:    ctrlClient,
+		K8sClient: fake.NewSimpleClientset(),
+		Healer:    &fakeHealer{},
+		RedisNodesByRole: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, string) ([]string, error) {
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-0", updated.Status.MasterNode)
+}
+
+// ... but a real promotion is still recorded, so the guard cannot pin the status
+// to a master that has been replaced.
+func TestReconcileStatusUpdatesMasterWhenANewMasterIsObserved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, rrvb2.AddToScheme(scheme))
+
+	seedInstance := newReplicationInstanceForTest()
+	seedInstance.Status.MasterNode = "example-replication-0"
+	ctrlClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(seedInstance).
+		WithObjects(seedInstance.DeepCopy()).
+		Build()
+
+	instance := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(seedInstance), instance))
+
+	r := &Reconciler{
+		Client:    ctrlClient,
+		K8sClient: fake.NewSimpleClientset(),
+		Healer:    &fakeHealer{},
+		RedisNodesByRole: func(_ context.Context, _ kubernetes.Interface, _ *rrvb2.RedisReplication, role string) ([]string, error) {
+			if role == "master" {
+				return []string{"example-replication-1"}, nil
+			}
+			return nil, nil
+		},
+		RedisReplicationRealMaster: func(context.Context, kubernetes.Interface, *rrvb2.RedisReplication, []string) string {
+			return ""
+		},
+	}
+
+	result, err := r.reconcileStatus(context.Background(), instance)
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &rrvb2.RedisReplication{}
+	require.NoError(t, ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(instance), updated))
+	assert.Equal(t, "example-replication-1", updated.Status.MasterNode)
+}
+
 func newReplicationInstanceForTest() *rrvb2.RedisReplication {
 	size := int32(3)
 	return &rrvb2.RedisReplication{

--- a/internal/controller/redisreplication/redisreplication_sentinel.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel.go
@@ -1,15 +1,22 @@
 package redisreplication
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"strings"
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common/statefulset"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func newSentinelService(rr *rrvb2.RedisReplication) corev1.Service {
@@ -156,4 +163,112 @@ func resolveHostnamesOrDefault(v string) string {
 		return "no"
 	}
 	return v
+}
+
+func (r *Reconciler) sentinelMonitoredMaster(ctx context.Context, inst *rrvb2.RedisReplication, candidates []string) (string, error) {
+	if r.SentinelMonitoredMaster != nil {
+		return r.SentinelMonitoredMaster(ctx, inst, candidates)
+	}
+	return r.querySentinelMonitoredMaster(ctx, redis.NewClient(), inst, candidates)
+}
+
+func (r *Reconciler) querySentinelMonitoredMaster(ctx context.Context, redisClient redis.Client, inst *rrvb2.RedisReplication, candidates []string) (string, error) {
+	// Sentinel reports the master by IP, or by hostname when hostnames are announced.
+	podByAddress := make(map[string]string, 2*len(candidates))
+	for _, podName := range candidates {
+		pod, err := r.K8sClient.CoreV1().Pods(inst.Namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("get pod %s: %w", podName, err)
+		}
+		podByAddress[replicationPodHostname(inst, podName)] = podName
+		if pod.Status.PodIP != "" {
+			podByAddress[pod.Status.PodIP] = podName
+		}
+	}
+
+	sentinelPassword, err := r.sentinelPassword(ctx, inst)
+	if err != nil {
+		return "", fmt.Errorf("get sentinel password secret: %w", err)
+	}
+	sentinelPods, err := r.getSentinelPods(ctx, inst)
+	if err != nil {
+		return "", fmt.Errorf("get sentinel pods: %w", err)
+	}
+
+	votes := make(map[string]int, len(candidates))
+	for _, sentinelPod := range sentinelPods.Items {
+		if !k8sutils.IsRedisPodProbeable(&sentinelPod) {
+			continue
+		}
+		info, err := redisClient.Connect(&redis.ConnectionInfo{
+			Host:     sentinelPod.Status.PodIP,
+			Port:     "26379",
+			Password: sentinelPassword,
+		}).GetInfoSentinel(ctx)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			log.FromContext(ctx).V(1).Info("Failed to read sentinel info, skipping sentinel pod", "pod", sentinelPod.Name, "error", err)
+			continue
+		}
+		if podName := podByAddress[sentinelReportedMasterHost(info)]; podName != "" {
+			votes[podName]++
+		}
+	}
+
+	quorum := int(inst.Spec.Sentinel.Size/2) + 1
+	for _, podName := range candidates {
+		if votes[podName] >= quorum {
+			return podName, nil
+		}
+	}
+	return "", nil
+}
+
+func sentinelReportedMasterHost(info *redis.InfoSentinelResult) string {
+	if info == nil {
+		return ""
+	}
+	for _, master := range info.Masters {
+		if master.Name == masterGroupName {
+			return sentinelAddressHost(master.Address)
+		}
+	}
+	return ""
+}
+
+func sentinelAddressHost(address string) string {
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		return host
+	}
+	if i := strings.LastIndex(address, ":"); i >= 0 {
+		return strings.Trim(address[:i], "[]")
+	}
+	return address
+}
+
+func (r *Reconciler) sentinelPassword(ctx context.Context, inst *rrvb2.RedisReplication) (string, error) {
+	if inst.Spec.Sentinel.ExistingPasswordSecret == nil {
+		return "", nil
+	}
+	secret, err := r.K8sClient.CoreV1().Secrets(inst.Namespace).Get(
+		ctx,
+		*inst.Spec.Sentinel.ExistingPasswordSecret.Name,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(secret.Data[*inst.Spec.Sentinel.ExistingPasswordSecret.Key]), nil
+}
+
+func replicationPodHostname(inst *rrvb2.RedisReplication, podName string) string {
+	return fmt.Sprintf(
+		"%s.%s.%s.svc.%s",
+		podName,
+		common.GetHeadlessServiceNameFromPodName(podName),
+		inst.Namespace,
+		envs.GetServiceDNSDomain(),
+	)
 }

--- a/internal/k8sutils/redis-replication-topology.go
+++ b/internal/k8sutils/redis-replication-topology.go
@@ -1,0 +1,121 @@
+package k8sutils
+
+import (
+	"context"
+	"strconv"
+
+	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	redisRoleMaster = "master"
+	redisRoleSlave  = "slave"
+)
+
+type RedisReplicationTopology struct {
+	Masters []string
+	Slaves  []string
+	// Unobserved holds pods whose role could not be determined (missing, not ready, or probe failed).
+	// Masters and Slaves may be incomplete when this is non-empty.
+	Unobserved []string
+}
+
+func (t RedisReplicationTopology) Complete() bool {
+	return len(t.Unobserved) == 0
+}
+
+func (t RedisReplicationTopology) Observed() int {
+	return len(t.Masters) + len(t.Slaves)
+}
+
+// GetRedisReplicationTopology probes every replication pod for its role.
+// Pods that cannot be probed are reported in Unobserved instead of failing
+// the whole sweep, so a single crashed pod does not block reconciliation.
+func GetRedisReplicationTopology(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication) (RedisReplicationTopology, error) {
+	return getRedisReplicationTopology(ctx, cl, cr, func(ctx context.Context, pod *corev1.Pod) (string, error) {
+		redisClient := configureRedisReplicationClientForPod(ctx, cl, cr, pod)
+		defer redisClient.Close()
+
+		return checkRedisServerRole(ctx, redisClient, pod.Name)
+	})
+}
+
+// GetRedisNodesByRole returns the pods with the given role ("master" or "slave").
+// Unobserved pods are excluded; use GetRedisReplicationTopology if you need to
+// know whether the view is complete.
+func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string) ([]string, error) {
+	topology, err := GetRedisReplicationTopology(ctx, cl, cr)
+	if err != nil {
+		return nil, err
+	}
+	return topology.byRole(redisRole), nil
+}
+
+func (t RedisReplicationTopology) byRole(redisRole string) []string {
+	switch redisRole {
+	case redisRoleMaster:
+		return t.Masters
+	case redisRoleSlave:
+		return t.Slaves
+	default:
+		return nil
+	}
+}
+
+func getRedisReplicationTopology(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, probeRole func(context.Context, *corev1.Pod) (string, error)) (RedisReplicationTopology, error) {
+	var topology RedisReplicationTopology
+
+	statefulset, err := GetStatefulSet(ctx, cl, cr.GetNamespace(), cr.GetName())
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to Get the Statefulset of the", "custom resource", cr.Name, "in namespace", cr.Namespace)
+		return RedisReplicationTopology{}, err
+	}
+
+	replicas := cr.Spec.GetReplicationCounts("replication")
+
+	for i := 0; i < int(replicas); i++ {
+		podName := statefulset.Name + "-" + strconv.Itoa(i)
+		pod, err := cl.CoreV1().Pods(cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				topology.Unobserved = append(topology.Unobserved, podName)
+				continue
+			}
+			return RedisReplicationTopology{}, err
+		}
+
+		if !IsRedisPodProbeable(pod) {
+			log.FromContext(ctx).V(1).Info("Redis pod is not Running and Ready, skipping role probe", "pod", podName)
+			topology.Unobserved = append(topology.Unobserved, podName)
+			continue
+		}
+
+		podRole, err := probeRole(ctx, pod)
+		if err != nil {
+			// A cancelled context is not a pod-specific failure; bail out
+			// instead of reporting a partial topology as success.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return RedisReplicationTopology{}, ctxErr
+			}
+			log.FromContext(ctx).V(1).Info("Failed to probe Redis role, skipping pod", "pod", podName, "error", err)
+			topology.Unobserved = append(topology.Unobserved, podName)
+			continue
+		}
+		switch podRole {
+		case redisRoleMaster:
+			topology.Masters = append(topology.Masters, podName)
+		case redisRoleSlave:
+			topology.Slaves = append(topology.Slaves, podName)
+		default:
+			log.FromContext(ctx).Info("Redis pod reported an unknown role, skipping pod", "pod", podName, "role", podRole)
+			topology.Unobserved = append(topology.Unobserved, podName)
+		}
+	}
+
+	return topology, nil
+}

--- a/internal/k8sutils/redis-replication-topology_test.go
+++ b/internal/k8sutils/redis-replication-topology_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+	k8sTesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -56,14 +58,35 @@ func TestIsRedisPodProbeable(t *testing.T) {
 	}
 }
 
-func TestGetRedisNodesByRoleSkipsUnprobeablePods(t *testing.T) {
+// Every probe shares the reconcile context, so a cancellation fails all of them.
+// Skipping them would report a partial topology as a complete one.
+func TestGetRedisReplicationTopologyPropagatesContextCancellation(t *testing.T) {
+	client := k8sClientFake.NewSimpleClientset(
+		newRedisReplicationStatefulSet(),
+		newReadyRedisPod("example-replication-0", "10.0.0.10"),
+		newReadyRedisPod("example-replication-1", "10.0.0.11"),
+		newReadyRedisPod("example-replication-2", "10.0.0.12"),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	topology, err := getRedisReplicationTopology(ctx, client, newRedisReplication(), func(ctx context.Context, _ *corev1.Pod) (string, error) {
+		return "", ctx.Err()
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, RedisReplicationTopology{}, topology)
+}
+
+func TestGetRedisReplicationTopologyReportsUnobservedPods(t *testing.T) {
 	tests := []struct {
-		name string
-		pod  runtime.Object
+		name  string
+		pod   runtime.Object
+		probe func(pod *corev1.Pod) (string, error)
 	}{
 		{
 			name: "pod not found",
-			pod:  nil,
 		},
 		{
 			name: "pod pending",
@@ -76,6 +99,20 @@ func TestGetRedisNodesByRoleSkipsUnprobeablePods(t *testing.T) {
 		{
 			name: "pod running and ready without ip",
 			pod:  newReadyRedisPod("example-replication-2", ""),
+		},
+		{
+			name: "ready pod fails the probe",
+			pod:  newReadyRedisPod("example-replication-2", "10.0.0.12"),
+			probe: func(*corev1.Pod) (string, error) {
+				return "", errors.New("probe failed")
+			},
+		},
+		{
+			name: "ready pod reports no role",
+			pod:  newReadyRedisPod("example-replication-2", "10.0.0.12"),
+			probe: func(*corev1.Pod) (string, error) {
+				return "", nil
+			},
 		},
 	}
 
@@ -91,23 +128,29 @@ func TestGetRedisNodesByRoleSkipsUnprobeablePods(t *testing.T) {
 			}
 			client := k8sClientFake.NewSimpleClientset(objects...)
 
-			var probedPods []string
-			nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
-				probedPods = append(probedPods, pod.Name)
-				if pod.Name == "example-replication-0" {
+			topology, err := getRedisReplicationTopology(context.Background(), client, newRedisReplication(), func(_ context.Context, pod *corev1.Pod) (string, error) {
+				switch pod.Name {
+				case "example-replication-0":
 					return "master", nil
+				case "example-replication-1":
+					return "slave", nil
+				default:
+					require.NotNil(t, tt.probe, "pod %s should not have been probed", pod.Name)
+					return tt.probe(pod)
 				}
-				return "slave", nil
 			})
 
-			assert.NoError(t, err)
-			assert.Equal(t, []string{"example-replication-0"}, nodes)
-			assert.ElementsMatch(t, []string{"example-replication-0", "example-replication-1"}, probedPods)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"example-replication-0"}, topology.Masters)
+			assert.Equal(t, []string{"example-replication-1"}, topology.Slaves)
+			assert.Equal(t, []string{"example-replication-2"}, topology.Unobserved)
+			assert.False(t, topology.Complete())
+			assert.Equal(t, 2, topology.Observed())
 		})
 	}
 }
 
-func TestGetRedisNodesByRoleSkipsWhenReadyPodProbeFails(t *testing.T) {
+func TestGetRedisReplicationTopologyIsCompleteWhenEveryPodAnswers(t *testing.T) {
 	client := k8sClientFake.NewSimpleClientset(
 		newRedisReplicationStatefulSet(),
 		newReadyRedisPod("example-replication-0", "10.0.0.10"),
@@ -115,58 +158,56 @@ func TestGetRedisNodesByRoleSkipsWhenReadyPodProbeFails(t *testing.T) {
 		newReadyRedisPod("example-replication-2", "10.0.0.12"),
 	)
 
-	nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
-		if pod.Name == "example-replication-0" {
-			return "master", nil
-		}
+	topology, err := getRedisReplicationTopology(context.Background(), client, newRedisReplication(), func(_ context.Context, pod *corev1.Pod) (string, error) {
 		if pod.Name == "example-replication-1" {
-			return "", errors.New("probe failed")
-		}
-		return "slave", nil
-	})
-
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"example-replication-0"}, nodes)
-}
-
-// Every probe shares the reconcile context, so a cancellation fails all of them.
-// Skipping them would report a partial topology as a complete one.
-func TestGetRedisNodesByRolePropagatesContextCancellation(t *testing.T) {
-	client := k8sClientFake.NewSimpleClientset(
-		newRedisReplicationStatefulSet(),
-		newReadyRedisPod("example-replication-0", "10.0.0.10"),
-		newReadyRedisPod("example-replication-1", "10.0.0.11"),
-		newReadyRedisPod("example-replication-2", "10.0.0.12"),
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	nodes, err := getRedisNodesByRole(ctx, client, newRedisReplication(), "master", func(ctx context.Context, _ *corev1.Pod) (string, error) {
-		return "", ctx.Err()
-	})
-
-	require.ErrorIs(t, err, context.Canceled)
-	assert.Empty(t, nodes)
-}
-
-func TestGetRedisNodesByRoleCompleteTopology(t *testing.T) {
-	client := k8sClientFake.NewSimpleClientset(
-		newRedisReplicationStatefulSet(),
-		newReadyRedisPod("example-replication-0", "10.0.0.10"),
-		newReadyRedisPod("example-replication-1", "10.0.0.11"),
-		newReadyRedisPod("example-replication-2", "10.0.0.12"),
-	)
-
-	nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "slave", func(_ context.Context, pod *corev1.Pod) (string, error) {
-		if pod.Name == "example-replication-0" {
 			return "master", nil
 		}
 		return "slave", nil
 	})
 
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []string{"example-replication-1", "example-replication-2"}, nodes)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"example-replication-1"}, topology.Masters)
+	assert.Equal(t, []string{"example-replication-0", "example-replication-2"}, topology.Slaves)
+	assert.Empty(t, topology.Unobserved)
+	assert.True(t, topology.Complete())
+	assert.Equal(t, 3, topology.Observed())
+}
+
+// Only NotFound is a fact about the pod; any other API failure is a failure of
+// the sweep and must not be reported as a partial topology.
+func TestGetRedisReplicationTopologyFailsWhenPodCannotBeFetched(t *testing.T) {
+	client := k8sClientFake.NewSimpleClientset(
+		newRedisReplicationStatefulSet(),
+		newReadyRedisPod("example-replication-0", "10.0.0.10"),
+		newReadyRedisPod("example-replication-1", "10.0.0.11"),
+		newReadyRedisPod("example-replication-2", "10.0.0.12"),
+	)
+	client.PrependReactor("get", "pods", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+		if action.(k8sTesting.GetAction).GetName() == "example-replication-1" {
+			return true, nil, apierrors.NewInternalError(errors.New("etcd unavailable"))
+		}
+		return false, nil, nil
+	})
+
+	topology, err := getRedisReplicationTopology(context.Background(), client, newRedisReplication(), func(context.Context, *corev1.Pod) (string, error) {
+		return "master", nil
+	})
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsInternalError(err))
+	assert.Equal(t, RedisReplicationTopology{}, topology)
+}
+
+func TestRedisReplicationTopologyByRole(t *testing.T) {
+	topology := RedisReplicationTopology{
+		Masters:    []string{"example-replication-1"},
+		Slaves:     []string{"example-replication-0", "example-replication-2"},
+		Unobserved: []string{"example-replication-3"},
+	}
+
+	assert.Equal(t, []string{"example-replication-1"}, topology.byRole("master"))
+	assert.Equal(t, []string{"example-replication-0", "example-replication-2"}, topology.byRole("slave"))
+	assert.Nil(t, topology.byRole("sentinel"))
 }
 
 func newRedisReplication() *rrvb2.RedisReplication {

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -934,7 +934,8 @@ func getRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 
 		podRole, err := probeRole(ctx, pod)
 		if err != nil {
-			return nil, err
+			log.FromContext(ctx).Error(err, "Failed to probe Redis role, skipping pod", "pod", podName)
+			continue
 		}
 		if podRole == redisRole {
 			pods = append(pods, podName)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -1046,7 +1046,8 @@ func getRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 
 		podRole, err := probeRole(ctx, pod)
 		if err != nil {
-			return nil, err
+			log.FromContext(ctx).Error(err, "Failed to probe Redis role, skipping pod", "pod", podName)
+			continue
 		}
 		if podRole == redisRole {
 			pods = append(pods, podName)

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -23,7 +23,6 @@ import (
 	redis "github.com/redis/go-redis/v9"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1008,60 +1007,6 @@ func formatRedisAddress(ip string, port int) string {
 
 func getRedisReplicationHostname(redisInfo RedisDetails, cr *rrvb2.RedisReplication) string {
 	return fmt.Sprintf("%s.%s-headless.%s.svc.%s", redisInfo.PodName, cr.Name, cr.Namespace, envs.GetServiceDNSDomain())
-}
-
-// Get Redis nodes by it's role i.e. master, slave and sentinel
-func GetRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string) ([]string, error) {
-	return getRedisNodesByRole(ctx, cl, cr, redisRole, func(ctx context.Context, pod *corev1.Pod) (string, error) {
-		redisClient := configureRedisReplicationClientForPod(ctx, cl, cr, pod)
-		defer redisClient.Close()
-
-		return checkRedisServerRole(ctx, redisClient, pod.Name)
-	})
-}
-
-func getRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2.RedisReplication, redisRole string, probeRole func(context.Context, *corev1.Pod) (string, error)) ([]string, error) {
-	statefulset, err := GetStatefulSet(ctx, cl, cr.GetNamespace(), cr.GetName())
-	if err != nil {
-		log.FromContext(ctx).Error(err, "Failed to Get the Statefulset of the", "custom resource", cr.Name, "in namespace", cr.Namespace)
-		return nil, err
-	}
-
-	var pods []string
-	replicas := cr.Spec.GetReplicationCounts("replication")
-
-	for i := 0; i < int(replicas); i++ {
-		podName := statefulset.Name + "-" + strconv.Itoa(i)
-		pod, err := cl.CoreV1().Pods(cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-
-		if !IsRedisPodProbeable(pod) {
-			continue
-		}
-
-		podRole, err := probeRole(ctx, pod)
-		if err != nil {
-			// A cancelled or expired reconcile context says nothing about this pod:
-			// every remaining probe shares the context and would fail the same way,
-			// so skipping them would turn a shutdown into a successful reconcile over
-			// a partial topology. Only pod-specific failures may be skipped.
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return nil, ctxErr
-			}
-			log.FromContext(ctx).V(1).Info("Failed to probe Redis role, skipping pod", "pod", podName, "error", err)
-			continue
-		}
-		if podRole == redisRole {
-			pods = append(pods, podName)
-		}
-	}
-
-	return pods, nil
 }
 
 func IsRedisPodProbeable(pod *corev1.Pod) bool {

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -1046,7 +1046,14 @@ func getRedisNodesByRole(ctx context.Context, cl kubernetes.Interface, cr *rrvb2
 
 		podRole, err := probeRole(ctx, pod)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "Failed to probe Redis role, skipping pod", "pod", podName)
+			// A cancelled or expired reconcile context says nothing about this pod:
+			// every remaining probe shares the context and would fail the same way,
+			// so skipping them would turn a shutdown into a successful reconcile over
+			// a partial topology. Only pod-specific failures may be skipped.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			log.FromContext(ctx).V(1).Info("Failed to probe Redis role, skipping pod", "pod", podName, "error", err)
 			continue
 		}
 		if podRole == redisRole {

--- a/internal/k8sutils/redis_get_nodes_by_role_test.go
+++ b/internal/k8sutils/redis_get_nodes_by_role_test.go
@@ -106,7 +106,7 @@ func TestGetRedisNodesByRoleSkipsUnprobeablePods(t *testing.T) {
 	}
 }
 
-func TestGetRedisNodesByRoleFailsWhenReadyPodProbeFails(t *testing.T) {
+func TestGetRedisNodesByRoleSkipsWhenReadyPodProbeFails(t *testing.T) {
 	client := k8sClientFake.NewSimpleClientset(
 		newRedisReplicationStatefulSet(),
 		newReadyRedisPod("example-replication-0", "10.0.0.10"),
@@ -114,14 +114,18 @@ func TestGetRedisNodesByRoleFailsWhenReadyPodProbeFails(t *testing.T) {
 		newReadyRedisPod("example-replication-2", "10.0.0.12"),
 	)
 
-	_, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
+	nodes, err := getRedisNodesByRole(context.Background(), client, newRedisReplication(), "master", func(_ context.Context, pod *corev1.Pod) (string, error) {
+		if pod.Name == "example-replication-0" {
+			return "master", nil
+		}
 		if pod.Name == "example-replication-1" {
 			return "", errors.New("probe failed")
 		}
 		return "slave", nil
 	})
 
-	assert.ErrorContains(t, err, "probe failed")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"example-replication-0"}, nodes)
 }
 
 func TestGetRedisNodesByRoleCompleteTopology(t *testing.T) {

--- a/internal/k8sutils/redis_get_nodes_by_role_test.go
+++ b/internal/k8sutils/redis_get_nodes_by_role_test.go
@@ -7,6 +7,7 @@ import (
 
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,6 +127,27 @@ func TestGetRedisNodesByRoleSkipsWhenReadyPodProbeFails(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"example-replication-0"}, nodes)
+}
+
+// Every probe shares the reconcile context, so a cancellation fails all of them.
+// Skipping them would report a partial topology as a complete one.
+func TestGetRedisNodesByRolePropagatesContextCancellation(t *testing.T) {
+	client := k8sClientFake.NewSimpleClientset(
+		newRedisReplicationStatefulSet(),
+		newReadyRedisPod("example-replication-0", "10.0.0.10"),
+		newReadyRedisPod("example-replication-1", "10.0.0.11"),
+		newReadyRedisPod("example-replication-2", "10.0.0.12"),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	nodes, err := getRedisNodesByRole(ctx, client, newRedisReplication(), "master", func(ctx context.Context, _ *corev1.Pod) (string, error) {
+		return "", ctx.Err()
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, nodes)
 }
 
 func TestGetRedisNodesByRoleCompleteTopology(t *testing.T) {


### PR DESCRIPTION
Fixes #1842

## Summary

When a worker node crashes, Redis pods can remain `Running`/`Ready` with stale Kubernetes status while Redis is unreachable. `GetRedisNodesByRole` previously fail-fast on the first probe error, which blocked the entire RedisReplication reconcile loop and prevented healthy pods from updating `status.masterNode` and `redis-role` labels.

This change:

- Skips per-pod Redis probe failures in `GetRedisNodesByRole` (log + continue) instead of aborting reconcile
- Removes stale `redis-role` labels from pods that are probeable in Kubernetes but unreachable over Redis, so master Services do not keep routing to dead pods during the stale-Ready window

## Test plan

- [x] `go test ./internal/k8sutils/... -run 'GetRedisNodesByRole|IsRedisPodProbeable'`
- [x] `go test ./internal/controller/common/redis/... -run UpdateRedisRoleLabel`
- [x] `go test ./internal/controller/redisreplication/... -run 'TestReconcile'`

Made with [Cursor](https://cursor.com)


| Situation | How the controller decides |
|---|---|
| All pods observed, exactly one says master | Trust it. Nothing else could be the master. |
| Partial view (some pods unreachable), one says master, **it has replicas attached** | Trust it. A freshly booted standalone never has replicas, so replicas prove it's the real one. |
| Partial view, lone master, no replicas, **Sentinel enabled** | Ask Sentinel. Sentinel promotes masters on its own, so the recorded master might already have been replaced, and a newly promoted master might legitimately have no replicas (e.g. 2-pod setup, old master died). |
| Partial view, lone master, no replicas, **no Sentinel** | Fall back to `Status.MasterNode`. Nothing else can promote behind the controller's back, so if the recorded master says "I'm master," it still is. |
| Several pods say master | First check which has replicas attached. If none does and Sentinel is on, use Sentinel's pick — so a master Sentinel promoted doesn't get demoted just because `Status.MasterNode` is stale. |
| All pods observed, **none** says master | Conclusive: there is no master. Clear `Status.MasterNode`. |
| Partial view, none of the observed pods says master | Inconclusive: the master may be an unobserved pod. Keep the previous `Status.MasterNode`. |