### PR TITLE
fix(cluster): create NodePort services before StatefulSets

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -169,6 +169,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	err = k8sutils.EnsureRedisClusterNodePortServices(ctx, instance, "leader", r.K8sClient)
+	if err != nil {
+		return intctrlutil.RequeueE(ctx, err, "")
+	}
 	err = k8sutils.CreateRedisLeader(ctx, instance, r.K8sClient)
 	if err != nil {
 		return intctrlutil.RequeueE(ctx, err, "")
@@ -202,16 +206,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				return intctrlutil.Requeue()
 			}
 		}
-		// if we have followers create their service.
+		err = k8sutils.EnsureRedisClusterNodePortServices(ctx, instance, "follower", r.K8sClient)
+		if err != nil {
+			return intctrlutil.RequeueE(ctx, err, "")
+		}
+		err = k8sutils.CreateRedisFollower(ctx, instance, r.K8sClient)
+		if err != nil {
+			return intctrlutil.RequeueE(ctx, err, "")
+		}
 		if followerReplicas != 0 {
 			err = k8sutils.CreateRedisFollowerService(ctx, instance, r.K8sClient)
 			if err != nil {
 				return intctrlutil.RequeueE(ctx, err, "")
 			}
-		}
-		err = k8sutils.CreateRedisFollower(ctx, instance, r.K8sClient)
-		if err != nil {
-			return intctrlutil.RequeueE(ctx, err, "")
 		}
 		err = k8sutils.ReconcileRedisPodDisruptionBudget(ctx, instance, "follower", instance.Spec.RedisFollower.PodDisruptionBudget, r.K8sClient)
 		if err != nil {

--- a/internal/controller/rediscluster/rediscluster_controller_test.go
+++ b/internal/controller/rediscluster/rediscluster_controller_test.go
@@ -2,8 +2,11 @@ package rediscluster
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
@@ -259,6 +262,125 @@ var _ = Describe("Redis Cluster Controller", func() {
 				ReadyLeaderReplicas:   3,
 				ReadyFollowerReplicas: 3,
 			}))
