### PR TITLE
docs: select only the metrics service in ServiceMonitor examples

### DIFF
--- a/docs/content/en/docs/Monitoring/_index.md
+++ b/docs/content/en/docs/Monitoring/_index.md
@@ -54,6 +54,8 @@ serviceMonitor:
 
 For kubectl related configuration, we may have to create `ServiceMonitor` definition in a YAML manifest and apply it using `kubectl` command.
 
+When the exporter is enabled, the operator creates a dedicated `<name>-metrics` service labelled with `app.kubernetes.io/component: metrics`. For standalone, replication and sentinel setups the regular Redis service exposes the exporter port as well, so a selector that only matches `redis_setup_type` selects both services and Prometheus scrapes the exporter twice. Match on `app.kubernetes.io/component: metrics` as well to select only the metrics service.
+
 ServiceMonitor for Redis cluster setup:
 
 ```yaml
@@ -62,13 +64,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: redis-cluster
-  labels:
-    redis-operator: "true"
-    env: production
 spec:
   selector:
     matchLabels:
       redis_setup_type: cluster
+      app.kubernetes.io/component: metrics
   endpoints:
   - port: redis-exporter
     interval: 30s
@@ -86,13 +86,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: redis-standalone
-  labels:
-    redis-operator: "true"
-    env: production
 spec:
   selector:
     matchLabels:
       redis_setup_type: standalone
+      app.kubernetes.io/component: metrics
   endpoints:
   - port: redis-exporter
     interval: 30s


### PR DESCRIPTION
**Description**

Fixes #1833.

The ServiceMonitor examples select services by `redis_setup_type` alone. When the exporter is enabled, `CreateOrUpdateMetricsService` creates a dedicated `<name>-metrics` service that carries the same setup-type labels plus `app.kubernetes.io/component: metrics`. For standalone, replication and sentinel the regular service is created with `epp`, so it exposes the exporter port too, and both services end up scraped — the duplicate metrics reported in the issue. Cluster services are created with `disableMetrics`, so they are not affected, but the extra label is correct there as well.

The examples now match on `app.kubernetes.io/component: metrics` in addition to `redis_setup_type`, and a short paragraph explains why. The `redis-operator: "true"` / `env: production` labels on the ServiceMonitor metadata are dropped as requested in the issue — nothing selects on them.

I did not change `imagePullPolicy: Always` to `IfNotPresent` (point 1 of the issue). Every example in `example/v1beta2/` uses `Always` for `redisExporter`, so changing only the docs would leave the two inconsistent. Happy to do it across the docs and the examples in a follow-up if you want that default flipped.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)
