### PR TITLE
fix: enable Redis 7+ features for clusterVersion >= v7 instead of exactly v7

### DIFF
--- a/api/rediscluster/v1beta2/rediscluster_types.go
+++ b/api/rediscluster/v1beta2/rediscluster_types.go
@@ -30,6 +30,11 @@ type RedisClusterSpec struct {
 	HostNetwork      bool                    `json:"hostNetwork,omitempty"`
 	// +kubebuilder:default:=6379
 	Port *int `json:"port,omitempty"`
+	// ClusterVersion is the major version of the Redis image in use, written as
+	// `v6`, `v7`, `v8` and so on. It must match the major version of the image
+	// configured for the cluster: Redis 7+ features such as hostname based
+	// cluster announcements and CLUSTER ADDSLOTSRANGE are enabled for `v7` and
+	// every later major version, and disabled for `v6` and older.
 	// +kubebuilder:default:=v7
 	ClusterVersion     *string                      `json:"clusterVersion,omitempty"`
 	RedisConfig        *common.RedisConfig          `json:"redisConfig,omitempty"`

--- a/charts/redis-operator/crds/crds.yaml
+++ b/charts/redis-operator/crds/crds.yaml
@@ -5622,6 +5622,12 @@ spec:
                 type: integer
               clusterVersion:
                 default: v7
+                description: |-
+                  ClusterVersion is the major version of the Redis image in use, written as
+                  `v6`, `v7`, `v8` and so on. It must match the major version of the image
+                  configured for the cluster: Redis 7+ features such as hostname based
+                  cluster announcements and CLUSTER ADDSLOTSRANGE are enabled for `v7` and
+                  every later major version, and disabled for `v6` and older.
                 type: string
               env:
                 items:

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -125,7 +125,7 @@ securityContext: {}
 #  runAsNonRoot: true
 #  runAsUser: 1000
 
-# Feature gates for alpha/experimental features.
+# -- Feature gates for alpha/experimental features.
 # Only set gates that are supported by the deployed operator image; passing an
 # unknown gate makes the operator exit at startup.
 featureGates: {}

--- a/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
+++ b/config/crd/bases/redis.redis.opstreelabs.in_redisclusters.yaml
@@ -223,6 +223,12 @@ spec:
                 type: integer
               clusterVersion:
                 default: v7
+                description: |-
+                  ClusterVersion is the major version of the Redis image in use, written as
+                  `v6`, `v7`, `v8` and so on. It must match the major version of the image
+                  configured for the cluster: Redis 7+ features such as hostname based
+                  cluster announcements and CLUSTER ADDSLOTSRANGE are enabled for `v7` and
+                  every later major version, and disabled for `v6` and older.
                 type: string
               env:
                 items:

--- a/docs/content/en/docs/CRD Reference/API Reference/_index.md
+++ b/docs/content/en/docs/CRD Reference/API Reference/_index.md
@@ -213,7 +213,7 @@ _Appears in:_
 | `kubernetesConfig` _[KubernetesConfig](#kubernetesconfig)_ |  |  |  |
 | `hostNetwork` _boolean_ |  |  |  |
 | `port` _integer_ |  | 6379 |  |
-| `clusterVersion` _string_ |  | v7 |  |
+| `clusterVersion` _string_ | ClusterVersion is the major version of the Redis image in use, written as<br />`v6`, `v7`, `v8` and so on. It must match the major version of the image<br />configured for the cluster: Redis 7+ features such as hostname based<br />cluster announcements and CLUSTER ADDSLOTSRANGE are enabled for `v7` and<br />every later major version, and disabled for `v6` and older. | v7 |  |
 | `redisConfig` _[RedisConfig](#redisconfig)_ |  |  |  |
 | `redisLeader` _[RedisLeader](#redisleader)_ |  |  |  |
 | `redisFollower` _[RedisFollower](#redisfollower)_ |  |  |  |

--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -94,7 +94,7 @@ func GenerateConfig() error {
 		if clusterAnnounceIP != "" {
 			cfg.Append("cluster-announce-ip", clusterAnnounceIP)
 		}
-		if redisMajorVersion == "v7" {
+		if util.IsRedisVersionAtLeastV7(redisMajorVersion) {
 			fqdnName, err := fqdn.FqdnHostname()
 			if err != nil {
 				log.Printf("Warning: Failed to get FQDN: %v", err)
@@ -117,7 +117,7 @@ func GenerateConfig() error {
 
 		if clusterMode == "cluster" {
 			cfg.Append("tls-cluster", "yes")
-			if redisMajorVersion == "v7" && nodeport == "false" {
+			if util.IsRedisVersionAtLeastV7(redisMajorVersion) && nodeport == "false" {
 				cfg.Append("cluster-preferred-endpoint-type", "hostname")
 			}
 		}

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -104,3 +104,48 @@ vars currentEpoch 3 lastVoteEpoch 0
 
 	t.Logf("Successfully updated nodes.conf with new IP %s", newIP)
 }
+
+func Test_GenerateConfig_RedisMajorVersionGates(t *testing.T) {
+	tests := []struct {
+		name              string
+		redisMajorVersion string
+		expectV7Features  bool
+	}{
+		{name: "v6 keeps the pre-7 configuration", redisMajorVersion: "v6", expectV7Features: false},
+		{name: "v7 enables hostname based clustering", redisMajorVersion: "v7", expectV7Features: true},
+		{name: "v8 also enables hostname based clustering", redisMajorVersion: "v8", expectV7Features: true},
+		{name: "v10 is not compared lexically", redisMajorVersion: "v10", expectV7Features: true},
+		{name: "unparseable version falls back to the v7 default", redisMajorVersion: "latest", expectV7Features: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			confPath := filepath.Join(tmp, "redis.conf")
+
+			t.Setenv("REDIS_CONFIG_FILE", confPath)
+			t.Setenv("SETUP_MODE", "cluster")
+			t.Setenv("NODE_CONF_DIR", tmp)
+			t.Setenv("NODEPORT", "false")
+			t.Setenv("TLS_MODE", "true")
+			t.Setenv("REDIS_TLS_CERT", "/tls/tls.crt")
+			t.Setenv("REDIS_TLS_CERT_KEY", "/tls/tls.key")
+			t.Setenv("REDIS_MAJOR_VERSION", tt.redisMajorVersion)
+
+			require.NoError(t, GenerateConfig())
+
+			raw, err := os.ReadFile(confPath)
+			require.NoError(t, err)
+			conf := string(raw)
+
+			if tt.expectV7Features {
+				assert.Contains(t, conf, "cluster-preferred-endpoint-type hostname")
+				// cluster-announce-hostname is only written when the FQDN lookup
+				// succeeds, which is environment dependent, so it is not asserted here.
+			} else {
+				assert.NotContains(t, conf, "cluster-preferred-endpoint-type")
+				assert.NotContains(t, conf, "cluster-announce-hostname")
+			}
+		})
+	}
+}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -18,6 +18,7 @@ import (
 	common "github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/envs"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/features"
+	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 	retry "github.com/avast/retry-go"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/samber/lo"
@@ -82,7 +83,7 @@ func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.Red
 		port int
 	)
 	port = *cr.Spec.Port
-	if cr.Spec.ClusterVersion != nil && *cr.Spec.ClusterVersion == "v7" {
+	if cr.Spec.ClusterVersion != nil && util.IsRedisVersionAtLeastV7(*cr.Spec.ClusterVersion) {
 		host = rd.FQDN()
 	} else {
 		host = getRedisServerIP(ctx, client, rd)
@@ -203,7 +204,7 @@ func executeSingleLeaderAddSlots(ctx context.Context, client kubernetes.Interfac
 
 	// Redis 7+ supports ADDSLOTSRANGE which takes a start-end pair instead
 	// of listing every slot number individually — avoids the URL length issue entirely.
-	if cr.Spec.ClusterVersion != nil && *cr.Spec.ClusterVersion == "v7" {
+	if cr.Spec.ClusterVersion != nil && util.IsRedisVersionAtLeastV7(*cr.Spec.ClusterVersion) {
 		cmd := []string{"redis-cli"}
 		cmd = append(cmd, flags...)
 		cmd = append(cmd, "CLUSTER", "ADDSLOTSRANGE", "0", "16383")

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -485,7 +485,16 @@ func TestExecuteSingleLeaderAddSlots(t *testing.T) {
 			rangeCommand:  true,
 		},
 		{
+			name:         "redis v8 also uses a single ADDSLOTSRANGE command",
+			redisCluster: newCluster(ptr.To("v8"), false, false),
+			rangeCommand: true,
+		},
+		{
 			name:         "redis v6 falls back to batched ADDSLOTS",
+			redisCluster: newCluster(ptr.To("v6"), false, false),
+		},
+		{
+			name:         "unset cluster version falls back to batched ADDSLOTS",
 			redisCluster: newCluster(nil, false, false),
 		},
 		{
@@ -568,6 +577,48 @@ func TestCreateMultipleLeaderRedisCommand(t *testing.T) {
 				"mycluster-leader-0.mycluster-leader-headless.default.svc.cluster.local:6379",
 				"mycluster-leader-1.mycluster-leader-headless.default.svc.cluster.local:6379",
 				"mycluster-leader-2.mycluster-leader-headless.default.svc.cluster.local:6379",
+				"--cluster-yes",
+			},
+		},
+		{
+			name: "Multiple leaders cluster version v8 keeps FQDN addressing",
+			redisCluster: &rcvb2.RedisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mycluster",
+					Namespace: "default",
+				},
+				Spec: rcvb2.RedisClusterSpec{
+					ClusterSize:    ptr.To(int32(3)),
+					ClusterVersion: ptr.To("v8"),
+					Port:           ptr.To(6379),
+				},
+			},
+			expectedCommands: []string{
+				"redis-cli", "--cluster", "create",
+				"mycluster-leader-0.mycluster-leader-headless.default.svc.cluster.local:6379",
+				"mycluster-leader-1.mycluster-leader-headless.default.svc.cluster.local:6379",
+				"mycluster-leader-2.mycluster-leader-headless.default.svc.cluster.local:6379",
+				"--cluster-yes",
+			},
+		},
+		{
+			name: "Multiple leaders cluster version v6 uses pod IPs",
+			redisCluster: &rcvb2.RedisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mycluster",
+					Namespace: "default",
+				},
+				Spec: rcvb2.RedisClusterSpec{
+					ClusterSize:    ptr.To(int32(3)),
+					ClusterVersion: ptr.To("v6"),
+					Port:           ptr.To(6379),
+				},
+			},
+			expectedCommands: []string{
+				"redis-cli", "--cluster", "create",
+				"192.168.1.1:6379",
+				"192.168.1.2:6379",
+				"192.168.1.3:6379",
 				"--cluster-yes",
 			},
 		},

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,42 @@
+package util
+
+import "strconv"
+
+// redisDefaultMajorVersion is the major version assumed when the configured
+// value cannot be parsed. It matches the `v7` default of
+// RedisCluster.spec.clusterVersion, so unset or malformed values keep the
+// behaviour existing clusters already rely on.
+const redisDefaultMajorVersion = 7
+
+// RedisMajorVersion extracts the major version number from a value of the form
+// `v7`, `7`, `v7.2` or `v8.0.1`. Values that do not start with a digit (after an
+// optional leading `v`) fall back to redisDefaultMajorVersion.
+func RedisMajorVersion(version string) int {
+	v := version
+	if len(v) > 0 && (v[0] == 'v' || v[0] == 'V') {
+		v = v[1:]
+	}
+	i := 0
+	for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return redisDefaultMajorVersion
+	}
+	major, err := strconv.Atoi(v[:i])
+	if err != nil {
+		// Only reachable for absurdly long digit runs; treat as the default.
+		return redisDefaultMajorVersion
+	}
+	return major
+}
+
+// IsRedisVersionAtLeastV7 reports whether the given version string denotes
+// Redis 7 or newer. Features introduced in Redis 7.0 — cluster-announce-hostname,
+// cluster-preferred-endpoint-type and CLUSTER ADDSLOTSRANGE — are available for
+// every later major version too, so they must be gated on `>= 7` rather than on
+// an exact `v7` match. Otherwise a user honestly setting `clusterVersion: v8`
+// would silently get the Redis 6 code path.
+func IsRedisVersionAtLeastV7(version string) bool {
+	return RedisMajorVersion(version) >= 7
+}

--- a/internal/util/version_test.go
+++ b/internal/util/version_test.go
@@ -1,0 +1,57 @@
+package util
+
+import "testing"
+
+func TestRedisMajorVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    int
+	}{
+		{name: "v6", version: "v6", want: 6},
+		{name: "v7", version: "v7", want: 7},
+		{name: "v8", version: "v8", want: 8},
+		{name: "v10 is not lexically compared", version: "v10", want: 10},
+		{name: "major without leading v", version: "7", want: 7},
+		{name: "uppercase V", version: "V8", want: 8},
+		{name: "minor version is ignored", version: "v7.2", want: 7},
+		{name: "patch version is ignored", version: "v8.0.1", want: 8},
+		{name: "minor version without leading v", version: "1.0", want: 1},
+		{name: "empty falls back to the default", version: "", want: 7},
+		{name: "garbage falls back to the default", version: "latest", want: 7},
+		{name: "lone v falls back to the default", version: "v", want: 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedisMajorVersion(tt.version); got != tt.want {
+				t.Errorf("RedisMajorVersion(%q) = %d, want %d", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRedisVersionAtLeastV7(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "v5 is below 7", version: "v5", want: false},
+		{name: "v6 is below 7", version: "v6", want: false},
+		{name: "v7 is supported", version: "v7", want: true},
+		{name: "v8 is supported", version: "v8", want: true},
+		{name: "v10 is supported", version: "v10", want: true},
+		{name: "bare 7 is supported", version: "7", want: true},
+		{name: "v7.2 is supported", version: "v7.2", want: true},
+		{name: "1.0 is below 7", version: "1.0", want: false},
+		{name: "empty defaults to v7 behaviour", version: "", want: true},
+		{name: "garbage defaults to v7 behaviour", version: "not-a-version", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRedisVersionAtLeastV7(tt.version); got != tt.want {
+				t.Errorf("IsRedisVersionAtLeastV7(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`RedisCluster.spec.clusterVersion` is a free-form string that defaults to `v7`, and every place that gates Redis 7+ behaviour compares it with an exact string match against `"v7"`. quay.io/opstree/redis now publishes Redis 8 images (v8.2.9 through v8.10.1), so a user who runs one of them and honestly sets `clusterVersion: v8` silently drops onto the **Redis 6 code path**:

- no `cluster-announce-hostname`
- no `cluster-preferred-endpoint-type hostname` under TLS
- IP-based cluster addressing instead of FQDN
- 17 batched `CLUSTER ADDSLOTS` calls instead of a single `CLUSTER ADDSLOTSRANGE`

Nothing errors out — the cluster just comes up in a weaker configuration. Leaving the default at `v7` while running a v8 image happens to work, but only by accident.

## Fix

New helper in `internal/util/version.go`:

- `RedisMajorVersion(string) int` — parses `v7`, `7`, `v7.2`, `v8.0.1` (optional leading `v`, then the leading digit run) and falls back to `7` when there are no digits to read.
- `IsRedisVersionAtLeastV7(string) bool` — the gate the four call sites now use.

The four call sites that changed:

| File | Gate |
| --- | --- |
| `internal/agent/bootstrap/redis/config.go:97` | `cluster-announce-hostname` |
| `internal/agent/bootstrap/redis/config.go:120` | `cluster-preferred-endpoint-type hostname` (TLS, non-NodePort) |
| `internal/k8sutils/redis.go:86` | FQDN vs pod IP for cluster node addressing |
| `internal/k8sutils/redis.go:207` | `CLUSTER ADDSLOTSRANGE` vs per-slot `ADDSLOTS` |

The `REDIS_MAJOR_VERSION` default of `"v7"` in `config.go:43` is unchanged, as is the `+kubebuilder:default:=v7` on the field.

## Compatibility

- `v7` and unset behave exactly as before, so existing clusters are unaffected.
- `v6` and older keep the pre-7 path.
- **One deliberate behaviour change:** an unparseable value such as `clusterVersion: latest` used to fail the `== "v7"` check and fall to the Redis 6 path; it now falls back to the `v7` default instead. Treating a malformed value as the field's own default is the more predictable of the two, and `latest` alongside a modern image was getting the wrong path before.
- The `nil` guard on `cr.Spec.ClusterVersion` is kept, so a CR with no version set (only reachable when the CRD default is bypassed) still takes the pre-7 path.

## Not done, on purpose

A `+kubebuilder:validation:Pattern` of `^v?[0-9]+$` was considered and skipped: it would reject the `v7.2`-style values the parser is explicitly built to tolerate, and would block updates to existing CRs that already store something like `v7.0.15`.

## Tests

- `internal/util/version_test.go` covers `v6`, `v7`, `v8`, `v10`, `7`, `V8`, `v7.2`, `v8.0.1`, `1.0`, empty, garbage and a lone `v`.
- `internal/k8sutils/redis_test.go` gains v8/v6 cases for both the ADDSLOTS choice and FQDN-vs-IP addressing.
- `internal/agent/bootstrap/redis/config_test.go` gains `Test_GenerateConfig_RedisMajorVersionGates`, checking the config gates for v6/v7/v8/v10/`latest`.
- `make codegen` was run, so the CRD YAML, chart CRDs and API reference docs are in sync.

`go test ./internal/... ./api/...` passes apart from the four envtest suites, which fail on this machine for want of a local etcd binary and fail identically on an unmodified tree.

## Related

Issue #1769 is **not** an instance of this bug — that report sets `clusterVersion: v7` with a v7.4.8 image, so it was already on the v7 path; its `Invalid IP address or hostname` error is headless-service DNS not resolving in that cluster. This change does not affect it.

## Second commit: unblocking the Helm Docs Test job

The `helm_docs_test` job fails on an up-to-date `main`, so it failed here too before anything in this PR could turn green — and `validate_examples` and the E2E job `needs:` it, so they never ran either.

The cause is in `charts/redis-operator/values.yaml`: the comment above `featureGates` starts with a plain `#` rather than the `# --` marker helm-docs looks for, so helm-docs emits an empty description while the committed `README.md` still carries the text. This PR does not touch `values.yaml`, `Chart.yaml` or `README.md` in that chart otherwise — they are byte-identical to `main` — so the failure was inherited, not introduced.

The second commit adds the missing `# --` marker. `README.md` needs no change: after the fix, both helm-docs 1.14.2 and the `jnorwood/helm-docs:latest` image the CI job uses regenerate the README byte-for-byte as committed. Happy to split this into its own PR if you would rather keep the two apart.
