### PR TITLE
fix(utils): pass client certificate to exec-based redis-cli

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -445,15 +445,24 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 	}
 }
 
+// getRedisTLSArgs returns the TLS flags for the redis-cli commands the operator
+// executes inside the Redis pods. The client certificate is always sent: Redis
+// defaults to `tls-auth-clients yes`, so a server requiring client certificates
+// rejects the TLS handshake when redis-cli presents none. This matches the flags
+// the generated liveness and readiness probes already use.
 func getRedisTLSArgs(tlsConfig *commonapi.TLSConfig, clientHost string) []string {
 	cmd := []string{}
 	if tlsConfig != nil {
+		caFile, certFile, keyFile := getTLSSecretKeys(tlsConfig)
 		cmd = append(cmd, "--tls")
 		if tlsConfig.CaCertFile != "" {
-			caFile, _, _ := getTLSSecretKeys(tlsConfig)
 			cmd = append(cmd, "--cacert")
 			cmd = append(cmd, "/tls/"+caFile)
 		}
+		cmd = append(cmd, "--cert")
+		cmd = append(cmd, "/tls/"+certFile)
+		cmd = append(cmd, "--key")
+		cmd = append(cmd, "/tls/"+keyFile)
 		cmd = append(cmd, "--insecure")
 	}
 	return cmd

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -491,7 +491,7 @@ func TestExecuteSingleLeaderAddSlots(t *testing.T) {
 		{
 			name:          "redis v6 with TLS includes TLS flags in every batch",
 			redisCluster:  newCluster(nil, false, true),
-			expectedFlags: []string{"--tls", "--cacert", "/tls/ca.crt", "--insecure"},
+			expectedFlags: []string{"--tls", "--cacert", "/tls/ca.crt", "--cert", "/tls/tls.crt", "--key", "/tls/tls.key", "--insecure"},
 		},
 	}
 
@@ -640,7 +640,7 @@ func TestGetRedisTLSArgs(t *testing.T) {
 			name:       "with TLS configuration",
 			tlsConfig:  &common.TLSConfig{},
 			clientHost: "redis-host",
-			expected:   []string{"--tls", "--insecure"},
+			expected:   []string{"--tls", "--cert", "/tls/tls.crt", "--key", "/tls/tls.key", "--insecure"},
 		},
 		{
 			name: "with TLS and explicit CA configuration",
@@ -648,7 +648,17 @@ func TestGetRedisTLSArgs(t *testing.T) {
 				CaCertFile: "custom-ca.crt",
 			},
 			clientHost: "redis-host",
-			expected:   []string{"--tls", "--cacert", "/tls/custom-ca.crt", "--insecure"},
+			expected:   []string{"--tls", "--cacert", "/tls/custom-ca.crt", "--cert", "/tls/tls.crt", "--key", "/tls/tls.key", "--insecure"},
+		},
+		{
+			name: "with custom client certificate and key keys",
+			tlsConfig: &common.TLSConfig{
+				CaCertFile:  "custom-ca.crt",
+				CertKeyFile: "custom-tls.crt",
+				KeyFile:     "custom-tls.key",
+			},
+			clientHost: "redis-host",
+			expected:   []string{"--tls", "--cacert", "/tls/custom-ca.crt", "--cert", "/tls/custom-tls.crt", "--key", "/tls/custom-tls.key", "--insecure"},
 		},
 		{
 			name:       "without TLS configuration",


### PR DESCRIPTION
**Description**

`getRedisTLSArgs` (`internal/k8sutils/redis.go`) builds the TLS flags for every `redis-cli` command the operator executes inside the Redis pods, and emitted only `--tls --cacert --insecure`. Redis defaults to `tls-auth-clients yes`, so the server requires a client certificate, the TLS handshake is rejected and `redis-cli` exits 1 with an empty stderr.

This helper feeds 12 call sites, covering every cluster-shaping operation:

| File | Functions |
| --- | --- |
| `internal/k8sutils/redis.go` | `executeSingleLeaderAddSlots`, `ExecuteRedisClusterCommand`, `createRedisReplicationCommand`, `checkClusterHealth` |
| `internal/k8sutils/cluster-scaling.go` | `ReshardRedisCluster`, `FixRedisCluster`, `RebalanceRedisClusterEmptyMasters`, `RebalanceRedisCluster`, `AddRedisNodeToCluster`, `RemoveRedisFollowerNodesFromCluster`, `RemoveRedisNodeFromCluster`, `ClusterFailover` |

So an affected cluster never reaches `Ready`, keeps `redis_cluster_healthy` at 0, never gets `SetRedisClusterDynamicConfig` applied (`maxMemoryPercentOfLimit`), and cannot be created or scaled at all.

The fix always passes `--cert` and `--key`, resolved through the existing `getTLSSecretKeys` helper so `spec.TLS.cert` and `spec.TLS.key` are honoured and the defaults stay `tls.crt` / `tls.key`. The certificate comes from the TLS secret the operator already mounts at `/tls`, so no new secret, API field or CRD change is required.

This mirrors what the generated liveness and readiness probes already do (`getProbeInfo` in `internal/k8sutils/statefulset.go`) and what the Go client does via `getRedisTLSConfig` (`internal/k8sutils/secrets.go`). Behaviour is unchanged for `tls-auth-clients optional` and `no`.

Fixes #1863

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Verified against a live TLS-enabled cluster running with `tls-auth-clients yes`. The operator's own command fails:

```
redis-cli --cluster check 127.0.0.1:6379 --tls --cacert /tls/ca.crt --insecure; echo exit=$?
# exit=1
```

The same command with the client certificate added returns the three `[OK]` lines `checkClusterHealth` looks for:

```
redis-cli --cluster check 127.0.0.1:6379 --tls --cacert /tls/ca.crt --cert /tls/tls.crt --key /tls/tls.key; echo exit=$?
# exit=0
```

Tests changed:

- `TestGetRedisTLSArgs`: updated expectations, plus a new case covering custom `cert` / `key` secret keys
- `TestExecuteSingleLeaderAddSlots`: updated TLS flag expectation

`go build ./...`, `go vet ./...` and `go test ./internal/k8sutils/...` pass. The `TestAPIs` suites in `internal/controller/*` fail locally for an unrelated reason: envtest cannot start a control plane without `/usr/local/kubebuilder/bin/etcd`.

No documentation change seemed warranted since no user-facing option changes, but happy to add a note to the TLS guide if you would prefer one.
