### PR TITLE
fix(utils): drop redis-cli -t from the cluster health check

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -679,33 +679,37 @@ func RedisClusterStatusHealth(ctx context.Context, client kubernetes.Interface, 
 	return false
 }
 
-// checkClusterHealth performs a single cluster health check against a specific pod
-// clusterCheckConnectTimeoutSeconds bounds how long redis-cli waits when dialing
-// a cluster peer during the health check.
+// clusterCheckExecTimeout bounds a single `redis-cli --cluster check` exec.
 //
-// redis-cli has no default connect timeout, so `--cluster check` blocks
-// indefinitely on any node whose recorded address is stale -- which is exactly
-// the state left behind when pods come back on new IPs (a StatefulSet recreate,
-// an eviction, a node drain). Because the health check runs 3 attempts against
-// each leader, a stuck dial can pin a single reconcile for far longer than the
-// exec timeout budget, so the reconcile never reaches RepairDisconnectedNodes,
-// which is what would issue the CLUSTER MEET that corrects those addresses. The
-// cluster then stays out of Ready indefinitely instead of self-healing.
+// `--cluster check` dials every node recorded in the cluster config and
+// redis-cli applies no connect timeout of its own, so it blocks indefinitely on
+// any node whose recorded address is stale -- which is exactly the state left
+// behind when pods come back on new IPs (a StatefulSet recreate, an eviction, a
+// node drain). Because the health check runs 3 attempts against each leader, a
+// stuck dial can pin a single reconcile for far longer than
+// defaultExecCommandTimeout, so the reconcile never reaches
+// RepairDisconnectedNodes, which is what would issue the CLUSTER MEET that
+// corrects those addresses. The cluster then stays out of Ready indefinitely
+// instead of self-healing.
 //
-// Bounding the dial makes the probe fail in seconds and report the cluster as
-// unhealthy, letting the repair path run on the next reconcile.
-const clusterCheckConnectTimeoutSeconds = 5
+// The bound is applied to the exec context rather than through redis-cli's `-t`
+// flag because `-t` only exists in redis-cli 7.4 and later. Passing it to any
+// older redis-cli aborts the command with "Unrecognized option or bad number of
+// args for: '-t'", which breaks the health check outright on Redis 6.x and
+// 7.0-7.2 clusters. Bounding it operator-side keeps the anti-hang guarantee for
+// every supported Redis version.
+const clusterCheckExecTimeout = 15 * time.Second
 
-// clusterCheckCommand builds the `redis-cli --cluster check` argv, bounding the
-// peer dial with clusterCheckConnectTimeoutSeconds so an unreachable node cannot
-// block the reconcile.
+// clusterCheckCommand builds the `redis-cli --cluster check` argv. It carries no
+// timeout flag on purpose; see clusterCheckExecTimeout.
 func clusterCheckCommand(port int, authArgs, tlsArgs []string) []string {
-	cmd := []string{"redis-cli", "-t", strconv.Itoa(clusterCheckConnectTimeoutSeconds), "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", port)}
+	cmd := []string{"redis-cli", "--cluster", "check", fmt.Sprintf("127.0.0.1:%d", port)}
 	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, tlsArgs...)
 	return cmd
 }
 