+		})
+	})
+	Context("When deploying a NodePort Redis Cluster", func() {
+		var redisCluster *rcvb2.RedisCluster
+
+		// announceEnv collects the cluster announce variables of the pod template.
+		announceEnv := func(sts *appsv1.StatefulSet) map[string]string {
+			env := map[string]string{}
+			for _, container := range sts.Spec.Template.Spec.Containers {
+				for _, e := range container.Env {
+					if strings.HasPrefix(e.Name, "announce_port_") || strings.HasPrefix(e.Name, "announce_bus_port_") {
+						env[e.Name] = e.Value
+					}
+				}
+			}
+			return env
+		}
+
+		// expectAnnounceEnvMatchesServices asserts that every announce variable of the
+		// pod template carries the node port Kubernetes actually allocated to the
+		// matching per-pod Service.
+		expectAnnounceEnvMatchesServices := func(sts *appsv1.StatefulSet, role string) {
+			env := announceEnv(sts)
+			ExpectWithOffset(1, env).To(HaveLen(6), "every ordinal must contribute a client and a bus announce variable")
+			for i := 0; i < 3; i++ {
+				serviceName := fmt.Sprintf("%s-%s-%d", redisCluster.Name, role, i)
+				svc := &corev1.Service{}
+				ExpectWithOffset(1, k8sClient.Get(context.Background(), types.NamespacedName{Name: serviceName, Namespace: ns}, svc)).To(Succeed())
+
+				ports := map[string]int32{}
+				for _, port := range svc.Spec.Ports {
+					ports[port.Name] = port.NodePort
+				}
+				ExpectWithOffset(1, ports["redis-client"]).NotTo(BeZero(), "Kubernetes must have allocated a client node port")
+				ExpectWithOffset(1, ports["redis-bus"]).NotTo(BeZero(), "Kubernetes must have allocated a bus node port")
+
+				prefix := strings.ReplaceAll(serviceName, "-", "_")
+				ExpectWithOffset(1, env["announce_port_"+prefix]).To(Equal(strconv.Itoa(int(ports["redis-client"]))))
+				ExpectWithOffset(1, env["announce_bus_port_"+prefix]).To(Equal(strconv.Itoa(int(ports["redis-bus"]))))
+			}
+		}
+
+		getStatefulSet := func(name string) (*appsv1.StatefulSet, error) {
+			sts := &appsv1.StatefulSet{}
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, sts)
+			return sts, err
+		}
+
+		BeforeEach(func() {
+			redisCluster = &rcvb2.RedisCluster{}
+			yamlFile, err := os.ReadFile(filepath.Join("testdata", "nodeport.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal(yamlFile, redisCluster)).To(Succeed())
+			redisCluster.Namespace = ns
+
+			Expect(k8sClient.Create(context.Background(), redisCluster)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(context.Background(), redisCluster)).Should(Succeed())
+		})
+
+		It("should announce the allocated node ports from the first StatefulSet revision", func() {
+			leaderName := redisCluster.Name + "-leader"
+			followerName := redisCluster.Name + "-follower"
+
+			By("waiting for the leader StatefulSet")
+			var leaderSts *appsv1.StatefulSet
+			Eventually(func() error {
+				var err error
+				leaderSts, err = getStatefulSet(leaderName)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			By("verifying the leader announce variables match the node ports Kubernetes allocated")
+			expectAnnounceEnvMatchesServices(leaderSts, "leader")
+
+			By("verifying the leader pod template was not corrected by a later reconciliation")
+			// The generation only stays at 1 if the first rendered spec already carried
+			// the announce variables. When the per-pod Services were created after the
+			// StatefulSet, the first revision was missing them and a second update
+			// bumped the generation.
+			Expect(leaderSts.Generation).To(BeEquivalentTo(1))
+			Consistently(func() (int64, error) {
+				sts, err := getStatefulSet(leaderName)
+				return sts.Generation, err
+			}, time.Second*2, interval).Should(BeEquivalentTo(1))
+
+			By("marking the leader StatefulSet ready so the follower is reconciled")
+			Eventually(func() error {
+				sts, err := getStatefulSet(leaderName)
+				if err != nil {
+					return err
+				}
+				sts.Status.Replicas = *sts.Spec.Replicas
+				sts.Status.ReadyReplicas = *sts.Spec.Replicas
+				sts.Status.AvailableReplicas = *sts.Spec.Replicas
+				sts.Status.CurrentReplicas = *sts.Spec.Replicas
+				sts.Status.UpdatedReplicas = *sts.Spec.Replicas
+				sts.Status.ObservedGeneration = sts.Generation
+				return k8sClient.Status().Update(context.Background(), sts)
+			}, timeout, interval).Should(Succeed())
+
+			By("waiting for the follower StatefulSet")
+			var followerSts *appsv1.StatefulSet
+			Eventually(func() error {
+				var err error
+				followerSts, err = getStatefulSet(followerName)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			By("verifying the follower announces its own node ports from its first revision")
+			expectAnnounceEnvMatchesServices(followerSts, "follower")
+			Expect(followerSts.Generation).To(BeEquivalentTo(1))
+
+			By("verifying the leader announce variables did not leak into the follower template")
+			for name := range announceEnv(followerSts) {
+				Expect(name).NotTo(ContainSubstring("_leader_"))
+			}
 		})
 	})
 })

--- a/internal/controller/rediscluster/testdata/nodeport.yaml
+++ b/internal/controller/rediscluster/testdata/nodeport.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisCluster
+metadata:
+  name: redis-cluster-nodeport
+spec:
+  clusterSize: 3
+  clusterVersion: v7
+  # A user supplied env slice is shared between the leader and the follower render
+  # of the same reconciliation, so it must not accumulate announce variables.
+  env:
+    - name: USER_DEFINED
+      value: "yes"
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.12
+    imagePullPolicy: IfNotPresent
+    service:
+      serviceType: NodePort

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -2,14 +2,17 @@ package k8sutils
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
+	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -117,8 +120,11 @@ func generateRedisClusterInitContainerParams(cr *rcvb2.RedisCluster) initContain
 	return initcontainerProp
 }
 
-// generateRedisClusterContainerParams generates Redis container information
-func generateRedisClusterContainerParams(ctx context.Context, cl kubernetes.Interface, cr *rcvb2.RedisCluster, securityContext *corev1.SecurityContext, readinessProbeDef *corev1.Probe, livenessProbeDef *corev1.Probe, role string, resources *corev1.ResourceRequirements) containerParameters {
+// generateRedisClusterContainerParams generates Redis container information. It
+// returns an error when the per-pod NodePort Services required to build the
+// cluster announce variables cannot be read, so that an incomplete pod template
+// is never handed to the StatefulSet reconciler.
+func generateRedisClusterContainerParams(ctx context.Context, cl kubernetes.Interface, cr *rcvb2.RedisCluster, securityContext *corev1.SecurityContext, readinessProbeDef *corev1.Probe, livenessProbeDef *corev1.Probe, role string, resources *corev1.ResourceRequirements) (containerParameters, error) {
 	trueProperty := true
 	falseProperty := false
 	containerProp := containerParameters{
@@ -137,7 +143,13 @@ func generateRedisClusterContainerParams(ctx context.Context, cl kubernetes.Inte
 		containerProp.EnvVars = cr.Spec.EnvVars
 	}
 	if cr.Spec.KubernetesConfig.GetServiceType() == "NodePort" {
-		envVars := util.Coalesce(containerProp.EnvVars, &[]corev1.EnvVar{})
+		// Start from a copy: containerProp.EnvVars may alias cr.Spec.EnvVars, which is
+		// shared between the leader and the follower render of the same reconciliation.
+		// Appending in place would leak one role's announce variables into the other.
+		envVars := &[]corev1.EnvVar{}
+		if containerProp.EnvVars != nil {
+			*envVars = append(*envVars, *containerProp.EnvVars...)
+		}
 		*envVars = append(*envVars, corev1.EnvVar{
 			Name:  "NODEPORT",
 			Value: "true",
@@ -151,31 +163,28 @@ func generateRedisClusterContainerParams(ctx context.Context, cl kubernetes.Inte
 			},
 		})
 
-		type ports struct {
-			announcePort    int
-			announceBusPort int
-		}
-		nps := map[string]ports{} // pod name to ports
 		replicas := cr.Spec.GetReplicaCounts(role)
 		for i := 0; i < int(replicas); i++ {
-			svc, err := getService(ctx, cl, cr.Namespace, cr.Name+"-"+role+"-"+strconv.Itoa(i))
+			serviceName := cr.Name + "-" + role + "-" + strconv.Itoa(i)
+			svc, err := getService(ctx, cl, cr.Namespace, serviceName)
 			if err != nil {
-				log.FromContext(ctx).Error(err, "Cannot get service for Redis", "Setup.Type", role)
-			} else {
-				nps[svc.Name] = ports{
-					announcePort:    int(svc.Spec.Ports[0].NodePort),
-					announceBusPort: int(svc.Spec.Ports[1].NodePort),
-				}
+				// Rendering the StatefulSet without the announce variables makes Redis
+				// announce an address nothing listens on, so fail instead of shipping a
+				// pod template that is known to be incomplete.
+				return containerParameters{}, fmt.Errorf("cannot get nodeport service %s/%s: %w", cr.Namespace, serviceName, err)
 			}
-		}
-		for name, np := range nps {
+			announcePort, announceBusPort, err := clusterAnnounceNodePorts(svc)
+			if err != nil {
+				return containerParameters{}, err
+			}
+			envSuffix := strings.ReplaceAll(svc.Name, "-", "_")
 			*envVars = append(*envVars, corev1.EnvVar{
-				Name:  "announce_port_" + strings.ReplaceAll(name, "-", "_"),
-				Value: strconv.Itoa(np.announcePort),
+				Name:  "announce_port_" + envSuffix,
+				Value: strconv.Itoa(int(announcePort)),
 			})
 			*envVars = append(*envVars, corev1.EnvVar{
-				Name:  "announce_bus_port_" + strings.ReplaceAll(name, "-", "_"),
-				Value: strconv.Itoa(np.announceBusPort),
+				Name:  "announce_bus_port_" + envSuffix,
+				Value: strconv.Itoa(int(announceBusPort)),
 			})
 		}
 		containerProp.EnvVars = envVars
@@ -224,7 +233,27 @@ func generateRedisClusterContainerParams(ctx context.Context, cl kubernetes.Inte
 		containerProp.ACLConfig = cr.Spec.ACL
 	}
 
-	return containerProp
+	return containerProp, nil
+}
+
+// clusterAnnounceNodePorts returns the allocated client and cluster-bus node ports
+// of a per-pod NodePort Service. Ports are matched by name because the order of
+// the port list is not part of the API contract, and a zero node port means
+// Kubernetes has not allocated one yet.
+func clusterAnnounceNodePorts(svc *corev1.Service) (int32, int32, error) {
+	var announcePort, announceBusPort int32
+	for _, port := range svc.Spec.Ports {
+		switch port.Name {
+		case redisClientPortName:
+			announcePort = port.NodePort
+		case redisBusPortName:
+			announceBusPort = port.NodePort
+		}
+	}
+	if announcePort == 0 || announceBusPort == 0 {
+		return 0, 0, fmt.Errorf("service %s/%s has no allocated %q and %q node port", svc.Namespace, svc.Name, redisClientPortName, redisBusPortName)
+	}
+	return announcePort, announceBusPort, nil
 }
 
 // CreateRedisLeader will create a leader redis setup
@@ -296,7 +325,12 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(ctx context.Context, cr *
 	labels["cluster"] = cr.Name
 	annotations := generateStatefulSetsAnots(cr.ObjectMeta, cr.Spec.KubernetesConfig.IgnoreAnnotations)
 	objectMetaInfo := generateObjectMetaInformation(stateFulName, cr.Namespace, labels, annotations)
-	err := CreateOrUpdateStateFul(
+	containerParams, err := generateRedisClusterContainerParams(ctx, cl, cr, service.SecurityContext, service.ReadinessProbe, service.LivenessProbe, service.RedisStateFulType, service.Resources)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Cannot generate container parameters for Redis", "Setup.Type", service.RedisStateFulType)
+		return err
+	}
+	err = CreateOrUpdateStateFul(
 		ctx,
 		cl,
 		cr.GetNamespace(),
@@ -304,7 +338,7 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(ctx context.Context, cr *
 		generateRedisClusterParams(ctx, cr, service.getReplicaCount(cr), service.ExternalConfig, service),
 		redisClusterAsOwner(cr),
 		generateRedisClusterInitContainerParams(cr),
-		generateRedisClusterContainerParams(ctx, cl, cr, service.SecurityContext, service.ReadinessProbe, service.LivenessProbe, service.RedisStateFulType, service.Resources),
+		containerParams,
 		cr.Spec.Sidecars,
 	)
 	if err != nil {
@@ -329,7 +363,7 @@ func (service RedisClusterService) CreateRedisClusterService(ctx context.Context
 	}
 
 	busPort := corev1.ServicePort{
-		Name:     "redis-bus",
+		Name:     redisBusPortName,
 		Port:     int32(*cr.Spec.Port + 10000),
 		Protocol: corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{
@@ -434,15 +468,16 @@ func (service RedisClusterService) createOrUpdateClusterNodePortService(ctx cont
 	return nil
 }
 
-func (service RedisClusterService) createOrUpdateClusterNodePortServiceForReplica(ctx context.Context, cr *rcvb2.RedisCluster, cl kubernetes.Interface, replica int) error {
+// clusterNodePortServiceParams returns the object metadata and the cluster-bus
+// port of the per-pod NodePort Service of a single replica.
+func (service RedisClusterService) clusterNodePortServiceParams(cr *rcvb2.RedisCluster, replica int) (metav1.ObjectMeta, corev1.ServicePort) {
 	serviceName := cr.Name + "-" + service.RedisServiceRole + "-" + strconv.Itoa(replica)
 	labels := getRedisLabels(cr.Name+"-"+service.RedisServiceRole, cluster, service.RedisServiceRole, map[string]string{
 		"statefulset.kubernetes.io/pod-name": serviceName,
 	})
 	annotations := generateServiceAnots(cr.ObjectMeta, nil, disableMetrics)
-	objectMetaInfo := generateObjectMetaInformation(serviceName, cr.Namespace, labels, annotations)
 	busPort := corev1.ServicePort{
-		Name:     "redis-bus",
+		Name:     redisBusPortName,
 		Port:     int32(*cr.Spec.Port + 10000),
 		Protocol: corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{
@@ -450,12 +485,24 @@ func (service RedisClusterService) createOrUpdateClusterNodePortServiceForReplic
 			IntVal: int32(*cr.Spec.Port + 10000),
 		},
 	}
+	return generateObjectMetaInformation(serviceName, cr.Namespace, labels, annotations), busPort
+}
+
+func (service RedisClusterService) createOrUpdateClusterNodePortServiceForReplica(ctx context.Context, cr *rcvb2.RedisCluster, cl kubernetes.Interface, replica int) error {
+	objectMetaInfo, busPort := service.clusterNodePortServiceParams(cr, replica)
 	return CreateOrUpdateService(ctx, cr.Namespace, objectMetaInfo, redisClusterAsOwner(cr), disableMetrics, false, "NodePort", *cr.Spec.Port, cl, busPort)
 }
 
 // EnsureRedisClusterNodePortServices creates missing per-pod NodePort Services
-// before the StatefulSet is rendered. Existing Services are left untouched so
-// their selectors cannot get ahead of a StatefulSet update that later fails.
+// before the StatefulSet is rendered, so that Kubernetes has allocated the node
+// ports that the pod template announces.
+//
+// Missing Services are created, never updated: an update would move the selector
+// of a Service that is already backing a running pod ahead of a StatefulSet update
+// that may still fail on an immutable field, which is the regression fixed by
+// upstream #1347/#1348. Creating directly rather than going through
+// CreateOrUpdateService keeps that guarantee even if the Service appears between
+// the lookup and the write.
 func EnsureRedisClusterNodePortServices(ctx context.Context, cr *rcvb2.RedisCluster, role string, cl kubernetes.Interface) error {
 	if cr.Spec.KubernetesConfig.GetServiceType() != "NodePort" {
 		return nil
@@ -471,7 +518,14 @@ func EnsureRedisClusterNodePortServices(ctx context.Context, cr *rcvb2.RedisClus
 			return err
 		}
 
-		if err := service.createOrUpdateClusterNodePortServiceForReplica(ctx, cr, cl, i); err != nil {
+		objectMetaInfo, busPort := service.clusterNodePortServiceParams(cr, i)
+		serviceDef := generateServiceDef(objectMetaInfo, disableMetrics, redisClusterAsOwner(cr), false, "NodePort", *cr.Spec.Port, busPort)
+		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(serviceDef); err != nil {
+			return err
+		}
+		// A concurrent creation is not a failure: the Service exists, which is all
+		// the StatefulSet render needs.
+		if err := createService(ctx, cl, cr.Namespace, serviceDef); err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/common"
 	"github.com/OT-CONTAINER-KIT/redis-operator/internal/util"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -425,26 +426,55 @@ func (service RedisClusterService) createOrUpdateClusterNodePortService(ctx cont
 	replicas := cr.Spec.GetReplicaCounts(service.RedisServiceRole)
 
 	for i := 0; i < int(replicas); i++ {
-		serviceName := cr.Name + "-" + service.RedisServiceRole + "-" + strconv.Itoa(i)
-		labels := getRedisLabels(cr.Name+"-"+service.RedisServiceRole, cluster, service.RedisServiceRole, map[string]string{
-			"statefulset.kubernetes.io/pod-name": serviceName,
-		})
-		annotations := generateServiceAnots(cr.ObjectMeta, nil, disableMetrics)
-		objectMetaInfo := generateObjectMetaInformation(serviceName, cr.Namespace, labels, annotations)
-		busPort := corev1.ServicePort{
-			Name:     "redis-bus",
-			Port:     int32(*cr.Spec.Port + 10000),
-			Protocol: corev1.ProtocolTCP,
-			TargetPort: intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: int32(*cr.Spec.Port + 10000),
-			},
-		}
-		err := CreateOrUpdateService(ctx, cr.Namespace, objectMetaInfo, redisClusterAsOwner(cr), disableMetrics, false, "NodePort", *cr.Spec.Port, cl, busPort)
-		if err != nil {
+		if err := service.createOrUpdateClusterNodePortServiceForReplica(ctx, cr, cl, i); err != nil {
 			log.FromContext(ctx).Error(err, "Cannot create nodeport service for Redis", "Setup.Type", service.RedisServiceRole)
 			return err
 		}
 	}
+	return nil
+}
+
+func (service RedisClusterService) createOrUpdateClusterNodePortServiceForReplica(ctx context.Context, cr *rcvb2.RedisCluster, cl kubernetes.Interface, replica int) error {
+	serviceName := cr.Name + "-" + service.RedisServiceRole + "-" + strconv.Itoa(replica)
+	labels := getRedisLabels(cr.Name+"-"+service.RedisServiceRole, cluster, service.RedisServiceRole, map[string]string{
+		"statefulset.kubernetes.io/pod-name": serviceName,
+	})
+	annotations := generateServiceAnots(cr.ObjectMeta, nil, disableMetrics)
+	objectMetaInfo := generateObjectMetaInformation(serviceName, cr.Namespace, labels, annotations)
+	busPort := corev1.ServicePort{
+		Name:     "redis-bus",
+		Port:     int32(*cr.Spec.Port + 10000),
+		Protocol: corev1.ProtocolTCP,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: int32(*cr.Spec.Port + 10000),
+		},
+	}
+	return CreateOrUpdateService(ctx, cr.Namespace, objectMetaInfo, redisClusterAsOwner(cr), disableMetrics, false, "NodePort", *cr.Spec.Port, cl, busPort)
+}
+
+// EnsureRedisClusterNodePortServices creates missing per-pod NodePort Services
+// before the StatefulSet is rendered. Existing Services are left untouched so
+// their selectors cannot get ahead of a StatefulSet update that later fails.
+func EnsureRedisClusterNodePortServices(ctx context.Context, cr *rcvb2.RedisCluster, role string, cl kubernetes.Interface) error {
+	if cr.Spec.KubernetesConfig.GetServiceType() != "NodePort" {
+		return nil
+	}
+
+	service := RedisClusterService{RedisServiceRole: role}
+	replicas := cr.Spec.GetReplicaCounts(role)
+	for i := 0; i < int(replicas); i++ {
+		serviceName := cr.Name + "-" + role + "-" + strconv.Itoa(i)
+		if _, err := getService(ctx, cl, cr.Namespace, serviceName); err == nil {
+			continue
+		} else if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		if err := service.createOrUpdateClusterNodePortServiceForReplica(ctx, cr, cl, i); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/internal/k8sutils/redis-cluster_test.go
+++ b/internal/k8sutils/redis-cluster_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -435,10 +436,12 @@ func Test_generateRedisClusterContainerParams(t *testing.T) {
 		t.Fatalf("Failed to unmarshal file %s: %v", path, err)
 	}
 
-	actualLeaderContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader", input.Spec.GetRedisLeaderResources())
+	actualLeaderContainer, err := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisLeader.SecurityContext, input.Spec.RedisLeader.ReadinessProbe, input.Spec.RedisLeader.LivenessProbe, "leader", input.Spec.GetRedisLeaderResources())
+	require.NoError(t, err)
 	assert.EqualValues(t, expectedLeaderContainer, actualLeaderContainer, "Expected %+v, got %+v", expectedLeaderContainer, actualLeaderContainer)
 
-	actualFollowerContainer := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower", input.Spec.GetRedisFollowerResources())
+	actualFollowerContainer, err := generateRedisClusterContainerParams(context.TODO(), fake.NewSimpleClientset(), input, input.Spec.RedisFollower.SecurityContext, input.Spec.RedisFollower.ReadinessProbe, input.Spec.RedisFollower.LivenessProbe, "follower", input.Spec.GetRedisFollowerResources())
+	require.NoError(t, err)
 	assert.EqualValues(t, expectedFollowerContainer, actualFollowerContainer, "Expected %+v, got %+v", expectedFollowerContainer, actualFollowerContainer)
 }
 
@@ -590,12 +593,22 @@ func TestEnsureRedisClusterNodePortServices(t *testing.T) {
 		services, err := client.CoreV1().Services("redis").List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.Len(t, services.Items, 3)
-		for i := range services.Items {
-			service := services.Items[i]
-			assert.Equal(t, "redis-cluster-follower-"+strconv.Itoa(i), service.Name)
+		for i := 0; i < 3; i++ {
+			name := "redis-cluster-follower-" + strconv.Itoa(i)
+			service, err := client.CoreV1().Services("redis").Get(t.Context(), name, metav1.GetOptions{})
+			require.NoError(t, err)
 			assert.Equal(t, corev1.ServiceTypeNodePort, service.Spec.Type)
-			assert.Len(t, service.Spec.Ports, 2)
-			assert.Equal(t, service.Name, service.Spec.Selector["statefulset.kubernetes.io/pod-name"])
+			assert.Equal(t, name, service.Spec.Selector["statefulset.kubernetes.io/pod-name"])
+
+			ports := map[string]int32{}
+			for _, port := range service.Spec.Ports {
+				ports[port.Name] = port.Port
+			}
+			assert.Equal(t, map[string]int32{"redis-client": 6379, "redis-bus": 16379}, ports)
+
+			require.Len(t, service.OwnerReferences, 1)
+			assert.Equal(t, "RedisCluster", service.OwnerReferences[0].Kind)
+			assert.Equal(t, "redis-cluster", service.OwnerReferences[0].Name)
 		}
 	})
 
@@ -647,5 +660,134 @@ func TestEnsureRedisClusterNodePortServices(t *testing.T) {
 		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("NodePort", 3), "leader", client)
 
 		require.EqualError(t, err, "service lookup failed")
+	})
+
+	t.Run("never updates a service that appears between the lookup and the create", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		// The lookup misses but the Service exists by the time the create is issued,
+		// which must not turn the preflight into an update of a live Service.
+		client.PrependReactor("get", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(corev1.Resource("services"), action.(k8stesting.GetAction).GetName())
+		})
+		client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			service := action.(k8stesting.CreateAction).GetObject().(*corev1.Service)
+			return true, nil, apierrors.NewAlreadyExists(corev1.Resource("services"), service.Name)
+		})
+
+		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("NodePort", 3), "leader", client)
+
+		require.NoError(t, err)
+		for _, action := range client.Actions() {
+			assert.NotEqual(t, "update", action.GetVerb())
+			assert.NotEqual(t, "patch", action.GetVerb())
+		}
+	})
+}
+
+func Test_generateRedisClusterContainerParams_NodePort(t *testing.T) {
+	newNodePortCluster := func(replicas int32, envVars *[]corev1.EnvVar) *rcvb2.RedisCluster {
+		cluster := &rcvb2.RedisCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "redis"},
+			Spec: rcvb2.RedisClusterSpec{
+				ClusterSize: ptr.To(replicas),
+				EnvVars:     envVars,
+				KubernetesConfig: common.KubernetesConfig{
+					Service: &common.ServiceConfig{ServiceType: "NodePort"},
+				},
+			},
+		}
+		cluster.SetDefault()
+		return cluster
+	}
+	nodePortService := func(name string, ports ...corev1.ServicePort) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redis"},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort, Ports: ports},
+		}
+	}
+	clientPort := func(nodePort int32) corev1.ServicePort {
+		return corev1.ServicePort{Name: "redis-client", Port: 6379, NodePort: nodePort}
+	}
+	busPort := func(nodePort int32) corev1.ServicePort {
+		return corev1.ServicePort{Name: "redis-bus", Port: 16379, NodePort: nodePort}
+	}
+	envValues := func(params containerParameters) map[string]string {
+		values := map[string]string{}
+		require.NotNil(t, params.EnvVars)
+		for _, env := range *params.EnvVars {
+			values[env.Name] = env.Value
+		}
+		return values
+	}
+
+	t.Run("fails instead of rendering a template without announce variables", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+
+		_, err := generateRedisClusterContainerParams(t.Context(), client, newNodePortCluster(1, nil), nil, nil, nil, "leader", nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "redis/redis-cluster-leader-0")
+	})
+
+	t.Run("fails when the node ports are not allocated yet", func(t *testing.T) {
+		client := fake.NewSimpleClientset(nodePortService("redis-cluster-leader-0", clientPort(0), busPort(0)))
+
+		_, err := generateRedisClusterContainerParams(t.Context(), client, newNodePortCluster(1, nil), nil, nil, nil, "leader", nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allocated")
+	})
+
+	t.Run("fails when the cluster bus port is missing from the service", func(t *testing.T) {
+		client := fake.NewSimpleClientset(nodePortService("redis-cluster-leader-0", clientPort(30000)))
+
+		_, err := generateRedisClusterContainerParams(t.Context(), client, newNodePortCluster(1, nil), nil, nil, nil, "leader", nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allocated")
+	})
+
+	t.Run("matches ports by name rather than by position", func(t *testing.T) {
+		client := fake.NewSimpleClientset(nodePortService("redis-cluster-leader-0", busPort(31000), clientPort(30000)))
+
+		params, err := generateRedisClusterContainerParams(t.Context(), client, newNodePortCluster(1, nil), nil, nil, nil, "leader", nil)
+
+		require.NoError(t, err)
+		values := envValues(params)
+		assert.Equal(t, "30000", values["announce_port_redis_cluster_leader_0"])
+		assert.Equal(t, "31000", values["announce_bus_port_redis_cluster_leader_0"])
+	})
+
+	t.Run("does not leak announce variables between the leader and follower render", func(t *testing.T) {
+		client := fake.NewSimpleClientset(
+			nodePortService("redis-cluster-leader-0", clientPort(30000), busPort(31000)),
+			nodePortService("redis-cluster-follower-0", clientPort(30001), busPort(31001)),
+		)
+		// A user supplied env slice is shared by both renders of the same reconciliation.
+		cr := newNodePortCluster(1, &[]corev1.EnvVar{{Name: "USER_DEFINED", Value: "yes"}})
+
+		leader, err := generateRedisClusterContainerParams(t.Context(), client, cr, nil, nil, nil, "leader", nil)
+		require.NoError(t, err)
+		follower, err := generateRedisClusterContainerParams(t.Context(), client, cr, nil, nil, nil, "follower", nil)
+		require.NoError(t, err)
+
+		leaderValues := envValues(leader)
+		assert.Equal(t, "30000", leaderValues["announce_port_redis_cluster_leader_0"])
+		assert.NotContains(t, leaderValues, "announce_port_redis_cluster_follower_0")
+
+		followerValues := envValues(follower)
+		assert.Equal(t, "30001", followerValues["announce_port_redis_cluster_follower_0"])
+		assert.NotContains(t, followerValues, "announce_port_redis_cluster_leader_0")
+
+		var nodePortEnvCount int
+		for _, env := range *follower.EnvVars {
+			if env.Name == "NODEPORT" {
+				nodePortEnvCount++
+			}
+		}
+		assert.Equal(t, 1, nodePortEnvCount, "NODEPORT must not be appended twice")
+
+		require.NotNil(t, cr.Spec.EnvVars)
+		assert.Len(t, *cr.Spec.EnvVars, 1, "the cluster spec must not be mutated by rendering")
 	})
 }

--- a/internal/k8sutils/redis-cluster_test.go
+++ b/internal/k8sutils/redis-cluster_test.go
@@ -2,17 +2,23 @@ package k8sutils
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -544,4 +550,102 @@ func Test_generateRedisClusterInitContainerParams_PersistenceDisabled(t *testing
 	if actual.PersistenceEnabled != nil {
 		t.Fatalf("Expected PersistenceEnabled to be nil when persistence is disabled, got %v", *actual.PersistenceEnabled)
 	}
+}
+
+func TestEnsureRedisClusterNodePortServices(t *testing.T) {
+	newRedisCluster := func(serviceType string, replicas int32) *rcvb2.RedisCluster {
+		cluster := &rcvb2.RedisCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "redis.redis.opstreelabs.in/v1beta2",
+				Kind:       "RedisCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "redis-cluster",
+				Namespace: "redis",
+			},
+			Spec: rcvb2.RedisClusterSpec{
+				ClusterSize: ptr.To(replicas),
+				KubernetesConfig: common.KubernetesConfig{
+					Service: &common.ServiceConfig{ServiceType: serviceType},
+				},
+			},
+		}
+		cluster.SetDefault()
+		return cluster
+	}
+
+	t.Run("does nothing for a non-NodePort cluster", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("ClusterIP", 3), "leader", client)
+
+		require.NoError(t, err)
+		assert.Empty(t, client.Actions())
+	})
+
+	t.Run("creates every missing per-pod service", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("NodePort", 3), "follower", client)
+
+		require.NoError(t, err)
+		services, err := client.CoreV1().Services("redis").List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, services.Items, 3)
+		for i := range services.Items {
+			service := services.Items[i]
+			assert.Equal(t, "redis-cluster-follower-"+strconv.Itoa(i), service.Name)
+			assert.Equal(t, corev1.ServiceTypeNodePort, service.Spec.Type)
+			assert.Len(t, service.Spec.Ports, 2)
+			assert.Equal(t, service.Name, service.Spec.Selector["statefulset.kubernetes.io/pod-name"])
+		}
+	})
+
+	t.Run("creates only the service added by scale-up", func(t *testing.T) {
+		existingServices := make([]runtime.Object, 0, 3)
+		for i := 0; i < 3; i++ {
+			existingServices = append(existingServices, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "redis-cluster-leader-" + strconv.Itoa(i),
+					Namespace:   "redis",
+					Annotations: map[string]string{"preserve": "true"},
+				},
+				Spec: corev1.ServiceSpec{Selector: map[string]string{"preserve": "true"}},
+			})
+		}
+		client := fake.NewSimpleClientset(existingServices...)
+
+		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("NodePort", 4), "leader", client)
+
+		require.NoError(t, err)
+		services, err := client.CoreV1().Services("redis").List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, services.Items, 4)
+		for i := 0; i < 3; i++ {
+			service, err := client.CoreV1().Services("redis").Get(t.Context(), "redis-cluster-leader-"+strconv.Itoa(i), metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, "true", service.Annotations["preserve"])
+			assert.Equal(t, "true", service.Spec.Selector["preserve"])
+		}
+		var createActions, updateActions int
+		for _, action := range client.Actions() {
+			switch action.GetVerb() {
+			case "create":
+				createActions++
+			case "update":
+				updateActions++
+			}
+		}
+		assert.Equal(t, 1, createActions)
+		assert.Zero(t, updateActions)
+	})
+
+	t.Run("returns a service lookup error", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		client.PrependReactor("get", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("service lookup failed")
+		})
+
+		err := EnsureRedisClusterNodePortServices(t.Context(), newRedisCluster("NodePort", 3), "leader", client)
+
+		require.EqualError(t, err, "service lookup failed")
+	})
 }

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -102,7 +102,7 @@ func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.Red
 			return ""
 		}
 		svcPort, ok := lo.Find(svc.Spec.Ports, func(item corev1.ServicePort) bool {
-			return item.Name == "redis-client"
+			return item.Name == redisClientPortName
 		})
 		if ok {
 			port = int(svcPort.NodePort)

--- a/internal/k8sutils/services.go
+++ b/internal/k8sutils/services.go
@@ -15,6 +15,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	// redisClientPortName and redisBusPortName are the port names used on every
+	// Redis service. They are matched by name when reading back allocated node
+	// ports, because the order of ServicePort entries is not part of the API
+	// contract.
+	redisClientPortName    = "redis-client"
+	redisBusPortName       = "redis-bus"
+	sentinelClientPortName = "sentinel-client"
+)
+
 // exporterPortProvider return the exporter port if bool is true
 type exporterPortProvider func() (port int, enable bool)
 
