### PR TITLE
fix(replication): mount config volume for embedded sentinel to persists across container restarts and allow RO filesystem

### DIFF
--- a/internal/controller/redisreplication/redisreplication_sentinel.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel.go
@@ -92,6 +92,14 @@ func buildSentinelPodTemplate(rr *rrvb2.RedisReplication, labels map[string]stri
 	if sentinel.ServiceAccountName != nil {
 		spec.ServiceAccountName = *sentinel.ServiceAccountName
 	}
+	spec.Volumes = []corev1.Volume{
+		{
+			Name: common.VolumeNameConfig,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -114,6 +122,12 @@ func buildSentinelContainer(rr *rrvb2.RedisReplication) corev1.Container {
 			},
 		},
 		Env: buildSentinelEnv(rr),
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      common.VolumeNameConfig,
+				MountPath: "/etc/redis",
+			},
+		},
 	}
 	if rr.Spec.Sentinel.Resources != nil {
 		container.Resources = *rr.Spec.Sentinel.Resources

--- a/internal/controller/redisreplication/redisreplication_sentinel_test.go
+++ b/internal/controller/redisreplication/redisreplication_sentinel_test.go
@@ -6,6 +6,7 @@ import (
 
 	commonapi "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/service/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,9 @@ func TestBuildSentinelPodTemplate(t *testing.T) {
 	assert.Equal(t, "sentinel-sa", spec.ServiceAccountName)
 	require.Len(t, spec.Containers, 1)
 	assert.Equal(t, "sentinel", spec.Containers[0].Name)
+	require.Len(t, spec.Volumes, 1)
+	assert.Equal(t, common.VolumeNameConfig, spec.Volumes[0].Name)
+	assert.NotNil(t, spec.Volumes[0].EmptyDir)
 }
 
 // TestBuildSentinelPodTemplateOmitsUnsetPlacement ensures nil/empty placement
@@ -142,6 +146,9 @@ func TestBuildSentinelContainer(t *testing.T) {
 	assert.Same(t, securityContext, container.SecurityContext)
 	require.Len(t, container.Ports, 1)
 	assert.Equal(t, int32(26379), container.Ports[0].ContainerPort)
+	require.Len(t, container.VolumeMounts, 1)
+	assert.Equal(t, common.VolumeNameConfig, container.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/redis", container.VolumeMounts[0].MountPath)
 }
 
 func TestBuildSentinelEnv(t *testing.T) {


### PR DESCRIPTION
**Description**

When using the embedded Sentinel under RedisReplication.spec.sentinel, the generated Sentinel StatefulSet does not mount a writable volume on /etc/redis. And there is currently no way to configure and mount an emptyDir for it.

If `securityContext.readOnlyRootFilesystem` is set to true, the pod fails to start because the Redis Sentinel container requires /etc/redis/sentinel.conf to be writable.

This PR create a config emptyDir volume and mounts it at /etc/redis for the Sentinel StatefulSet controlled by a RedisReplication.
 
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes [#ISSUE](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1867)

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ x] Tests have been added/modified and all tests pass.
- [ x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ x] I have performed a self-review of my own code.
- [ x] Documentation has been updated or added where necessary.

**Additional Context**

Additionally, Sentinel currently loses the runtime changes written in sentinel.conf after a container restart because this file is not stored on a volume, as explained in [https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1725](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1725).

This PR basically extends what has been done in [https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1725](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1725) for RedisSentinel, but for RedisReplication.spec.sentinel.