+// checkClusterHealth performs a single cluster health check against a specific pod.
 func checkClusterHealth(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, podName string) error {
 	logger := log.FromContext(ctx)
 
@@ -715,7 +719,10 @@ func checkClusterHealth(ctx context.Context, client kubernetes.Interface, cr *rc
 	}
 	cmd := clusterCheckCommand(*cr.Spec.Port, authArgs, getRedisTLSArgs(cr.Spec.TLS, podName))
 
-	out, err := executeCommand1(ctx, client, cr, cmd, podName)
+	execCtx, cancel := context.WithTimeout(ctx, clusterCheckExecTimeout)
+	defer cancel()
+
+	out, err := executeCommand1(execCtx, client, cr, cmd, podName)
 	if err != nil {
 		return fmt.Errorf("failed to execute cluster check command: %w", err)
 	}

--- a/internal/k8sutils/redis_auth_args_test.go
+++ b/internal/k8sutils/redis_auth_args_test.go
@@ -150,21 +150,23 @@ func TestCheckRedisCLIAuthInEnv(t *testing.T) {
 }
 
 func TestClusterCheckCommand(t *testing.T) {
-	t.Run("bounds the peer dial with a connect timeout", func(t *testing.T) {
+	t.Run("carries no redis-cli timeout flag", func(t *testing.T) {
 		cmd := clusterCheckCommand(6379, nil, nil)
-		// redis-cli has no default connect timeout, so without -t the check
-		// blocks forever on nodes whose recorded IP is stale and the reconcile
-		// never reaches the repair path. The flag must precede --cluster.
+		// redis-cli only learned -t in 7.4; on 6.x and 7.0-7.2 it aborts with
+		// "Unrecognized option or bad number of args for: '-t'" and the health
+		// check can never pass. The dial is bounded by clusterCheckExecTimeout
+		// on the exec context instead.
 		require.Equal(t, []string{
-			"redis-cli", "-t", "5", "--cluster", "check", "127.0.0.1:6379",
+			"redis-cli", "--cluster", "check", "127.0.0.1:6379",
 		}, cmd)
-		assert.Positive(t, clusterCheckConnectTimeoutSeconds)
+		assert.NotContains(t, cmd, "-t")
+		assert.Positive(t, clusterCheckExecTimeout)
 	})
 
 	t.Run("auth and tls args are appended after the check target", func(t *testing.T) {
 		cmd := clusterCheckCommand(6380, []string{"-a", "sekret"}, []string{"--tls", "--insecure"})
 		require.Equal(t, []string{
-			"redis-cli", "-t", "5", "--cluster", "check", "127.0.0.1:6380",
+			"redis-cli", "--cluster", "check", "127.0.0.1:6380",
 			"-a", "sekret", "--tls", "--insecure",
 		}, cmd)
 	})

--- a/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: redis-version-compat-redis-cluster
+spec:
+  steps:
+    # Every other cluster test in this suite runs quay.io/opstree/redis:latest,
+    # whose redis-cli is several majors ahead of the tag the charts install by
+    # default. Anything the operator shells out to redis-cli for is therefore
+    # only exercised against the newest CLI, so a flag missing from the default
+    # version passes CI while breaking real deployments. This lane pins the
+    # chart default so that class of regression fails here first.
+    - name: Install cluster on the default chart Redis version
+      try:
+        - apply:
+            file: cluster.yaml
+        # state: Ready is set from `redis-cli --cluster check`, so this assert
+        # fails whenever the operator builds a command the default redis-cli
+        # cannot parse.
+        - assert:
+            file: ready-cluster.yaml
+
+    - name: Cluster check succeeds on the default chart Redis version
+      try:
+        - script:
+            timeout: 60s
+            content: >
+              kubectl exec --namespace ${NAMESPACE} redis-cluster-v1beta2-leader-0
+              -c redis-cluster-v1beta2-leader --
+              redis-cli --cluster check 127.0.0.1:6379
+            check:
+              (contains($stdout, 'All 16384 slots covered')): true

--- a/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/cluster.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  persistenceEnabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+  redisLeader:
+    replicas: 3
+  redisFollower:
+    replicas: 0
+  kubernetesConfig:
+    # Pinned on purpose: this is the tag every chart installs by default, and
+    # its redis-cli is older than the one in quay.io/opstree/redis:latest that
+    # the rest of the suite runs on. See chainsaw-test.yaml.
+    image: quay.io/opstree/redis:v7.0.15
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 101m
+        memory: 128Mi
+      limits:
+        cpu: 101m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+    nodeConfVolume: true
+    nodeConfVolumeClaimTemplate:
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/ready-cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/ready-cluster.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-v1beta2
+status:
+  readyFollowerReplicas: 0
+  readyLeaderReplicas: 3
+  state: Ready
+  reason: RedisCluster is ready


### PR DESCRIPTION
**Description**

`c5017206` added `-t <seconds>` to the `redis-cli --cluster check` argv to bound the peer dial. `redis-cli` only gained `-t` in 7.4, so on any older Redis the command aborts with `Unrecognized option or bad number of args for: '-t'`, `RedisClusterStatusHealth` never passes, and the cluster never reaches `state: Ready`.

This affects every Redis 6.x and 7.0-7.2 cluster, including `quay.io/opstree/redis:v7.0.15`, which is the default tag in all four charts.

This PR does two things:

1. Removes the flag and applies the bound on the operator side instead, with a context deadline on the health-check exec (`clusterCheckExecTimeout`, 15s). That preserves the guarantee `c5017206` was added for, a stuck dial can no longer pin a reconcile and starve `RepairDisconnectedNodes`, without depending on the redis-cli version.
2. Adds a chainsaw lane that runs a `RedisCluster` on the default chart Redis version, so this class of regression fails in CI instead of in user deployments.

`clusterVersion` was not usable as a gate for the flag: it is major-only (`v6`/`v7`) and the boundary is 7.4.

Fixes #1873

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Verified against the real images:

| image | redis-cli | `-t 5 --cluster check` |
|---|---|---|
| `quay.io/opstree/redis:v7.0.15` (chart default) | 7.0.15 | `Unrecognized option or bad number of args for: '-t'` |
| `redis:6.2-alpine` | 6.2.24 | same |
| `redis:7.2-alpine` | 7.2.16 | same |
| `redis:7.4-alpine` | 7.4.11 | accepted |
| `quay.io/opstree/redis:latest` (e2e default) | 8.10.1 | accepted |

On the unit test: `TestClusterCheckCommand` previously compared the argv slice to a hardcoded slice and never ran `redis-cli`, so it passed on the commit that introduced the regression and could not have caught it. It now asserts the absence of a version-dependent timeout flag, with the reason in a comment. A unit test cannot verify what `redis-cli` accepts, which is why the e2e lane is part of this PR rather than a follow-up.

On the e2e lane: every existing chainsaw cluster test pins `quay.io/opstree/redis:latest`, so the version the charts install by default had no coverage at all. `tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/` pins `v7.0.15` and asserts `state: Ready`, which is set from `redis-cli --cluster check`, plus an explicit `--cluster check` call. Reverting the `redis.go` change in this PR makes that lane fail. It is deliberately minimal, 3 leaders and no followers, no TLS and no exporter, to keep CI time down while still exercising the redis-cli code path.

Local checks: `go build ./...` and `go test ./internal/k8sutils/ ./internal/util/ ./internal/envs/ ./internal/webhook/` pass, `gofmt -l internal/` is clean, `yamllint -c .yamllint.yml` passes on the new test directory. The `internal/controller/*` envtest suites fail locally with and without this change because the envtest binaries are not installed, so they are unaffected by it. The chainsaw lane itself has not been run locally, it needs the kind-based CI environment.
