### PR TITLE
fix: use FQDN for replica-announce-ip and sentinel announce-ip

### DIFF
--- a/example/v1beta2/redis_sentinel/sentinel.yaml
+++ b/example/v1beta2/redis_sentinel/sentinel.yaml
@@ -10,6 +10,11 @@ spec:
     fsGroup: 1000
   redisSentinelConfig:
     redisReplicationName: redis-replication
+    # Requires Redis 6.2+, which added Sentinel's hostname support.
+    # Set both together: a hostname is only a valid announce address when
+    # Sentinel is resolving hostnames.
+    resolveHostnames: "yes"
+    announceHostnames: "yes"
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:latest
     imagePullPolicy: IfNotPresent

--- a/example/v1beta2/replication_sentinel/redis-replication.yaml
+++ b/example/v1beta2/replication_sentinel/redis-replication.yaml
@@ -40,6 +40,11 @@ spec:
             storage: 1Gi
   sentinel:
     size: 3
+    # Requires Redis 6.2+, which added Sentinel's hostname support.
+    # Set both together: a hostname is only a valid announce address when
+    # Sentinel is resolving hostnames.
+    resolveHostnames: "yes"
+    announceHostnames: "yes"
     image: quay.io/opstree/redis-sentinel:latest
     imagePullPolicy: IfNotPresent
     resources:

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -104,6 +104,11 @@ func GenerateConfig() error {
 		}
 	} else {
 		fmt.Println("Setting up redis in standalone mode")
+		if clusterMode == "replication" {
+			if fqdnName, err := fqdn.FqdnHostname(); err == nil {
+				cfg.Append("replica-announce-ip", fqdnName)
+			}
+		}
 	}
 
 	if tlsMode == "true" {

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -30,6 +30,19 @@ supervised no
 pidfile /var/run/redis.pid
 `
 
+var fqdnHostname = fqdn.FqdnHostname
+
+func announceHostname() (string, error) {
+	name, err := fqdnHostname()
+	if err != nil {
+		return "", err
+	}
+	if !strings.Contains(name, ".") {
+		return "", fmt.Errorf("hostname %q is not fully qualified", name)
+	}
+	return name, nil
+}
+
 // GenerateConfig generates Redis configuration file
 func GenerateConfig() error {
 	confPath := util.CoalesceEnv1("REDIS_CONFIG_FILE", "/etc/redis/redis.conf")
@@ -58,7 +71,8 @@ func GenerateConfig() error {
 		cfg.Append("protected-mode", "no")
 	}
 
-	if clusterMode == "cluster" {
+	switch clusterMode {
+	case "cluster":
 		nodeConfPath := filepath.Join(nodeConfDir, "nodes.conf")
 
 		// cluster-node-timeout is raised from 5000ms to 15000ms (configurable
@@ -102,13 +116,19 @@ func GenerateConfig() error {
 				cfg.Append("cluster-announce-hostname", fqdnName)
 			}
 		}
-	} else {
-		fmt.Println("Setting up redis in standalone mode")
-		if clusterMode == "replication" {
-			if fqdnName, err := fqdn.FqdnHostname(); err == nil {
+	case "replication":
+		fmt.Println("Setting up redis in replication mode")
+		announceHostnames := util.CoalesceEnv1("ANNOUNCE_HOSTNAMES", "no")
+		resolveHostnames := util.CoalesceEnv1("RESOLVE_HOSTNAMES", "no")
+		if announceHostnames == "yes" && resolveHostnames == "yes" {
+			if fqdnName, err := announceHostname(); err != nil {
+				log.Printf("Warning: Failed to get FQDN for replica-announce-ip: %v", err)
+			} else {
 				cfg.Append("replica-announce-ip", fqdnName)
 			}
 		}
+	default:
+		fmt.Println("Setting up redis in standalone mode")
 	}
 
 	if tlsMode == "true" {

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -68,6 +68,48 @@ func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 	}
 }
 
+func Test_GenerateConfig_ReplicaAnnounceIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMode string
+		isReplica bool
+	}{
+		{
+			name:      "replication mode - sets replica-announce-ip when FQDN available",
+			setupMode: "replication",
+			isReplica: true,
+		},
+		{
+			name:      "standalone mode - never sets replica-announce-ip",
+			setupMode: "standalone",
+			isReplica: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			confPath := filepath.Join(t.TempDir(), "redis.conf")
+			t.Setenv("REDIS_CONFIG_FILE", confPath)
+			t.Setenv("SETUP_MODE", tt.setupMode)
+
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			if !tt.isReplica {
+				assert.NotContains(t, conf, "replica-announce-ip")
+			}
+			// replica-announce-ip is only set when fqdn.FqdnHostname()
+			// succeeds (i.e. inside a K8s pod with DNS). On dev machines
+			// the FQDN lookup may fail, so we only assert the invariant:
+			// it must never fall back to 0.0.0.0.
+			assert.NotContains(t, conf, "replica-announce-ip 0.0.0.0")
+		})
+	}
+}
+
 func Test_updateMyselfIP(t *testing.T) {
 	testData := `7a6b5f4f99496c97f4e32c30c077aa95cab92664 10.244.0.246:0@16379,,tls-port=6379,shard-id=a03445a0d3f6d405af261041e0cb77a8a176f42b slave b66f2fa597eeda567cf05f3701419be9a3b2f50e 0 1756463509000 1 connected
 93ad60e9ce21430683a3534d2c96ab1b8077cfe8 10.244.0.237:0@16379,,tls-port=6379,shard-id=2f177491b895051f91e91e554a2a9da2cd167aeb master - 0 1756463509685 2 connected 5461-10922

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,28 +70,74 @@ func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 }
 
 func Test_GenerateConfig_ReplicaAnnounceIP(t *testing.T) {
+	const fakeFQDN = "redis-replication-0.redis-replication-headless.ns.svc.cluster.local"
+
 	tests := []struct {
 		name      string
 		setupMode string
-		isReplica bool
+		announce  string
+		resolve   string
+		resolver  func() (string, error)
+		want      bool
 	}{
 		{
-			name:      "replication mode - sets replica-announce-ip when FQDN available",
-			setupMode: "replication",
-			isReplica: true,
+			name:      "replication with hostnames enabled announces the FQDN",
+			setupMode: "replication", announce: "yes", resolve: "yes",
+			resolver: func() (string, error) { return fakeFQDN, nil },
+			want:     true,
 		},
 		{
-			name:      "standalone mode - never sets replica-announce-ip",
-			setupMode: "standalone",
-			isReplica: false,
+			// Sentinel rejects a hostname here unless it resolves hostnames itself,
+			// so announcing one would make the replica undiscoverable.
+			name:      "replication with resolve-hostnames off stays on IPs",
+			setupMode: "replication", announce: "yes", resolve: "no",
+			resolver: func() (string, error) { return fakeFQDN, nil },
+			want:     false,
+		},
+		{
+			name:      "replication with announce-hostnames off stays on IPs",
+			setupMode: "replication", announce: "no", resolve: "yes",
+			resolver: func() (string, error) { return fakeFQDN, nil },
+			want:     false,
+		},
+		{
+			name:      "replication with both off (the default) stays on IPs",
+			setupMode: "replication", announce: "no", resolve: "no",
+			resolver: func() (string, error) { return fakeFQDN, nil },
+			want:     false,
+		},
+		{
+			name:      "resolver failure omits the directive",
+			setupMode: "replication", announce: "yes", resolve: "yes",
+			resolver: func() (string, error) { return "", errors.New("boom") },
+			want:     false,
+		},
+		{
+			// go-fqdn returns a nil error even when it only found the short name.
+			name:      "unqualified hostname is rejected",
+			setupMode: "replication", announce: "yes", resolve: "yes",
+			resolver: func() (string, error) { return "redis-replication-0", nil },
+			want:     false,
+		},
+		{
+			name:      "standalone never announces",
+			setupMode: "standalone", announce: "yes", resolve: "yes",
+			resolver: func() (string, error) { return fakeFQDN, nil },
+			want:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			orig := fqdnHostname
+			fqdnHostname = tt.resolver
+			t.Cleanup(func() { fqdnHostname = orig })
+
 			confPath := filepath.Join(t.TempDir(), "redis.conf")
 			t.Setenv("REDIS_CONFIG_FILE", confPath)
 			t.Setenv("SETUP_MODE", tt.setupMode)
+			t.Setenv("ANNOUNCE_HOSTNAMES", tt.announce)
+			t.Setenv("RESOLVE_HOSTNAMES", tt.resolve)
 
 			require.NoError(t, GenerateConfig())
 
@@ -98,14 +145,11 @@ func Test_GenerateConfig_ReplicaAnnounceIP(t *testing.T) {
 			require.NoError(t, err)
 			conf := string(raw)
 
-			if !tt.isReplica {
+			if tt.want {
+				assert.Contains(t, conf, "replica-announce-ip "+fakeFQDN)
+			} else {
 				assert.NotContains(t, conf, "replica-announce-ip")
 			}
-			// replica-announce-ip is only set when fqdn.FqdnHostname()
-			// succeeds (i.e. inside a K8s pod with DNS). On dev machines
-			// the FQDN lookup may fail, so we only assert the invariant:
-			// it must never fall back to 0.0.0.0.
-			assert.NotContains(t, conf, "replica-announce-ip 0.0.0.0")
 		})
 	}
 }

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -6,6 +6,7 @@ import (
 
 	agentutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/agent/util"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
+	"github.com/Showmax/go-fqdn"
 )
 
 // defaultSentinelConfig from https://github.com/OT-CONTAINER-KIT/redis/blob/master/sentinel.conf
@@ -77,7 +78,9 @@ func GenerateConfig() error {
 
 		// If resolveHostnames is set to yes, then we need to announce the hostnames
 		if announceHostnames == "yes" && resolveHostnames == "yes" {
-			cfg.Append("sentinel announce-ip", ip)
+			if fqdnName, err := fqdn.FqdnHostname(); err == nil {
+				cfg.Append("sentinel announce-ip", fqdnName)
+			}
 		}
 	}
 

--- a/internal/agent/bootstrap/sentinel/config.go
+++ b/internal/agent/bootstrap/sentinel/config.go
@@ -2,12 +2,27 @@ package bootstrap
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
 	agentutil "github.com/OT-CONTAINER-KIT/redis-operator/internal/agent/util"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 	"github.com/Showmax/go-fqdn"
 )
