### PR TITLE
chore: update version to 0.26.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ===========================
 
 # Current Operator version
-VERSION ?= 0.24.0
+VERSION ?= 0.26.0
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 0.25.0
-appVersion: "0.25.0"
+version: 0.26.0
+appVersion: "0.26.0"
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
 engine: gotpl
 maintainers:

--- a/charts/redis-operator/README.md
+++ b/charts/redis-operator/README.md
@@ -123,7 +123,7 @@ kubectl create secret tls <webhook-server-cert> --key tls.key --cert tls.crt -n 
 | redisOperator.imagePullPolicy | string | `"Always"` |  |
 | redisOperator.imagePullSecrets | list | `[]` |  |
 | redisOperator.imageTag | string | `""` |  |
-| redisOperator.initContainerImageTag | string | `"v0.25.0"` | initContainerImageTag is the init-config init container image tag. If not specified, defaults to imageTag, then falls back to chart appVersion. Typically only needs to be set when using a different version for the init container. |
+| redisOperator.initContainerImageTag | string | `"v0.26.0"` | initContainerImageTag is the init-config init container image tag. If not specified, defaults to imageTag, then falls back to chart appVersion. Typically only needs to be set when using a different version for the init container. |
 | redisOperator.metrics.bindAddress | string | `":8080"` |  |
 | redisOperator.metrics.enabled | bool | `true` |  |
 | redisOperator.name | string | `"redis-operator"` |  |

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -7,7 +7,7 @@ redisOperator:
   # -- initContainerImageTag is the init-config init container image tag.
   # If not specified, defaults to imageTag, then falls back to chart appVersion.
   # Typically only needs to be set when using a different version for the init container.
-  initContainerImageTag: "v0.25.0"
+  initContainerImageTag: "v0.26.0"
   imagePullPolicy: Always
   imagePullSecrets: []
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opstree/redis-operator
-  newTag: v0.24.0
+  newTag: v0.26.0

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -83,7 +83,7 @@ gcs_engine_id = "016691298986124624340:x7qv2dywdao"
 # current release branch. Never is rc.
 release_branch = "release-1.27.0"
 # the main version. Never is rc.
-release_version = "0.24.0"
+release_version = "0.26.0"
 
 # shown for production
 supported_k8s = "1.23"


### PR DESCRIPTION
**Description**

Release bump for `v0.26.0`, following the same six-file shape as the merged #1660 (v0.24.0) and #1631 (v0.23.0).

The operator was released as `v0.26.0` on 2026-07-15, but `main` is still on older versions in several places, and two of them are **two releases behind**:

| File | on `main` | here |
| --- | --- | --- |
| `charts/redis-operator/Chart.yaml` (`version`, `appVersion`) | `0.25.0` | `0.26.0` |
| `charts/redis-operator/values.yaml` (`initContainerImageTag`) | `v0.25.0` | `v0.26.0` |
| `charts/redis-operator/README.md` | `v0.25.0` | regenerated |
| `Makefile` (`VERSION`) | `0.24.0` | `0.26.0` |
| `config/manager/kustomization.yaml` (`newTag`) | `v0.24.0` | `v0.26.0` |
| `docs/config.toml` (`release_version`) | `0.24.0` | `0.26.0` |

The chart matters most for users: `operator-deployment.yaml` resolves the image as `{{ .Values.redisOperator.imageTag | default (printf "v%s" .Chart.AppVersion) }}`, so while the published chart's appVersion says `0.25.0`, `helm install` from `ot-container-kit.github.io/helm-charts` deploys the **v0.25.0** operator. `initContainerImageTag` is pinned explicitly rather than left empty, so it needs the same bump or the init container would stay on v0.25.0 while the operator runs v0.26.0.

No CRD changes are needed: `charts/redis-operator/crds/crds.yaml` on `main` is already byte-identical to the one in the `v0.26.0` tag.

Fixes #1841

**Relationship to #1784**

Credit where it is due: @chicagomg opened #1784 back in 2026-05-30 doing exactly this for `v0.25.0`, and it identified the pattern and the same six files. It was never merged. In the meantime the chart alone reached `0.25.0` on `main` by another route, which left #1784 partly stale and the other three files stranded on `0.24.0`.

This PR supersedes #1784 by taking everything to the current release in one go. Happy to close this instead if you would rather merge #1784 first and have me rebase on top — whichever is less work for you.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass. — no new tests; a release bump is covered by the existing `ct lint` / chart-testing pipeline.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary. — README regenerated with `jnorwood/helm-docs:latest`, the same image `ci.yaml` uses.

**Additional Context**

Verified locally:

- `helm lint charts/redis-operator` passes.
- `helm template` resolves both the container image and the `INIT_CONTAINER_IMAGE` env var to `quay.io/opstree/redis-operator:v0.26.0`.
- `quay.io/opstree/redis-operator:v0.26.0` exists on quay.
- README regenerated with the helm-docs image CI uses; the only drift is the `initContainerImageTag` row, and no other chart README changed, so generated docs were already in sync.
- `KIND_VERSION ?= v0.24.0` in the `Makefile` is deliberately untouched — it is the kind tool version, not the operator release.

Why this release in particular is worth unblocking for Helm users: v0.26.0 is where `shouldScaleUpExistingCluster`, `RepairDisconnectedNodes` and `RepairStaleReplication` land. On v0.25.0, a RedisCluster that loses a leader still hits `if leaderCount <= 2` and retries `--cluster create`, which fails permanently against a populated cluster (`[ERR] Node ... is not empty`), so the cluster is never repaired and the operator loops. We hit exactly that: a cluster split in April and nothing reconciled it for four months. Anyone installing via Helm cannot reach that fix today. #1841 has five people asking for the chart release.
