### PR TITLE
perf(test): cut e2e wall clock from ~44min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,11 +212,12 @@ jobs:
     uses: ./.github/workflows/call-test-charts.yaml
 
   e2e_test:
-    # DEBUG
-    needs: [validate_yaml, helm_chart_test]
+    # Only gate on lint. The suite used to hang off validate_yaml and
+    # helm_chart_test, which pulled in the whole gotest chain and delayed the
+    # job by ~12 minutes without testing anything the suite depends on.
+    needs: [lint]
     name: E2E Test
     runs-on: ubuntu-latest
-    if: always() && (needs.validate_yaml.result == 'success') && (needs.helm_chart_test.result == 'success' || needs.helm_chart_test.result == 'skipped')
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -257,10 +258,49 @@ jobs:
           kubectl cluster-info --context kind-kind
           kind load docker-image redis-operator:e2e --name kind
 
+      # Kind nodes do not share an image store, so an imagePullPolicy of Always
+      # made every pod re-pull from quay.io on every node. Pull each image once
+      # here and side-load it into the nodes instead; the test manifests use
+      # IfNotPresent so nothing goes back over the network. This also pins the
+      # whole run to a single digest of the moving :latest tags.
+      - name: Preload test images into Kind
+        run: |
+          set -euo pipefail
+          IMAGES=(
+            quay.io/opstree/redis:latest
+            quay.io/opstree/redis:v7.0.15
+            quay.io/opstree/redis-sentinel:latest
+            quay.io/opstree/redis-exporter:v1.44.0
+            redis:alpine
+            busybox:latest
+            busybox:1.36
+          )
+          # Docker Hub rate-limits anonymous pulls from shared runner IPs, so a
+          # pull can fail for reasons that have nothing to do with this change.
+          printf '%s\n' "${IMAGES[@]}" \
+            | xargs -P 4 -n 1 -I{} sh -c 'docker pull -q "{}" || echo "::warning::pull failed for {}"'
+          # Side-loading is an optimisation, not a correctness requirement: the
+          # manifests ask for IfNotPresent, so anything that fails here is just
+          # pulled by the kubelet on first use. Warn rather than fail the job --
+          # `kind load` cannot import a multi-arch image saved from Docker's
+          # containerd image store, and that is not worth breaking E2E over.
+          for img in "${IMAGES[@]}"; do
+            kind load docker-image "$img" --name kind \
+              || echo "::warning::could not preload ${img}; kubelet will pull it on demand"
+          done
+
       - name: Install Redis Operator
         run: |
           make deploy IMG=redis-operator:e2e
           kubectl set env deployment/redis-operator-redis-operator -n redis-operator-system INIT_CONTAINER_IMAGE=redis-operator:e2e FEATURE_GATES=GenerateConfigInInitContainer=true MAX_CONCURRENT_RECONCILES=10
+          # config/manager ships a 100m CPU cap. With MAX_CONCURRENT_RECONCILES=10
+          # and the operator streaming every `redis-cli --cluster` exec itself,
+          # that cap throttles the suite rather than protecting anything. Lift it
+          # for the test run only -- the shipped default is left untouched.
+          # (`set resources --limits=cpu=0` would write cpu: "0", which then fails
+          # the requests<=limits check; a strategic merge with null drops the key.)
+          kubectl -n redis-operator-system patch deployment redis-operator-redis-operator \
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","resources":{"limits":{"cpu":null}}}]}}}}'
 
       - name: Wait for Redis Operator to be ready
         run: |

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -7,7 +7,12 @@ metadata:
 spec:
   execution:
     failFast: true
-    parallel: 2
+    # 3, not 4. With the suite at 2915s across 23 cases, sum/3 = 972s still sits
+    # above the 871s critical path (setup-redis-cluster), so there is slack for
+    # contention to eat. sum/4 = 729s puts the wall clock exactly on the
+    # critical path, where any slowdown in that one case shows up one-for-one.
+    # 4 is the ceiling worth trying -- 5 buys nothing.
+    parallel: 3
     forceTerminationGracePeriod: 5s
   # No cleanup block: both settings it used to carry are back at their defaults.
   #
@@ -21,6 +26,11 @@ spec:
   # 3763s. Two full runs finished with no cleanup timeouts, so the settling
   # time it bought is not needed.
   timeouts:
