### PR TITLE
fix(chart): allow configuring TLS secret volume mode and default to 0440

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-cluster
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.17.4
-appVersion: "0.17.4"
+version: 0.17.5
+appVersion: "0.17.5"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -49,6 +49,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.ca | string | `"ca.crt"` |  |
 | TLS.cert | string | `"tls.crt"` |  |
 | TLS.key | string | `"tls.key"` |  |
+| TLS.secret.defaultMode | int | `288` |  |
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
 | annotations | object | `{}` |  |

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -94,7 +94,7 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      secretName: {{ .Values.TLS.secret.secretName | quote }}
+      {{- toYaml .Values.TLS.secret | nindent 6 }}
   {{- end }}
   {{- if or (and .Values.acl.secret (ne .Values.acl.secret.secretName "")) .Values.acl.persistentVolumeClaim }}
   acl:

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -257,12 +257,6 @@ TLS:
   # RedisCluster spec as-is.
   secret:
     secretName: ""
-    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
-    # which leaves the Redis private key readable by every user on the node.
-    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
-    # whatever is set here, making 0440 the tightest reachable mode. It works
-    # with the podSecurityContext above because kubelet chowns the files to
-    # root:fsGroup.
     defaultMode: 0440
 
 acl:

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -253,8 +253,17 @@ TLS:
   ca: ca.crt
   cert: tls.crt
   key: tls.key
+  # Any corev1.SecretVolumeSource field is accepted here and passed to the
+  # RedisCluster spec as-is.
   secret:
     secretName: ""
+    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
+    # which leaves the Redis private key readable by every user on the node.
+    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
+    # whatever is set here, making 0440 the tightest reachable mode. It works
+    # with the podSecurityContext above because kubelet chowns the files to
+    # root:fsGroup.
+    defaultMode: 0440
 
 acl:
   # Configure ACL from Kubernetes Secret

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-replication
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.17.1
+appVersion: "0.17.1"
 type: application
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/README.md
+++ b/charts/redis-replication/README.md
@@ -47,6 +47,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.ca | string | `"ca.crt"` |  |
 | TLS.cert | string | `"tls.crt"` |  |
 | TLS.key | string | `"tls.key"` |  |
+| TLS.secret.defaultMode | int | `288` |  |
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -101,7 +101,7 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      secretName: {{ .Values.TLS.secret.secretName | quote }}
+      {{- toYaml .Values.TLS.secret | nindent 6 }}
   {{- end }}
   {{- if or (and .Values.acl.secret (ne .Values.acl.secret.secretName "")) .Values.acl.persistentVolumeClaim }}
   acl:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -193,8 +193,17 @@ TLS:
   ca: ca.crt
   cert: tls.crt
   key: tls.key
+  # Any corev1.SecretVolumeSource field is accepted here and passed to the
+  # spec as-is.
   secret:
     secretName: ""
+    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
+    # which leaves the Redis private key readable by every user on the node.
+    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
+    # whatever is set here, making 0440 the tightest reachable mode. It works
+    # with the podSecurityContext above because kubelet chowns the files to
+    # root:fsGroup.
+    defaultMode: 0440
 
 acl:
   # Configure ACL from Kubernetes Secret

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -197,12 +197,6 @@ TLS:
   # spec as-is.
   secret:
     secretName: ""
-    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
-    # which leaves the Redis private key readable by every user on the node.
-    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
-    # whatever is set here, making 0440 the tightest reachable mode. It works
-    # with the podSecurityContext above because kubelet chowns the files to
-    # root:fsGroup.
     defaultMode: 0440
 
 acl:

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: redis-sentinel
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.13
-appVersion: "0.16.13"
+version: 0.16.14
+appVersion: "0.16.14"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-sentinel/README.md
+++ b/charts/redis-sentinel/README.md
@@ -47,6 +47,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.ca | string | `"ca.crt"` |  |
 | TLS.cert | string | `"tls.crt"` |  |
 | TLS.key | string | `"tls.key"` |  |
+| TLS.secret.defaultMode | int | `288` |  |
 | TLS.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |
 | annotations | object | `{}` |  |

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -101,7 +101,7 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      secretName: {{ .Values.TLS.secret.secretName | quote }}
+      {{- toYaml .Values.TLS.secret | nindent 6 }}
   {{- end }}
   {{- if .Values.pdb.enabled }}
   pdb:

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -176,12 +176,6 @@ TLS:
   # spec as-is.
   secret:
     secretName: ""
-    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
-    # which leaves the Redis private key readable by every user on the node.
-    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
-    # whatever is set here, making 0440 the tightest reachable mode. It works
-    # with the podSecurityContext above because kubelet chowns the files to
-    # root:fsGroup.
     defaultMode: 0440
 
 pdb:

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -172,8 +172,17 @@ TLS:
   ca: ca.crt
   cert: tls.crt
   key: tls.key
+  # Any corev1.SecretVolumeSource field is accepted here and passed to the
+  # spec as-is.
   secret:
     secretName: ""