+
+var fqdnHostname = fqdn.FqdnHostname
+
+func announceHostname() (string, error) {
+	name, err := fqdnHostname()
+	if err != nil {
+		return "", err
+	}
+	if !strings.Contains(name, ".") {
+		return "", fmt.Errorf("hostname %q is not fully qualified", name)
+	}
+	return name, nil
+}
 
 // defaultSentinelConfig from https://github.com/OT-CONTAINER-KIT/redis/blob/master/sentinel.conf
 const defaultSentinelConfig = `
@@ -76,9 +91,14 @@ func GenerateConfig() error {
 			cfg.Append("sentinel myid", sentinelID)
 		}
 
-		// If resolveHostnames is set to yes, then we need to announce the hostnames
+		// If resolveHostnames is set to yes, then we need to announce the hostnames.
+		// Note the pre-existing `sentinel monitor` line above still renders the
+		// unset IP env as 0.0.0.0; the operator repairs it with SENTINEL MONITOR
+		// once it knows the master. See #1806.
 		if announceHostnames == "yes" && resolveHostnames == "yes" {
-			if fqdnName, err := fqdn.FqdnHostname(); err == nil {
+			if fqdnName, err := announceHostname(); err != nil {
+				log.Printf("Warning: Failed to get FQDN for sentinel announce-ip: %v", err)
+			} else {
 				cfg.Append("sentinel announce-ip", fqdnName)
 			}
 		}

--- a/internal/agent/bootstrap/sentinel/config_test.go
+++ b/internal/agent/bootstrap/sentinel/config_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_GenerateConfig_SentinelAnnounceIP(t *testing.T) {
+	const fakeFQDN = "redis-replication-s-0.redis-replication-s-hl.ns.svc.cluster.local"
+
 	tests := []struct {
 		name              string
 		resolveHostnames  string
@@ -44,10 +46,16 @@ func Test_GenerateConfig_SentinelAnnounceIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			orig := fqdnHostname
+			fqdnHostname = func() (string, error) { return fakeFQDN, nil }
+			t.Cleanup(func() { fqdnHostname = orig })
+
 			confPath := filepath.Join(t.TempDir(), "sentinel.conf")
 			t.Setenv("SENTINEL_CONFIG_FILE", confPath)
 			t.Setenv("RESOLVE_HOSTNAMES", tt.resolveHostnames)
 			t.Setenv("ANNOUNCE_HOSTNAMES", tt.announceHostnames)
+			// Pin the guard below to the real pre-fix value rather than the default.
+			t.Setenv("IP", "0.0.0.0")
 
 			require.NoError(t, GenerateConfig())
 
@@ -58,7 +66,11 @@ func Test_GenerateConfig_SentinelAnnounceIP(t *testing.T) {
 			assert.NotContains(t, conf, "sentinel announce-ip 0.0.0.0",
 				"sentinel announce-ip must never be set to 0.0.0.0")
 
-			if !tt.hostnamesEnabled {
+			if tt.hostnamesEnabled {
+				// Positive assertion: without this an implementation that stopped
+				// emitting announce-ip altogether would still satisfy the test.
+				assert.Contains(t, conf, "sentinel announce-ip "+fakeFQDN)
+			} else {
 				assert.NotContains(t, conf, "sentinel announce-ip ")
 			}
 		})

--- a/internal/agent/bootstrap/sentinel/config_test.go
+++ b/internal/agent/bootstrap/sentinel/config_test.go
@@ -9,6 +9,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_GenerateConfig_SentinelAnnounceIP(t *testing.T) {
+	tests := []struct {
+		name              string
+		resolveHostnames  string
+		announceHostnames string
+		hostnamesEnabled  bool
+	}{
+		{
+			name:              "both enabled - uses FQDN, never 0.0.0.0",
+			resolveHostnames:  "yes",
+			announceHostnames: "yes",
+			hostnamesEnabled:  true,
+		},
+		{
+			name:              "resolve only - does not set sentinel announce-ip",
+			resolveHostnames:  "yes",
+			announceHostnames: "no",
+			hostnamesEnabled:  false,
+		},
+		{
+			name:              "announce only - does not set sentinel announce-ip",
+			resolveHostnames:  "no",
+			announceHostnames: "yes",
+			hostnamesEnabled:  false,
+		},
+		{
+			name:              "both disabled - does not set sentinel announce-ip",
+			resolveHostnames:  "no",
+			announceHostnames: "no",
+			hostnamesEnabled:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			confPath := filepath.Join(t.TempDir(), "sentinel.conf")
+			t.Setenv("SENTINEL_CONFIG_FILE", confPath)
+			t.Setenv("RESOLVE_HOSTNAMES", tt.resolveHostnames)
+			t.Setenv("ANNOUNCE_HOSTNAMES", tt.announceHostnames)
+
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			assert.NotContains(t, conf, "sentinel announce-ip 0.0.0.0",
+				"sentinel announce-ip must never be set to 0.0.0.0")
+
+			if !tt.hostnamesEnabled {
+				assert.NotContains(t, conf, "sentinel announce-ip ")
+			}
+		})
+	}
+}
+
 func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/controller/redisreplication/redisreplication_controller.go
+++ b/internal/controller/redisreplication/redisreplication_controller.go
@@ -176,7 +176,7 @@ func (r *Reconciler) reconcileFinalizer(ctx context.Context, instance *rrvb2.Red
 }
 
 func (r *Reconciler) reconcileResources(ctx context.Context, instance *rrvb2.RedisReplication) (ctrl.Result, error) {
-	if err := k8sutils.CreateReplicationRedis(ctx, instance, r.K8sClient); err != nil {
+	if err := k8sutils.CreateReplicationRedis(ctx, instance, r.K8sClient, r.Client); err != nil {
 		return intctrlutil.RequeueAfter(ctx, time.Second*60, "")
 	}
 	if err := k8sutils.CreateReplicationService(ctx, instance, r.K8sClient); err != nil {

--- a/internal/controller/redisreplication/redisreplication_sentinel.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel.go
@@ -127,6 +127,8 @@ func buildSentinelContainer(rr *rrvb2.RedisReplication) corev1.Container {
 func buildSentinelEnv(rr *rrvb2.RedisReplication) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{Name: "QUORUM", Value: fmt.Sprintf("%d", rr.Spec.Sentinel.Size/2+1)},
+		{Name: "RESOLVE_HOSTNAMES", Value: resolveHostnamesOrDefault(rr.Spec.Sentinel.ResolveHostnames)},
+		{Name: "ANNOUNCE_HOSTNAMES", Value: resolveHostnamesOrDefault(rr.Spec.Sentinel.AnnounceHostnames)},
 	}
 	passwordSecret := rr.Spec.KubernetesConfig.ExistingPasswordSecret
 	if rr.Spec.Sentinel.ExistingPasswordSecret != nil {
@@ -147,4 +149,11 @@ func buildSentinelEnv(rr *rrvb2.RedisReplication) []corev1.EnvVar {
 	}
 
 	return envs
+}
+
+func resolveHostnamesOrDefault(v string) string {
+	if v == "" {
+		return "no"
+	}
+	return v
 }

--- a/internal/controller/redisreplication/redisreplication_sentinel_test.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel_test.go
@@ -165,11 +165,39 @@ func TestBuildSentinelEnv(t *testing.T) {
 		return rr
 	}
 
-	t.Run("no password secret only sets quorum", func(t *testing.T) {
+	envValue := func(envs []corev1.EnvVar, name string) (string, bool) {
+		for _, e := range envs {
+			if e.Name == name {
+				return e.Value, true
+			}
+		}
+		return "", false
+	}
+
+	t.Run("no password secret sets quorum and the hostname knobs", func(t *testing.T) {
 		envs := buildSentinelEnv(newRR(nil, nil))
-		require.Len(t, envs, 1)
+		require.Len(t, envs, 3)
 		assert.Equal(t, "QUORUM", envs[0].Name)
 		assert.Equal(t, "2", envs[0].Value) // size 3 -> 3/2+1
+		// Without these the embedded Sentinel always rendered `resolve-hostnames no`
+		// and spec.sentinel.resolveHostnames was silently a no-op.
+		v, ok := envValue(envs, "RESOLVE_HOSTNAMES")
+		require.True(t, ok, "RESOLVE_HOSTNAMES must be passed to the embedded Sentinel")
+		assert.Equal(t, "no", v)
+		v, ok = envValue(envs, "ANNOUNCE_HOSTNAMES")
+		require.True(t, ok, "ANNOUNCE_HOSTNAMES must be passed to the embedded Sentinel")
+		assert.Equal(t, "no", v)
+	})
+
+	t.Run("hostname knobs are propagated from the spec", func(t *testing.T) {
+		rr := newRR(nil, nil)
+		rr.Spec.Sentinel.ResolveHostnames = "yes"
+		rr.Spec.Sentinel.AnnounceHostnames = "yes"
+		envs := buildSentinelEnv(rr)
+		v, _ := envValue(envs, "RESOLVE_HOSTNAMES")
+		assert.Equal(t, "yes", v)
+		v, _ = envValue(envs, "ANNOUNCE_HOSTNAMES")
+		assert.Equal(t, "yes", v)
 	})
 
 	t.Run("falls back to top-level redis secret", func(t *testing.T) {

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -78,7 +78,7 @@ func CreateReplicationService(ctx context.Context, cr *rrvb2.RedisReplication, c
 }
 
 // CreateReplicationRedis will create a replication redis setup
-func CreateReplicationRedis(ctx context.Context, cr *rrvb2.RedisReplication, cl kubernetes.Interface) error {
+func CreateReplicationRedis(ctx context.Context, cr *rrvb2.RedisReplication, cl kubernetes.Interface, ctrlClient client.Client) error {
 	stateFulName := cr.Name
 	labels := getRedisLabels(cr.Name, replication, "replication", cr.Labels)
 	annotations := generateStatefulSetsAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.IgnoreAnnotations)
@@ -92,7 +92,7 @@ func CreateReplicationRedis(ctx context.Context, cr *rrvb2.RedisReplication, cl 
 		generateRedisReplicationParams(cr),
 		redisReplicationAsOwner(cr),
 		generateRedisReplicationInitContainerParams(cr),
-		generateRedisReplicationContainerParams(cr),
+		generateRedisReplicationContainerParams(ctx, cr, ctrlClient),
 		cr.Spec.Sidecars,
 	)
 	if err != nil {
@@ -152,7 +152,7 @@ func generateRedisReplicationParams(cr *rrvb2.RedisReplication) statefulSetParam
 }
 
 // generateRedisReplicationContainerParams generates Redis container information
-func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) containerParameters {
+func generateRedisReplicationContainerParams(ctx context.Context, cr *rrvb2.RedisReplication, ctrlClient client.Client) containerParameters {
 	trueProperty := true
 	falseProperty := false
 	containerProp := containerParameters{
@@ -218,16 +218,40 @@ func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) contain
 		containerProp.SentinelMasterName = cr.SentinelMasterName()
 		containerProp.SentinelPort = 26379
 		containerProp.PreStopWaitSeconds = preStopWaitSeconds(cr.Spec.TerminationGracePeriodSeconds)
-		hostnameEnv := []corev1.EnvVar{
-			{Name: "RESOLVE_HOSTNAMES", Value: sentinelHostnameFlag(cr.Spec.Sentinel.ResolveHostnames)},
-			{Name: "ANNOUNCE_HOSTNAMES", Value: sentinelHostnameFlag(cr.Spec.Sentinel.AnnounceHostnames)},
-		}
-		if containerProp.EnvVars != nil {
-			hostnameEnv = append(append([]corev1.EnvVar{}, *containerProp.EnvVars...), hostnameEnv...)
-		}
-		containerProp.EnvVars = &hostnameEnv
 	}
+	resolve, announce := sentinelHostnameSettings(ctx, ctrlClient, cr)
+	hostnameEnv := []corev1.EnvVar{
+		{Name: "RESOLVE_HOSTNAMES", Value: resolve},
+		{Name: "ANNOUNCE_HOSTNAMES", Value: announce},
+	}
+	if containerProp.EnvVars != nil {
+		hostnameEnv = append(append([]corev1.EnvVar{}, *containerProp.EnvVars...), hostnameEnv...)
+	}
+	containerProp.EnvVars = &hostnameEnv
+
 	return containerProp
+}
+
+func sentinelHostnameSettings(ctx context.Context, ctrlClient client.Client, cr *rrvb2.RedisReplication) (string, string) {
+	if cr.EnableSentinel() {
+		return sentinelHostnameFlag(cr.Spec.Sentinel.ResolveHostnames), sentinelHostnameFlag(cr.Spec.Sentinel.AnnounceHostnames)
+	}
+	if ctrlClient == nil {
+		return "no", "no"
+	}
+	var sentinels rsvb2.RedisSentinelList
+	if err := ctrlClient.List(ctx, &sentinels, client.InNamespace(cr.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list RedisSentinel, assuming hostnames are disabled")
+		return "no", "no"
+	}
+	for i := range sentinels.Items {
+		cfg := sentinels.Items[i].Spec.RedisSentinelConfig
+		if cfg == nil || cfg.RedisReplicationName != cr.Name {
+			continue
+		}
+		return sentinelHostnameFlag(cfg.ResolveHostnames), sentinelHostnameFlag(cfg.AnnounceHostnames)
+	}
+	return "no", "no"
 }
 
 // generateRedisReplicationInitContainerParams generates Redis Replication initcontainer information

--- a/internal/k8sutils/redis-replication.go
+++ b/internal/k8sutils/redis-replication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util/maps"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -217,6 +218,14 @@ func generateRedisReplicationContainerParams(cr *rrvb2.RedisReplication) contain
 		containerProp.SentinelMasterName = cr.SentinelMasterName()
 		containerProp.SentinelPort = 26379
 		containerProp.PreStopWaitSeconds = preStopWaitSeconds(cr.Spec.TerminationGracePeriodSeconds)
+		hostnameEnv := []corev1.EnvVar{
+			{Name: "RESOLVE_HOSTNAMES", Value: sentinelHostnameFlag(cr.Spec.Sentinel.ResolveHostnames)},
+			{Name: "ANNOUNCE_HOSTNAMES", Value: sentinelHostnameFlag(cr.Spec.Sentinel.AnnounceHostnames)},
+		}
+		if containerProp.EnvVars != nil {
+			hostnameEnv = append(append([]corev1.EnvVar{}, *containerProp.EnvVars...), hostnameEnv...)
+		}
+		containerProp.EnvVars = &hostnameEnv
 	}
 	return containerProp
 }
@@ -274,4 +283,11 @@ func IsRedisReplicationReady(ctx context.Context, client kubernetes.Interface, c
 		return false
 	}
 	return true
+}
+
+func sentinelHostnameFlag(v string) string {
+	if v == "" {
+		return "no"
+	}
+	return v
 }

--- a/internal/k8sutils/redis-replication_test.go
+++ b/internal/k8sutils/redis-replication_test.go
@@ -1,6 +1,7 @@
 package k8sutils
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -198,6 +199,16 @@ func Test_generateRedisReplicationContainerParams(t *testing.T) {
 				Name:  "CUSTOM_ENV_VAR_2",
 				Value: "custom_value_2",
 			},
+			// Always present so the bootstrap agent can gate replica-announce-ip
+			// on whether the monitoring Sentinel resolves hostnames.
+			{
+				Name:  "RESOLVE_HOSTNAMES",
+				Value: "no",
+			},
+			{
+				Name:  "ANNOUNCE_HOSTNAMES",
+				Value: "no",
+			},
 		},
 		AdditionalVolume: []corev1.Volume{
 			{
@@ -230,7 +241,7 @@ func Test_generateRedisReplicationContainerParams(t *testing.T) {
 		t.Fatalf("Failed to unmarshal file %s: %v", path, err)
 	}
 
-	actual := generateRedisReplicationContainerParams(input)
+	actual := generateRedisReplicationContainerParams(context.TODO(), input, nil)
 	assert.EqualValues(t, expected, actual, "Expected %+v, got %+v", expected, actual)
 }
 
@@ -245,7 +256,7 @@ func Test_generateRedisReplicationContainerParams_SentinelPreStop(t *testing.T) 
 	}
 
 	t.Run("sentinel disabled leaves preStop fields empty", func(t *testing.T) {
-		got := generateRedisReplicationContainerParams(base())
+		got := generateRedisReplicationContainerParams(context.TODO(), base(), nil)
 		assert.Empty(t, got.SentinelService)
 		assert.Empty(t, got.SentinelMasterName)
 		assert.Zero(t, got.SentinelPort)
@@ -257,7 +268,7 @@ func Test_generateRedisReplicationContainerParams_SentinelPreStop(t *testing.T) 
 		cr.Spec.Sentinel = &rrvb2.Sentinel{Size: 3}
 		cr.Spec.TerminationGracePeriodSeconds = ptr.To(int64(60))
 
-		got := generateRedisReplicationContainerParams(cr)
+		got := generateRedisReplicationContainerParams(context.TODO(), cr, nil)
 		assert.Equal(t, "my-replication-s-hl", got.SentinelService)
 		assert.Equal(t, "mymaster", got.SentinelMasterName)
 		assert.Equal(t, 26379, got.SentinelPort)
@@ -269,7 +280,7 @@ func Test_generateRedisReplicationContainerParams_SentinelPreStop(t *testing.T) 
 		cr := base()
 		cr.Spec.Sentinel = &rrvb2.Sentinel{Size: 0}
 
-		got := generateRedisReplicationContainerParams(cr)
+		got := generateRedisReplicationContainerParams(context.TODO(), cr, nil)
 		assert.Empty(t, got.SentinelService)
 	})
 }

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
@@ -87,6 +87,30 @@ spec:
             timeout: 300s
             file: ready-pvc-resized.yaml
 
+    - name: Assert sentinel discovered the replicas
+      try:
+        - script:
+            timeout: 90s
+            content: |
+              ./wait-for.sh 60 2 "kubectl -n ${NAMESPACE} exec redis-replication-s-0 -c sentinel -- redis-cli -p 26379 sentinel replicas mymaster | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$'"
+            check:
+              (contains($stdout, 'matched')): true
+
+    - name: Assert hostname announcements are off by default
+      try:
+        - script:
+            timeout: 60s
+            content: |
+              ./wait-for.sh 30 no "kubectl -n ${NAMESPACE} exec redis-replication-s-0 -c sentinel -- redis-cli -p 26379 sentinel config get resolve-hostnames | tail -1"
+            check:
+              (contains($stdout, 'matched')): true
+        - script:
+            timeout: 60s
+            content: |
+              ./wait-for.sh 30 "" "kubectl -n ${NAMESPACE} exec redis-replication-0 -c redis-replication -- redis-cli -a Opstree1234 --no-auth-warning config get replica-announce-ip | tail -1"
+            check:
+              (contains($stdout, 'matched')): true
+
     - name: Put data
       try:
         - script:
@@ -133,6 +157,37 @@ spec:
                        --password Opstree1234"
             check:
               (contains($stdout, 'OK')): true
+
+    - name: Enable hostname announcements
+      try:
+        - apply:
+            resource:
+              apiVersion: redis.redis.opstreelabs.in/v1beta2
+              kind: RedisReplication
+              metadata:
+                name: redis-replication
+              spec:
+                sentinel:
+                  resolveHostnames: "yes"
+                  announceHostnames: "yes"
+        - assert:
+            timeout: 5m
+            file: hostname-announce-on.yaml
+
+    - name: Assert the replica announces its FQDN
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              ./wait-for.sh 90 "redis-replication-0.redis-replication-headless.${NAMESPACE}.svc.cluster.local" "kubectl -n ${NAMESPACE} exec redis-replication-0 -c redis-replication -- redis-cli -a Opstree1234 --no-auth-warning config get replica-announce-ip | tail -1"
+            check:
+              (contains($stdout, 'matched')): true
+        - script:
+            timeout: 120s
+            content: |
+              ./wait-for.sh 90 2 "kubectl -n ${NAMESPACE} exec redis-replication-s-0 -c sentinel -- redis-cli -p 26379 sentinel replicas mymaster | grep -cE '^redis-replication-[0-9]+\.redis-replication-headless\.${NAMESPACE}\.svc\.cluster\.local:[0-9]+$'"
+            check:
+              (contains($stdout, 'matched')): true
 
     - name: redis-replication-uninstall
       description: Uninstall Redis Replication

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/hostname-announce-on.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/hostname-announce-on.yaml
@@ -1,0 +1,30 @@
+---
+# After enabling the knobs on the CR, the operator must propagate them to both
+# StatefulSets and the rollout must complete -- the values are env vars, so the
+# pods restart before the new config is rendered. Asserting readyReplicas here
+# is what makes the following exec-based checks race-free.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-replication
+spec:
+  template:
+    spec:
+      (containers[?name == 'redis-replication'] | [0].env[?name == 'RESOLVE_HOSTNAMES'] | [0].value): "yes"
+      (containers[?name == 'redis-replication'] | [0].env[?name == 'ANNOUNCE_HOSTNAMES'] | [0].value): "yes"
+status:
+  readyReplicas: 3
+  updatedReplicas: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-replication-s
+spec:
+  template:
+    spec:
+      (containers[?name == 'sentinel'] | [0].env[?name == 'RESOLVE_HOSTNAMES'] | [0].value): "yes"
+      (containers[?name == 'sentinel'] | [0].env[?name == 'ANNOUNCE_HOSTNAMES'] | [0].value): "yes"
+status:
+  readyReplicas: 3
+  updatedReplicas: 3

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/wait-for.sh
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/wait-for.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# wait-for.sh <seconds> <expected> <command>
+#
+# Polls <command> until its stdout equals <expected>, then prints "matched".
+# The hostname-announcement steps assert values that live inside Redis and
+# Sentinel rather than in the Kubernetes API, so they cannot be chainsaw
+# asserts and need a bounded poll instead.
+#
+# Runs under /bin/sh (dash) via chainsaw's `sh -c`, so keep it POSIX.
+set -u
+
+deadline=$(($(date +%s) + $1))
+expected=$2
+command=$3
+
+while :; do
+    got=$(sh -c "$command" 2>/dev/null)
+    if [ "$got" = "$expected" ]; then
+        echo "matched: $got"
+        exit 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "timeout: got [$got], want [$expected]"
+        exit 1
+    fi
+    sleep 5
+done


### PR DESCRIPTION
## Summary

- **replica-announce-ip**: In replication mode, set `replica-announce-ip` to the pod's FQDN hostname (via `fqdn.FqdnHostname()`), matching how cluster mode already sets `cluster-announce-hostname`. This ensures the master's `INFO replication` reports resolvable hostnames instead of raw TCP source IPs, which may be incorrect when the CNI SNATs cross-node pod traffic.

- **sentinel announce-ip**: When both `resolve-hostnames` and `announce-hostnames` are enabled, set `sentinel announce-ip` to the pod's FQDN instead of the hardcoded `0.0.0.0` fallback (the `IP` env var was never set). This fixes sentinel-to-sentinel discovery when hostname features are enabled.

## Problem

On clusters where the CNI masquerades cross-node pod traffic, the Redis master sees replicas connected from SNATed source IPs that differ from the pods' actual IPs. Sentinel discovers these unreachable IPs from the master's `INFO replication` output and:
1. Cannot connect to any replica (`link-pending-commands: 100`, `master-link-status: err`)
2. Marks all replicas as `s_down`
3. Cannot perform failover when the master goes down — no healthy replica candidates

Additionally, TLS clients (e.g., Redisson) that discover the master address through sentinel receive an IP address, connect to it, and fail TLS hostname verification because the certificate only has DNS SANs (not IP SANs).

## Test plan

- [x] `go test ./internal/agent/bootstrap/...` — all tests pass
- [x] `go vet ./internal/agent/bootstrap/...` — clean
- [x] Deploy to a dev cluster with `resolve-hostnames: yes` and `announce-hostnames: yes` enabled on sentinel
- [x] Verify `SENTINEL replicas mymaster` shows replicas with `runid` populated, `link-pending-commands: 0`, and `master-link-status: ok`
- [x] Verify sentinel-to-sentinel discovery works (check `SENTINEL sentinels mymaster`)
- [x] Verify Redisson client can connect via sentinel with TLS hostname verification