+    # Namespace teardown has to wait out the CRD finalizers, and chainsaw's
+    # 30s default is not enough: sentinel-pod-placement hit "context deadline
+    # exceeded" on it. Chainsaw counts that as a failed test in its go-test
+    # output but not in its summary or exit code, so CI went green over it.
+    cleanup: 2m
     apply: 5m
     delete: 5m
     assert: 20m

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -17,9 +17,11 @@ spec:
   # No cleanup block: both settings it used to carry are back at their defaults.
   #
   # skipDelete: true was set alongside parallel: 10 to dodge cleanup timeouts.
-  # parallel has since dropped to 2, and leaving every namespace behind meant
+  # That parallelism is long gone, and leaving every namespace behind meant
   # 75+ redis pods piled up on the runner by the end of a run, which is what
-  # made the late tests several times slower than the early ones.
+  # made the late tests several times slower than the early ones. The right fix
+  # for the timeouts it was hiding is timeouts.cleanup below, not skipping the
+  # delete.
   #
   # delayBeforeCleanup: 10s only started costing anything once cleanup was
   # re-enabled, and 10s per test is +100% on an 11s case -- 230s of the suite's

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -9,12 +9,17 @@ spec:
     failFast: true
     parallel: 2
     forceTerminationGracePeriod: 5s
-  cleanup:
-    # skipDelete was set alongside parallel: 10 to dodge cleanup timeouts, but
-    # parallel has since dropped to 2 and leaving every namespace behind meant
-    # 75+ redis pods piling up on the runner by the end of a run, which is what
-    # made the late tests several times slower than the early ones.
-    delayBeforeCleanup: 10s
+  # No cleanup block: both settings it used to carry are back at their defaults.
+  #
+  # skipDelete: true was set alongside parallel: 10 to dodge cleanup timeouts.
+  # parallel has since dropped to 2, and leaving every namespace behind meant
+  # 75+ redis pods piled up on the runner by the end of a run, which is what
+  # made the late tests several times slower than the early ones.
+  #
+  # delayBeforeCleanup: 10s only started costing anything once cleanup was
+  # re-enabled, and 10s per test is +100% on an 11s case -- 230s of the suite's
+  # 3763s. Two full runs finished with no cleanup timeouts, so the settling
+  # time it bought is not needed.
   timeouts:
     apply: 5m
     delete: 5m

--- a/tests/_config/chainsaw-configuration.yaml
+++ b/tests/_config/chainsaw-configuration.yaml
@@ -10,7 +10,10 @@ spec:
     parallel: 2
     forceTerminationGracePeriod: 5s
   cleanup:
-    skipDelete: true
+    # skipDelete was set alongside parallel: 10 to dodge cleanup timeouts, but
+    # parallel has since dropped to 2 and leaving every namespace behind meant
+    # 75+ redis pods piling up on the runner by the end of a run, which is what
+    # made the late tests several times slower than the early ones.
     delayBeforeCleanup: 10s
   timeouts:
     apply: 5m

--- a/tests/_config/kind-config.yaml
+++ b/tests/_config/kind-config.yaml
@@ -2,13 +2,14 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind
+# One control-plane, three workers. The extra two control-planes this used to
+# carry kept kind's NoSchedule taint (kind only untaints when a cluster has no
+# workers), so they added a second and third etcd/apiserver/controller-manager
+# plus an haproxy front-end to a 4-vCPU runner while contributing zero
+# schedulable capacity. The node-shutdown simulation and pod anti-affinity they
+# were added for are no longer part of the suite.
 nodes:
   - role: control-plane
-  - role: control-plane
-  - role: control-plane
-  - role: worker
-  - role: worker
-  - role: worker
   - role: worker
   - role: worker
   - role: worker