+    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
+    # which leaves the Redis private key readable by every user on the node.
+    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
+    # whatever is set here, making 0440 the tightest reachable mode. It works
+    # with the podSecurityContext above because kubelet chowns the files to
+    # root:fsGroup.
+    defaultMode: 0440
 
 pdb:
   enabled: false

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: redis
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
-version: 0.16.9
-appVersion: "0.16.9"
+version: 0.16.10
+appVersion: "0.16.10"
 home: https://github.com/ot-container-kit/redis-operator
 sources:
   - https://github.com/ot-container-kit/redis-operator

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -46,6 +46,7 @@ helm delete <my-release> --namespace <namespace>
 | TLS.ca | string | `"ca.crt"` |  |
 | TLS.cert | string | `"tls.crt"` |  |
 | TLS.key | string | `"tls.key"` |  |
+| TLS.secret.defaultMode | int | `288` |  |
 | TLS.secret.secretName | string | `""` |  |
 | acl.secret.secretName | string | `""` |  |
 | affinity | object | `{}` |  |

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -92,7 +92,7 @@ spec:
     cert: {{ .Values.TLS.cert | quote }}
     key: {{ .Values.TLS.key | quote }}
     secret:
-      secretName: {{ .Values.TLS.secret.secretName | quote }}
+      {{- toYaml .Values.TLS.secret | nindent 6 }}
   {{- end }}
   {{- if or (and .Values.acl.secret (ne .Values.acl.secret.secretName "")) .Values.acl.persistentVolumeClaim }}
   acl:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -181,12 +181,6 @@ TLS:
   # spec as-is.
   secret:
     secretName: ""
-    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
-    # which leaves the Redis private key readable by every user on the node.
-    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
-    # whatever is set here, making 0440 the tightest reachable mode. It works
-    # with the podSecurityContext above because kubelet chowns the files to
-    # root:fsGroup.
     defaultMode: 0440
 
 acl:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -177,8 +177,17 @@ TLS:
   ca: ca.crt
   cert: tls.crt
   key: tls.key
+  # Any corev1.SecretVolumeSource field is accepted here and passed to the
+  # spec as-is.
   secret:
     secretName: ""
+    # Kubernetes mounts secret volumes with mode 0644 unless told otherwise,
+    # which leaves the Redis private key readable by every user on the node.
+    # Secret volumes are always mounted read-only, so kubelet ORs 0440 into
+    # whatever is set here, making 0440 the tightest reachable mode. It works
+    # with the podSecurityContext above because kubelet chowns the files to
+    # root:fsGroup.
+    defaultMode: 0440
 
 acl:
   # Configure ACL from Kubernetes Secret


### PR DESCRIPTION
Closes #1868

### What

`charts/redis-cluster` copied a single field out of `TLS.secret` and discarded the rest:

```yaml
    secret:
      secretName: {{ .Values.TLS.secret.secretName | quote }}
```

The `RedisCluster` CRD declares `spec.TLS.secret` as a full `corev1.SecretVolumeSource`, and the operator forwards it to the StatefulSet untouched, so `defaultMode`, `items` and `optional` already work when the CR is applied directly. Only the chart was dropping them.

This passes the whole map through instead:

```yaml
    secret:
      {{- toYaml .Values.TLS.secret | nindent 6 }}
```

and sets `defaultMode: 0440` as the chart default in `values.yaml`.

### Why 0440

~~Kubernetes mounts secret volumes at 0644 unless told otherwise, which leaves the Redis private key readable by every user on the node at `/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~secret/tls-certs/..data/tls.key`.~~

Secret volumes are always mounted read-only, so kubelet ORs `0440` into whatever mode is requested (`pkg/volume/volume_linux.go`). `0440` is therefore the tightest mode actually reachable, and asking for anything stricter such as `0400` still yields `0440`.

It works with the chart's default `podSecurityContext` (`runAsUser: 1000`, `fsGroup: 1000`) because kubelet chowns the files to `root:fsGroup` and redis-server reads them through the group bit.

### Compatibility

The template change alone is backwards compatible. Values that only set `secretName` render exactly as before apart from quoting, which is YAML-equivalent.

The `defaultMode: 0440` default is the part with a behaviour change. It is safe for the chart's own defaults, but a user who overrides `podSecurityContext` to drop `fsGroup` while running as non-root would find redis-server unable to read its own key. Say the word and I will drop that hunk and keep only the passthrough, which still lets operators set the mode themselves.

### Verification

```
helm lint charts/redis-cluster            # 0 failed
```

TLS enabled renders the mode, TLS disabled is unchanged:

```
$ helm template t charts/redis-cluster --set TLS.secret.secretName=demo-tls | grep -A 6 "^  TLS:"
  TLS:
    ca: "ca.crt"
    cert: "tls.crt"
    key: "tls.key"
    secret:
      defaultMode: 288
      secretName: demo-tls
```

`288` is `0440` in decimal, which is what the int32 field expects.

Chart version and appVersion bumped to 0.17.5, and `README.md` regenerated with `helm-docs`.

One note for reviewers: `--set TLS.secret.defaultMode=0400` renders the string `"0400"` and would fail CRD validation. That is standard Helm `--set` behaviour for leading-zero numerics rather than anything specific to this chart. A values file, or `--set ...=256`, both produce a correct integer.