@@ -26,9 +36,9 @@ var disableMetrics exporterPortProvider = func() (int, bool) {
 func generateServiceDef(serviceMeta metav1.ObjectMeta, epp exporterPortProvider, ownerDef metav1.OwnerReference, headless bool, serviceType string, port int, extra ...corev1.ServicePort) *corev1.Service {
 	var PortName string
 	if serviceMeta.Labels["role"] == "sentinel" {
-		PortName = "sentinel-client"
+		PortName = sentinelClientPortName
 	} else {
-		PortName = "redis-client"
+		PortName = redisClientPortName
 	}
 	service := &corev1.Service{
 		TypeMeta:   generateMetaInformation("Service", "v1"),


### PR DESCRIPTION
## What this PR does

- Creates missing per-pod NodePort Services before rendering leader and follower StatefulSets, so Kubernetes-assigned client and bus ports are present in the Redis announce environment on the first revision.
- Leaves existing Services untouched during the preflight pass. Normal Service reconciliation still runs after the StatefulSet, preserving the StatefulSet-first update safety introduced for #1347.
- Covers initial creation, scale-up, non-NodePort clusters, and Service lookup failures with regression tests.

## Why

The Redis Cluster StatefulSet reads allocated NodePorts from the per-pod Services to populate `announce_port_*` and `announce_bus_port_*`. Previously the StatefulSet was created before those Services, so its first revision omitted the variables and Redis exited because `cluster-announce-port` had no value. A later reconciliation updated the StatefulSet template, but the CrashLooping pods were not automatically replaced.

The same ordering issue also occurred when scaling up because the StatefulSet existed while the new ordinal Service did not.

## Validation

- `KUBEBUILDER_ASSETS=<envtest-assets> go test ./... -coverprofile cover.out`
- `golangci-lint run` (0 issues)
- `make manager`
- Live Kubernetes test with a 3-leader/3-follower NodePort RedisCluster: both StatefulSets converged on revision 1, all six pods became Ready with 0 restarts, and Redis reported `cluster_state:ok`, 6 known nodes, and 3 shards.