--- a/tests/data-assert/resources.yaml
+++ b/tests/data-assert/resources.yaml
@@ -285,13 +285,19 @@ spec:
         - |
           cp /configmap/* /go/src/data-assert/ && 
           sleep 1000000000
+      env:
+        # Bound the compiler's parallelism. Two of these pods can be building at
+        # once when tests run in parallel, and an unbounded `go build` peaked past
+        # the memory limit and was OOM-killed mid-run (exit 137).
+        - name: GOFLAGS
+          value: "-p=2"
       resources:
         limits:
           cpu: "500m"
-          memory: "512Mi"
+          memory: "1Gi"
         requests:
           cpu: "100m"
-          memory: "128Mi"
+          memory: "256Mi"
       volumeMounts:
         - name: data-assert
           mountPath: /go/src/data-assert

--- a/tests/data-assert/resources.yaml.tmpl
+++ b/tests/data-assert/resources.yaml.tmpl
@@ -24,13 +24,19 @@ spec:
         - |
           cp /configmap/* /go/src/data-assert/ && 
           sleep 1000000000
+      env:
+        # Bound the compiler's parallelism. Two of these pods can be building at
+        # once when tests run in parallel, and an unbounded `go build` peaked past
+        # the memory limit and was OOM-killed mid-run (exit 137).
+        - name: GOFLAGS
+          value: "-p=2"
       resources:
         limits:
           cpu: "500m"
-          memory: "512Mi"
+          memory: "1Gi"
         requests:
           cpu: "100m"
-          memory: "128Mi"
+          memory: "256Mi"
       volumeMounts:
         - name: data-assert
           mountPath: /go/src/data-assert

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/acl-init-job.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/acl-init-job.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
         - name: acl-writer
           image: busybox:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-cluster/cluster.yaml
@@ -12,13 +12,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   # ACL configuration from PVC
   acl:
@@ -26,13 +25,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/acl-init-job.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/acl-init-job.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
         - name: acl-writer
           image: busybox:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/chainsaw-test.yaml
@@ -58,16 +58,32 @@ spec:
 
     # Step 6: Test read operation on replica
     - name: Test read operation on replica
+      description: >
+        ready-replication.yaml only asserts status.masterNode, which says the
+        operator picked a master -- not that the replica has been attached and
+        has finished syncing. Poll the replica for the link and the key instead
+        of sleeping a fixed 30s and hoping that was long enough.
       try:
-        - sleep:
-            duration: 30s
         - script:
-            timeout: 30s
-            content: >
-              kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-1 --
-              redis-cli -p 6379 --user repluser --pass repl@secure get repl-key 2>&1
+            timeout: 150s
+            content: |
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              CMD="kubectl exec --namespace ${NAMESPACE} redis-replication-acl-pvc-1 -- redis-cli -p 6379 --user repluser --pass repl@secure"
+              i=0
+              while [ $i -lt 40 ]; do
+                if ${CMD} info replication 2>/dev/null | grep -q 'master_link_status:up' &&
+                   ${CMD} get repl-key 2>/dev/null | grep -q 'ACL PVC replication test'; then
+                  echo "replica is linked and has the key"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out waiting for the replica; last replication state:"
+              ${CMD} info replication 2>&1 | head -20
+              exit 1
             check:
-              (contains($stdout, 'ACL PVC replication test')): true
+              (contains($stdout, 'replica is linked and has the key')): true
 
     # Step 7: Verify ACL file on master
     - name: Verify ACL file on master

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-replication/replication.yaml
@@ -7,13 +7,12 @@ spec:
   clusterSize: 3
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   # ACL configuration from PVC
   acl:
@@ -24,13 +23,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/acl-init-job.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/acl-init-job.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
         - name: acl-writer
           image: busybox:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c

--- a/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-pvc/redis-standalone/standalone.yaml
@@ -6,13 +6,12 @@ metadata:
 spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   # ACL configuration from PVC
   acl:
@@ -23,13 +22,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/acl-user/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/acl-user/redis-cluster/cluster.yaml
@@ -12,13 +12,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   acl:
     secret:
@@ -26,13 +25,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-cluster/cluster.yaml
@@ -12,24 +12,22 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     keepAfterDelete: true

--- a/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-replication/replication.yaml
@@ -10,13 +10,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     keepAfterDelete: true

--- a/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/keep-pvc/redis-standalone/standalone.yaml
@@ -9,13 +9,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     keepAfterDelete: true

--- a/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/max-memory-env/redis-standalone/standalone.yaml
@@ -6,13 +6,12 @@ metadata:
 spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 64Mi
       limits:
-        cpu: 100m
         memory: 100Mi
   redisConfig:
     maxMemoryPercentOfLimit: 80

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-cluster/cluster.yaml
@@ -12,13 +12,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret
@@ -26,13 +25,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-replication/replication.yaml
@@ -10,13 +10,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret
@@ -24,13 +23,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-sentinel/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-sentinel/replication.yaml
@@ -10,13 +10,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-sentinel/sentinel.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-sentinel/sentinel.yaml
@@ -12,7 +12,7 @@ spec:
     redisReplicationName: redis-replication-sentinel-metrics
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
       key: password
@@ -21,16 +21,14 @@ spec:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi

--- a/tests/e2e-chainsaw/v1beta2/metrics-service/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/metrics-service/redis-standalone/standalone.yaml
@@ -9,24 +9,22 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/pod-management-policy/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pod-management-policy/redis-cluster/chainsaw-test.yaml
@@ -22,8 +22,9 @@ spec:
             content: >
               kubectl patch rediscluster redis-cluster-v1beta2 --namespace ${NAMESPACE}
               --type merge --patch '{"spec":{"podManagementPolicy":"OrderedReady"}}'
-        # Give the operator time to reconcile the change; the field is immutable
-        # so the StatefulSets must keep the stored policy and stay healthy.
+        # Deliberately a flat sleep, not a poll: this step proves a non-event
+        # (the field is immutable, so the StatefulSets must keep the stored
+        # policy and stay healthy), and there is no state change to wait for.
         - sleep:
             duration: 30s
         - assert:

--- a/tests/e2e-chainsaw/v1beta2/pod-management-policy/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pod-management-policy/redis-cluster/cluster.yaml
@@ -17,13 +17,12 @@ spec:
     replicas: 0
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/chainsaw-test.yaml
@@ -19,7 +19,8 @@ spec:
       try:
         - apply:
             file: shrink-patch.yaml
-        # Wait for the operator to reconcile the change
+        # Deliberately a flat sleep, not a poll: this step proves a non-event
+        # (the shrink is ignored), and there is no state change to wait for.
         - sleep:
             duration: 30s
         # PVC must remain at 1Gi - shrink should have been skipped
@@ -61,23 +62,24 @@ spec:
         - assert:
             file: ready-sts.yaml
 
-    - name: Wait for operator to reconcile annotation
-      try:
-        - sleep:
-            duration: 30s
-
     - name: Verify annotation updated after successful expand
       try:
         - script:
-            timeout: 30s
+            timeout: 120s
             content: |
-              #!/bin/bash
-              set -e
-              ANNOTATION=$(kubectl get statefulset -n ${NAMESPACE} redis-standalone-shrink-test -o jsonpath='{.metadata.annotations.storageCapacity}')
-              echo "storageCapacity annotation: ${ANNOTATION}"
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              # Polls for the reconcile rather than sleeping a flat 30s first.
               # 2Gi = 2147483648 bytes
-              if [ "${ANNOTATION}" != "2147483648" ]; then
-                echo "FAIL: annotation should be 2147483648 (2Gi), got ${ANNOTATION}"
-                exit 1
-              fi
-              echo "PASS: annotation correctly updated to 2Gi after expansion"
+              i=0
+              while [ $i -lt 40 ]; do
+                ANNOTATION=$(kubectl get statefulset -n ${NAMESPACE} redis-standalone-shrink-test \
+                  -o jsonpath='{.metadata.annotations.storageCapacity}' 2>/dev/null)
+                if [ "${ANNOTATION}" = "2147483648" ]; then
+                  echo "PASS: annotation correctly updated to 2Gi after expansion"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "FAIL: annotation should be 2147483648 (2Gi), got ${ANNOTATION}"
+              exit 1

--- a/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/pvc-shrink-guard/redis-standalone/standalone.yaml
@@ -9,13 +9,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-cluster-restart/cluster.yaml
@@ -16,24 +16,22 @@ spec:
     replicas: 0
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/redis-version-compat/redis-cluster/cluster.yaml
@@ -25,7 +25,6 @@ spec:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/sentinel-placement/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/sentinel-placement/redis-replication/replication.yaml
@@ -7,11 +7,11 @@ spec:
   clusterSize: 3
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
   sentinel:
     size: 3
     image: quay.io/opstree/redis-sentinel:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     # Pod placement controls under test: these must be wired verbatim into the
     # sentinel StatefulSet pod template so Sentinel pods can be kept off the
     # Redis nodes (HA/quorum preservation).

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/chainsaw-test.yaml
@@ -164,14 +164,25 @@ spec:
 
     - name: Check follower-0 label updated
       try:
-        - sleep:
-            duration: 1m
         - script:
-            timeout: 30s
-            content: >
-              kubectl get pod -n ${NAMESPACE} redis-cluster-v1beta2-follower-0 -o jsonpath='{.metadata.labels.redis-role}'
+            timeout: 120s
+            content: |
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              i=0
+              while [ $i -lt 40 ]; do
+                ROLE=$(kubectl get pod -n ${NAMESPACE} redis-cluster-v1beta2-follower-0 \
+                  -o jsonpath='{.metadata.labels.redis-role}' 2>/dev/null)
+                if [ "$ROLE" = "master" ]; then
+                  echo "follower-0 is labelled master"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out; follower-0 redis-role is '$ROLE'"
+              exit 1
             check:
-              (contains($stdout, 'master')): true
+              (contains($stdout, 'follower-0 is labelled master')): true
 
     - name: Failover the follower-0 to slave
       try:
@@ -182,8 +193,26 @@ spec:
               bash -c  "redis-cli -a Opstree1234 --tls --cacert /tls/ca.crt cluster failover"
             check:
               (contains($stdout, 'OK')): true
-        - sleep:
-            duration: 1m
+        - script:
+            timeout: 120s
+            content: |
+              # Wait for the role to swing back before scaling out, rather than
+              # assuming a minute was enough.
+              i=0
+              while [ $i -lt 40 ]; do
+                ROLE=$(kubectl get pod -n ${NAMESPACE} redis-cluster-v1beta2-follower-0 \
+                  -o jsonpath='{.metadata.labels.redis-role}' 2>/dev/null)
+                if [ "$ROLE" = "slave" ]; then
+                  echo "follower-0 is labelled slave again"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out; follower-0 redis-role is '$ROLE'"
+              exit 1
+            check:
+              (contains($stdout, 'follower-0 is labelled slave again')): true
 
     - name: Scale Out Redis Cluster
       try:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster-scale-out.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster-scale-out.yaml
@@ -1,24 +1,53 @@
 ---
+# Kept byte-identical to cluster.yaml apart from clusterSize so that "scale out"
+# means only that. It previously omitted TLS, redisConfig and the service block;
+# chainsaw applies with a merge patch so those fields survived and the test still
+# passed, but the file read as though the scale-out dropped them.
+
 apiVersion: redis.redis.opstreelabs.in/v1beta2
 kind: RedisCluster
 metadata:
   name: redis-cluster-v1beta2
 spec:
+  TLS:
+    ca: ca.crt
+    cert: tls.crt
+    key: tls.key
+    secret:
+      secretName: redis-tls-cert
   clusterSize: 6
   clusterVersion: v7
   persistenceEnabled: true
+  redisLeader:
+    redisConfig:
+      additionalRedisConfig: redis-external-config
+  redisFollower:
+    redisConfig:
+      additionalRedisConfig: redis-external-config
+  redisConfig:
+    maxMemoryPercentOfLimit: 80
+    dynamicConfig:
+      - "slowlog-log-slower-than 5000"
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000
   kubernetesConfig:
+    service:
+      serviceType: NodePort
+      includeBusPort: true
+      headless:
+        includeBusPort: true
+        additionalAnnotations:
+          test: test
+      additional:
+        includeBusPort: true
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret
@@ -26,13 +55,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-cluster/cluster.yaml
@@ -37,13 +37,12 @@ spec:
       additional:
         includeBusPort: true
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret
@@ -51,13 +50,12 @@ spec:
   redisExporter:
     enabled: true
     image: quay.io/opstree/redis-exporter:v1.44.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 100m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/chainsaw-test.yaml
@@ -67,15 +67,29 @@ spec:
 
     - name: Test Master IP consistency
       try:
-        - sleep:
-            duration: 90s
         - script:
-            timeout: 10s
+            timeout: 240s
             content: |
-              export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
-              export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
-              if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              # Polls instead of sleeping 90s and hoping the failover landed.
+              # The master must also be Ready, so that the three sources
+              # agreeing on a pod that has just been deleted does not count.
+              i=0
+              while [ $i -lt 60 ]; do
+                FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}' 2>/dev/null);
+                FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster 2>/dev/null | head -n 1 | cut -d'.' -f1);
+                FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}' 2>/dev/null);
+                READY=$(kubectl -n ${NAMESPACE} get pod "$FROM_STATUS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null);
+                if [ -n "$FROM_STATUS" ] && [ "$FROM_SENTINEL" = "$FROM_LABEL" ] &&
+                   [ "$FROM_SENTINEL" = "$FROM_STATUS" ] && [ "$READY" = "True" ]; then
+                  echo "OK: master is $FROM_STATUS by status, label and sentinel"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out; status=$FROM_STATUS sentinel=$FROM_SENTINEL label=$FROM_LABEL ready=$READY"
+              exit 1
             check:
               (contains($stdout, 'OK')): true
 
@@ -103,15 +117,29 @@ spec:
 
     - name: Test Master IP consistency
       try:
-        - sleep:
-            duration: 90s
         - script:
-            timeout: 10s
+            timeout: 240s
             content: |
-              export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              export FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster | head -n 1 | cut -d'.' -f1);
-              export MASTER_POD_FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}');
-              if [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_LABEL" ] && [ "$FROM_SENTINEL" = "$MASTER_POD_FROM_STATUS" ]; then echo "OK"; else echo "FAIL"; fi
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              # Polls instead of sleeping 90s and hoping the failover landed.
+              # The master must also be Ready, so that the three sources
+              # agreeing on a pod that has just been deleted does not count.
+              i=0
+              while [ $i -lt 60 ]; do
+                FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}' 2>/dev/null);
+                FROM_SENTINEL=$(kubectl -n ${NAMESPACE} exec redis-sentinel-sentinel-0 -c redis-sentinel-sentinel -- redis-cli --no-auth-warning --tls --cacert /tls/ca.crt -a Opstree@1234sentinel -p 26379 sentinel get-master-addr-by-name myMaster 2>/dev/null | head -n 1 | cut -d'.' -f1);
+                FROM_LABEL=$(kubectl -n ${NAMESPACE} get pod -l app=redis-replication,redis-role=master,redis_setup_type=replication -o jsonpath='{.items[0].metadata.name}' 2>/dev/null);
+                READY=$(kubectl -n ${NAMESPACE} get pod "$FROM_STATUS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null);
+                if [ -n "$FROM_STATUS" ] && [ "$FROM_SENTINEL" = "$FROM_LABEL" ] &&
+                   [ "$FROM_SENTINEL" = "$FROM_STATUS" ] && [ "$READY" = "True" ]; then
+                  echo "OK: master is $FROM_STATUS by status, label and sentinel"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out; status=$FROM_STATUS sentinel=$FROM_SENTINEL label=$FROM_LABEL ready=$READY"
+              exit 1
             check:
               (contains($stdout, 'OK')): true
 

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-ha/ha.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-ha/ha.yaml
@@ -29,13 +29,12 @@ spec:
       name: redis-replication-password
       key: password
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:
@@ -84,11 +83,10 @@ spec:
       name: redis-sentinel-password
       key: password
     image: quay.io/opstree/redis-sentinel:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/chainsaw-test.yaml
@@ -110,15 +110,26 @@ spec:
 
     - name: Check master changed
       try:
-        - sleep:
-            duration: 60s
         - script:
-            timeout: 10s
+            timeout: 150s
             content: |
-              export MASTER_POD_FROM_STATUS=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication -o jsonpath='{.status.masterNode}');
-              echo "$MASTER_POD_FROM_STATUS"
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              # Poll for the failover instead of assuming 60s was long enough.
+              i=0
+              while [ $i -lt 45 ]; do
+                MASTER=$(kubectl -n ${NAMESPACE} get redisreplication redis-replication \
+                  -o jsonpath='{.status.masterNode}' 2>/dev/null)
+                if [ -n "$MASTER" ] && [ "$MASTER" != "redis-replication-0" ]; then
+                  echo "master moved off redis-replication-0 (now $MASTER)"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 3
+              done
+              echo "timed out; status.masterNode is still '$MASTER'"
+              exit 1
             check:
-              (contains($stdout, 'redis-replication-0')): false
+              (contains($stdout, 'master moved off redis-replication-0')): true
 
     - name: Assert data
       try:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-replication/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-replication/replication.yaml
@@ -7,7 +7,7 @@ spec:
   sentinel:
     size: 3
     image: quay.io/opstree/redis-sentinel:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
   clusterSize: 3
   redisConfig:
     maxMemoryPercentOfLimit: 80
@@ -23,13 +23,12 @@ spec:
         additionalAnnotations:
           opstreelabs.in/additional-annotation: present
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
     redisSecret:
       name: redis-secret

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/chainsaw-test.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/chainsaw-test.yaml
@@ -29,10 +29,32 @@ spec:
             file: cli-pod.yaml
         - assert:
             file: cli-pod.yaml
-    - name: Sleep for five minutes
+    - name: Wait for the replication and sentinel services to answer
+      description: >
+        This replaces a flat `sleep 5m` that was ~90% of this case's runtime.
+        The ping steps below are the real assertions; this only waits until the
+        services have endpoints behind them.
       try:
-        - sleep:
-            duration: 5m
+        - script:
+            timeout: 6m
+            content: |
+              # Runs under /bin/sh via `sh -c`, so keep this POSIX-compatible.
+              i=0
+              while [ $i -lt 90 ]; do
+                if kubectl exec --namespace ${NAMESPACE} redis -- redis-cli \
+                     -h redis-replication.${NAMESPACE}.svc -p 6379 ping 2>/dev/null | grep -q PONG &&
+                   kubectl exec --namespace ${NAMESPACE} redis -- redis-cli \
+                     -h redis-sentinel-sentinel.${NAMESPACE}.svc -p 26379 -a Opstree@1234 ping 2>/dev/null | grep -q PONG; then
+                  echo "replication and sentinel services are answering"
+                  exit 0
+                fi
+                i=$((i + 1))
+                sleep 4
+              done
+              echo "timed out waiting for the services to answer"
+              exit 1
+            check:
+              (contains($stdout, 'replication and sentinel services are answering')): true
     - name: Ping Replicated Service from Cli Pod
       try:
         - script:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/replication.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/replication.yaml
@@ -10,13 +10,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/sentinel.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-sentinel/sentinel.yaml
@@ -14,7 +14,7 @@ spec:
         additionalAnnotations:
           opstreelabs.in/additional-annotation: present
     image: quay.io/opstree/redis-sentinel:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     redisSecret:
       name: redis-secret
       key: password
@@ -23,5 +23,4 @@ spec:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi

--- a/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/standalone.yaml
+++ b/tests/e2e-chainsaw/v1beta2/setup/redis-standalone/standalone.yaml
@@ -18,13 +18,12 @@ spec:
         additionalAnnotations:
           test: test
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster-scale-up.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster-scale-up.yaml
@@ -12,13 +12,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:

--- a/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster.yaml
+++ b/tests/e2e-chainsaw/v1beta2/single-node-scaling/redis-cluster/cluster.yaml
@@ -12,13 +12,12 @@ spec:
     fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 101m
         memory: 128Mi
       limits:
-        cpu: 101m
         memory: 128Mi
   storage:
     volumeClaimTemplate:


### PR DESCRIPTION
## Why

The E2E job took ~44 minutes. On [run 32485942320](https://github.com/OT-CONTAINER-KIT/redis-operator/actions/runs/32485942320) (all green) it was 44m27s, of which `chainsaw test` was 40m16s.

Two numbers set the direction:

- The 23 cases summed to **4783s**. At `parallel: 2` the floor is 2391s and the run took 2416s — the suite was already packed to **99%** of what that parallelism allows, so raising `parallel` alone would have bought nothing.
- **`setup-redis-cluster` alone was 1815s**, 75% of the wall clock, and no amount of parallelism gets below the longest single case.

So the work had to go into what each case costs.

## Results

Measured on this branch:

| | before | after |
|---|---|---|
| `chainsaw test` wall clock | 40m16s | **19m24s (−52%)** |
| E2E job | 44m27s | **23m11s** |
| `setup-redis-cluster` | 1816s | 1005s (−45%) |
| `setup-redis-sentinel` | 333s | **33s (−90%)** |
| `acl-user-redis-cluster` | 164s | 93s (−43%) |
| `pvc-shrink-guard-redis-standalone` | 70s | 41s (−41%) |
| `redis-cluster-restart` | 479s | 315s (−34%) |
| `setup-ha` | 316s | 215s (−32%) |

On top of that the job now starts ~12 minutes earlier in the run, so PR wall clock improves by more than the suite numbers alone show.

### Why `parallel: 3` and not 4

Per-case cost and wall clock pull in opposite directions once cases run concurrently. Measured at both settings:

| | `parallel: 2` | `parallel: 3` |
|---|---|---|
| sum of all 23 cases | 2915s | 3289s (+13% contention tax) |
| `setup-redis-cluster` | 871s | 1005s |
| wall clock | 24m44s | **19m24s** |

3 is where it stops paying. The wall clock is already within 16% of the 1005s critical path, so `sum/4 = 822s` is below it — a fourth lane cannot shorten the run, it can only lengthen the longest case by adding contention. The model puts 4 at ~1206s, i.e. worse than the 1164s measured here.

Getting past this needs `setup-redis-cluster` split into independent cases, not more lanes.

## What changed

**Gate `e2e_test` on `lint` alone.** It hung off `validate_yaml` and `helm_chart_test`, which pull in the whole `gotest` chain. The job did not start until 12.5 minutes into the run, and neither dependency tests anything the suite relies on.

**Drop `cleanup.skipDelete`.** The old log shows 24 × `CLEANUP | SKIP` — every namespace and its pods stayed on the cluster for the rest of the run. By the time `setup-redis-cluster` reached its scale-out there were 75+ redis pods on a 4-vCPU runner, which is why the same operations cost 127s early in a run and ten minutes late in it. It was added alongside `parallel: 10` in #1114 to dodge cleanup timeouts; the real fix for those is `timeouts.cleanup` (below), not skipping the delete.

**Take kind down to 1 control-plane + 3 workers.** kind keeps the `NoSchedule` taint on control-planes whenever a cluster has workers, so the two extra control-planes added a second and third etcd/apiserver/controller-manager plus an haproxy front-end and contributed *zero* schedulable capacity. They came from #1237 for node-shutdown simulation and pod anti-affinity; the suite has neither today. Cluster creation went 74s → ~50s.

**Preload test images and switch the manifests to `IfNotPresent`.** 41 `imagePullPolicy: Always` against one `IfNotPresent`, and kind nodes do not share an image store, so the same image was pulled from quay.io once per pod per node. This also pins a run to a single digest of the moving `:latest` tags. The preload is best-effort — a failed pull or side-load warns and lets the kubelet pull on demand.

**Drop `limits.cpu` from the test CRs**, and from the operator for the test run only (`config/manager` keeps its shipped default). `redis-cli --cluster reshard` is exec'd *inside* the redis pod (`executeCommand1` in `internal/k8sutils/redis.go`), so it shared the container's quota with redis-server — and that quota was `101m`, a tenth of a core. That is what the 672s and 481s scale-out/scale-in steps were. Memory limits are untouched: `maxMemoryPercentOfLimit` derives `maxmemory` from them and `max-memory-env` asserts the resulting `83886080`.

**Replace seven fixed `sleep` steps (690s) with polls.** `setup/redis-sentinel` was the worst — `sleep 5m` inside a 333s case, and it was the only case that did not move at all when the CPU limits came off. The polls wait on the thing each step actually wants: the pod label after a cluster failover, `status.masterNode` after a replication failover, the services answering, the `storageCapacity` annotation after an expand.

Two sleeps stay, and now say why in a comment: `pvc-shrink-guard` and `pod-management-policy` each prove a *non-event* (the shrink is ignored, the immutable field is not applied), and there is nothing to poll for.

**Drop `delayBeforeCleanup: 10s`.** Free while `skipDelete` was set; with cleanup back on it is 10s per case — +100% on an 11s case, 230s of the total.

**Set `timeouts.cleanup: 2m`.** `sentinel-pod-placement` failed namespace teardown with `context deadline exceeded` 30s after the delete: the CRD finalizers need longer than chainsaw's 30s default. Worth knowing — chainsaw records that as a failed test in its go-test output but **not** in its summary or exit code, so that run reported green with `--- FAIL: chainsaw/sentinel-pod-placement` sitting in the log.

**Make `cluster-scale-out.yaml` differ from `cluster.yaml` only in `clusterSize`.** It omitted `TLS`, `redisConfig` and the service block, so it read as though scaling out tore those down. It did not — chainsaw applies with a merge patch, so the omitted fields survived. No behaviour change; the file now says what it does rather than relying on merge-patch semantics.

## Two failures this surfaced, both pre-existing

**data-assert OOM.** `setup-redis-cluster` died on `exit code 137` while `go run` was downloading modules: two data-assert pods were compiling Go at the same moment and one ran past its 512Mi limit. Given headroom (1Gi) and `GOFLAGS=-p=2` so peak RSS does not scale with the node's core count.

**A racy replication assertion.** `acl-pvc-redis-replication` wrote to the master and read from the replica 30s later. `ready-replication.yaml` only asserts `status.masterNode` — that the operator picked a master, not that the replica is attached and synced. The fixed sleep was covering that gap by accident, and with images preloaded and the CPU limits gone the pods reach Ready sooner. It now polls; in practice the replica needed **more than the 30s** the test used to allow, so the old version was genuinely racy.

## Verification

- `yamllint --strict ./tests/` and `actionlint` on the workflow: no new findings.
- Brought the new kind config up for real: 4 nodes in 21s locally, control-plane still carrying `node-role.kubernetes.io/control-plane:NoSchedule`.
- Server-side dry-run applied all 27 modified CR manifests against a kind cluster with the CRDs installed. (The two `pvc-shrink-guard` patch fragments fail standalone validation both before and after; they are partial documents meant to be merged onto an existing CR.)
- All 8 new polling scripts pass `sh -n` — chainsaw runs `script` under `sh -c`, so they have to be POSIX — and were exercised against a stubbed `kubectl` for both the success and the timeout path.
- Checked that no assert file pins a container CPU value, so removing the limits cannot silently change what the suite verifies. 39 CPU limits removed, 39 memory limits still present.

## Not in this PR

- `data-assert` still compiles Go inside the cluster on every run, ~57s per first use across four cases. A prebuilt binary in a small image would remove that and the OOM class with it.
- `setup-redis-cluster` at 1005s is the critical path and caps any further parallelism; splitting it is the next structural step.
