### PR TITLE
fix(cluster): resolve cluster nodes that announce no hostname

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -248,18 +248,18 @@ func repairDisconnectedNodes(ctx context.Context, client kubernetes.Interface, c
 	if err != nil {
 		return err
 	}
+	namer := newClusterNodePodNamer(client, cr)
 	var lastError error
 	for _, node := range nodes {
 		if !nodeFailedOrDisconnected(node) {
 			continue
 		}
-		host, err := getHostFromClusterNode(node)
+		podName, err := namer.podName(ctx, node)
 		if err != nil {
 			lastError = err
 			log.FromContext(ctx).V(1).Error(err, "Failed to get pod name from cluster node. Continuing with other nodes.", "Node", node)
 			continue
 		}
-		podName := strings.Split(host, ".")[0]
 		ip := getRedisServerIP(ctx, client, RedisDetails{
 			PodName:   podName,
 			Namespace: cr.Namespace,
@@ -303,12 +303,13 @@ func repairDisconnectedNodes(ctx context.Context, client kubernetes.Interface, c
 func RepairStaleReplication(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) (int, error) {
 	redisClient := configureRedisClient(ctx, client, cr, cr.Name+"-leader-0")
 	defer redisClient.Close()
+	namer := newClusterNodePodNamer(client, cr)
 	return repairStaleReplication(ctx, redisClient, func(podName string) *redis.Client {
 		return configureRedisClient(ctx, client, cr, podName)
-	})
+	}, namer.podName)
 }
 
-func repairStaleReplication(ctx context.Context, redisClient *redis.Client, makeClient func(podName string) *redis.Client) (int, error) {
+func repairStaleReplication(ctx context.Context, redisClient *redis.Client, makeClient func(podName string) *redis.Client, podNameOf func(context.Context, clusterNodesResponse) (string, error)) (int, error) {
 	logger := log.FromContext(ctx)
 
 	nodes, err := clusterNodes(ctx, redisClient)
@@ -325,12 +326,11 @@ func repairStaleReplication(ctx context.Context, redisClient *redis.Client, make
 		if nodeFailedOrDisconnected(node) {
 			continue
 		}
-		host, err := getHostFromClusterNode(node)
+		podName, err := podNameOf(ctx, node)
 		if err != nil {
 			lastError = err
 			continue
 		}
-		podName := strings.Split(host, ".")[0]
 		masterNodeID := node[3]
 
 		followerClient := makeClient(podName)
@@ -373,13 +373,151 @@ func replicationLinkUp(info string) bool {
 	return true
 }
 
-func getHostFromClusterNode(node clusterNodesResponse) (string, error) {
-	addressAndHost := node[1]
-	s := strings.Split(addressAndHost, ",")
-	if len(s) != 2 {
-		return "", fmt.Errorf("failed to extract host from host and address string, unexpected number of elements: %d", len(s))
+// clusterNodeAddress holds the parts of the address field of a CLUSTER NODES
+// entry, which Redis formats as "<ip:port@cport[,hostname[,auxiliary-field=value]*]>".
+// The hostname is only present when the node runs with cluster-announce-hostname
+// set, and Redis 7.2 and later may append auxiliary fields after it.
+type clusterNodeAddress struct {
+	ip       string
+	port     string
+	hostname string
+}
+
+func parseClusterNodeAddress(node clusterNodesResponse) (clusterNodeAddress, error) {
+	if len(node) < 2 {
+		return clusterNodeAddress{}, fmt.Errorf("cluster node entry has %d fields, want at least 2", len(node))
 	}
-	return strings.Split(addressAndHost, ",")[1], nil
+
+	var address clusterNodeAddress
+	field := node[1]
+	if ipPort, rest, found := strings.Cut(field, ","); found {
+		field = ipPort
+		address.hostname, _, _ = strings.Cut(rest, ",")
+	}
+	field, _, _ = strings.Cut(field, "@")
+
+	// An IPv6 address contains colons of its own, so the port is whatever
+	// follows the last one.
+	separator := strings.LastIndex(field, ":")
+	if separator < 0 {
+		return clusterNodeAddress{}, fmt.Errorf("cluster node address %q has no port", node[1])
+	}
+	address.ip, address.port = field[:separator], field[separator+1:]
+	return address, nil
+}
+
+// clusterNodePodNamer resolves the pod backing a CLUSTER NODES entry.
+//
+// The announced hostname is used when Redis reports one, but it is absent unless
+// the node runs with cluster-announce-hostname set, which is never the case for
+// NodePort clusters. The fallback matches the announced address against the
+// addresses the operator expects each pod to announce, and is built lazily so
+// clusters that do announce hostnames make no extra API calls.
+type clusterNodePodNamer struct {
+	client kubernetes.Interface
+	cr     *rcvb2.RedisCluster
+	byAddr map[string]string
+}
+
+func newClusterNodePodNamer(client kubernetes.Interface, cr *rcvb2.RedisCluster) *clusterNodePodNamer {
+	return &clusterNodePodNamer{client: client, cr: cr}
+}
+
+func (n *clusterNodePodNamer) podName(ctx context.Context, node clusterNodesResponse) (string, error) {
+	address, err := parseClusterNodeAddress(node)
+	if err != nil {
+		return "", err
+	}
+	if address.hostname != "" {
+		// The announced hostname is the pod FQDN, for example
+		// redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local
+		return strings.Split(address.hostname, ".")[0], nil
+	}
+
+	// A node the cluster has lost the address of is reported as ":0@0" with the
+	// noaddr flag. There is nothing to match it against, and no index lookup is
+	// going to help, so say so plainly rather than reporting a failed match.
+	if address.ip == "" {
+		return "", fmt.Errorf("cluster node %s announces no address (%q)", node[0], node[1])
+	}
+
+	if n.byAddr == nil {
+		byAddr, err := n.buildAddressIndex(ctx)
+		if err != nil {
+			return "", err
+		}
+		n.byAddr = byAddr
+	}
+
+	key := address.ip
+	if n.cr.Spec.KubernetesConfig.GetServiceType() == "NodePort" {
+		key = address.port
+	}
+	podName, found := n.byAddr[key]
+	if !found {
+		return "", fmt.Errorf("no pod of redis cluster %s/%s announces address %q", n.cr.Namespace, n.cr.Name, node[1])
+	}
+	return podName, nil
+}
+
+// buildAddressIndex maps the address every pod of the cluster is expected to
+// announce to that pod's name.
+//
+// NodePort clusters announce the node IP and the node port of the pod's own
+// Service, so they are indexed by node port: it identifies the pod on its own
+// and, unlike the node IP, it survives the pod being rescheduled onto another
+// node. Every other service type announces the pod IP.
+func (n *clusterNodePodNamer) buildAddressIndex(ctx context.Context) (map[string]string, error) {
+	if n.cr.Spec.ClusterSize == nil {
+		return nil, fmt.Errorf("redis cluster %s/%s has no cluster size", n.cr.Namespace, n.cr.Name)
+	}
+	nodePort := n.cr.Spec.KubernetesConfig.GetServiceType() == "NodePort"
+
+	byAddr := map[string]string{}
+	for _, role := range []string{"leader", "follower"} {
+		replicas := n.cr.Spec.GetReplicaCounts(role)
+		for i := 0; i < int(replicas); i++ {
+			podName := n.cr.Name + "-" + role + "-" + strconv.Itoa(i)
+			address, err := n.announcedAddressOf(ctx, podName, nodePort)
+			if err != nil {
+				return nil, err
+			}
+			// A pod that has not been scheduled yet, or whose Service has not been
+			// created yet, simply cannot be the one that announced anything.
+			if address != "" {
+				byAddr[address] = podName
+			}
+		}
+	}
+	return byAddr, nil
+}
+
+func (n *clusterNodePodNamer) announcedAddressOf(ctx context.Context, podName string, nodePort bool) (string, error) {
+	if nodePort {
+		svc, err := getService(ctx, n.client, n.cr.Namespace, podName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", nil
+			}
+			return "", err
+		}
+		clientPort, found := lo.Find(svc.Spec.Ports, func(port corev1.ServicePort) bool {
+			return port.Name == redisClientPortName
+		})
+		if !found || clientPort.NodePort == 0 {
+			return "", nil
+		}
+		return strconv.Itoa(int(clientPort.NodePort)), nil
+	}
+
+	pod, err := n.client.CoreV1().Pods(n.cr.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return pod.Status.PodIP, nil
 }
 
 // CreateMultipleLeaderRedisCommand will create command for single leader cluster creation

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -1307,10 +1307,11 @@ func TestParseClusterNodeAddress(t *testing.T) {
 		},
 		{
 			// A NodePort cluster runs without cluster-announce-hostname, so Redis
-			// reports the address on its own.
+			// reports the address on its own. Use the RFC 5737 TEST-NET-1 range
+			// rather than an address belonging to a real cluster.
 			name:         "address without a hostname",
-			field:        "192.168.10.16:30366@30781",
-			expectedIP:   "192.168.10.16",
+			field:        "192.0.2.16:30366@30781",
+			expectedIP:   "192.0.2.16",
 			expectedPort: "30366",
 		},
 		{
@@ -1396,7 +1397,7 @@ func TestClusterNodePodNamer(t *testing.T) {
 		)
 		namer := newClusterNodePodNamer(client, nodePortCluster())
 
-		podName, err := namer.podName(context.Background(), node("192.168.10.16:30445@30199"))
+		podName, err := namer.podName(context.Background(), node("192.0.2.16:30445@30199"))
 
 		require.NoError(t, err)
 		assert.Equal(t, "redis-cluster-follower-0", podName)
@@ -1410,7 +1411,7 @@ func TestClusterNodePodNamer(t *testing.T) {
 		namer := newClusterNodePodNamer(client, nodePortCluster())
 
 		// The recorded address still points at the node the pod used to run on.
-		podName, err := namer.podName(context.Background(), node("192.168.10.99:30366@30781"))
+		podName, err := namer.podName(context.Background(), node("192.0.2.99:30366@30781"))
 
 		require.NoError(t, err)
 		assert.Equal(t, "redis-cluster-leader-0", podName)
@@ -1446,10 +1447,10 @@ func TestClusterNodePodNamer(t *testing.T) {
 		client := k8sClientFake.NewSimpleClientset(perPodService("redis-cluster-leader-0", 30366))
 		namer := newClusterNodePodNamer(client, nodePortCluster())
 
-		_, err := namer.podName(context.Background(), node("192.168.10.16:31999@32999"))
+		_, err := namer.podName(context.Background(), node("192.0.2.16:31999@32999"))
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `announces address "192.168.10.16:31999@32999"`)
+		assert.Contains(t, err.Error(), `announces address "192.0.2.16:31999@32999"`)
 	})
 
 	t.Run("reports a node the cluster lost the address of without any lookup", func(t *testing.T) {
@@ -1471,7 +1472,7 @@ func TestClusterNodePodNamer(t *testing.T) {
 		namer := newClusterNodePodNamer(client, nodePortCluster())
 
 		for i := 0; i < 3; i++ {
-			_, err := namer.podName(context.Background(), node("192.168.10.16:30366@31366"))
+			_, err := namer.podName(context.Background(), node("192.0.2.16:30366@31366"))
 			require.NoError(t, err)
 		}
 
@@ -1495,8 +1496,8 @@ func TestRepairStaleReplication_nodePortClusterWithoutHostname(t *testing.T) {
 	redisClient, mock := redismock.NewClientMock()
 
 	mock.ExpectClusterNodes().SetVal(`
-e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 192.168.10.16:30366@30781 myself,master - 0 0 1 connected 0-16383
-07c37dfeb235213a872192d90877d0cd55635b91 192.168.10.16:30445@30199 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 1 connected
+e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 192.0.2.16:30366@30781 myself,master - 0 0 1 connected 0-16383
+07c37dfeb235213a872192d90877d0cd55635b91 192.0.2.16:30445@30199 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 1 connected
 `)
 
 	followerClient, followerMock := redismock.NewClientMock()

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-redis/redismock/v9"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -244,9 +245,12 @@ e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,redis-cluster-lea
 	)
 	followerMock.ExpectClusterReplicate("e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca").SetVal("OK")
 
+	namer := newClusterNodePodNamer(k8sClientFake.NewSimpleClientset(), &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+	})
 	repaired, lastError := repairStaleReplication(ctx, redisClient, func(_ string) *redis.Client {
 		return followerClient
-	})
+	}, namer.podName)
 	assert.NoError(t, lastError)
 	assert.Equal(t, 1, repaired)
 	assert.NoError(t, followerMock.ExpectationsWereMet(), "expected CLUSTER REPLICATE on the stale follower")
@@ -266,9 +270,12 @@ e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,redis-cluster-lea
 		"# Replication\r\nrole:slave\r\nmaster_host:10.0.0.1\r\nmaster_port:6379\r\nmaster_link_status:up\r\nmaster_last_io_seconds_ago:0\r\n",
 	)
 
+	namer := newClusterNodePodNamer(k8sClientFake.NewSimpleClientset(), &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+	})
 	repaired, lastError := repairStaleReplication(ctx, redisClient, func(_ string) *redis.Client {
 		return followerClient
-	})
+	}, namer.podName)
 	assert.NoError(t, lastError)
 	assert.Equal(t, 0, repaired)
 }
@@ -1280,4 +1287,258 @@ e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,hostname1 myself,
 			}
 		})
 	}
+}
+
+func TestParseClusterNodeAddress(t *testing.T) {
+	tests := []struct {
+		name             string
+		field            string
+		expectedIP       string
+		expectedPort     string
+		expectedHostname string
+		expectError      bool
+	}{
+		{
+			name:             "address with an announced hostname",
+			field:            "127.0.0.1:30001@31001,redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local",
+			expectedIP:       "127.0.0.1",
+			expectedPort:     "30001",
+			expectedHostname: "redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local",
+		},
+		{
+			// A NodePort cluster runs without cluster-announce-hostname, so Redis
+			// reports the address on its own.
+			name:         "address without a hostname",
+			field:        "192.168.10.16:30366@30781",
+			expectedIP:   "192.168.10.16",
+			expectedPort: "30366",
+		},
+		{
+			// Redis 7.2 and later may append auxiliary fields after the hostname.
+			name:             "address with auxiliary fields after the hostname",
+			field:            "127.0.0.1:6379@16379,redis-cluster-leader-0,shard-id=69bfa0c",
+			expectedIP:       "127.0.0.1",
+			expectedPort:     "6379",
+			expectedHostname: "redis-cluster-leader-0",
+		},
+		{
+			name:         "IPv6 address",
+			field:        "2001:db8::1:6379@16379",
+			expectedIP:   "2001:db8::1",
+			expectedPort: "6379",
+		},
+		{
+			name:        "address without a port",
+			field:       "127.0.0.1",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, err := parseClusterNodeAddress(clusterNodesResponse{"nodeid", tt.field, "master"})
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedIP, address.ip)
+			assert.Equal(t, tt.expectedPort, address.port)
+			assert.Equal(t, tt.expectedHostname, address.hostname)
+		})
+	}
+
+	t.Run("entry without an address field", func(t *testing.T) {
+		_, err := parseClusterNodeAddress(clusterNodesResponse{"nodeid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "want at least 2")
+	})
+}
+
+func TestClusterNodePodNamer(t *testing.T) {
+	nodePortCluster := func() *rcvb2.RedisCluster {
+		return &rcvb2.RedisCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+			Spec: rcvb2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(1)),
+				KubernetesConfig: common.KubernetesConfig{
+					Service: &common.ServiceConfig{ServiceType: "NodePort"},
+				},
+			},
+		}
+	}
+	clusterIPCluster := func() *rcvb2.RedisCluster {
+		return &rcvb2.RedisCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+			Spec:       rcvb2.RedisClusterSpec{ClusterSize: ptr.To(int32(1))},
+		}
+	}
+	perPodService := func(name string, nodePort int32) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{Name: "redis-bus", Port: 16379, NodePort: nodePort + 1000},
+					{Name: "redis-client", Port: 6379, NodePort: nodePort},
+				},
+			},
+		}
+	}
+	node := func(address string) clusterNodesResponse {
+		return clusterNodesResponse{"nodeid", address, "master"}
+	}
+
+	t.Run("resolves a NodePort cluster node that announces no hostname", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(
+			perPodService("redis-cluster-leader-0", 30366),
+			perPodService("redis-cluster-follower-0", 30445),
+		)
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		podName, err := namer.podName(context.Background(), node("192.168.10.16:30445@30199"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "redis-cluster-follower-0", podName)
+	})
+
+	t.Run("matches the node port rather than the node IP so a rescheduled pod still resolves", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(
+			perPodService("redis-cluster-leader-0", 30366),
+			perPodService("redis-cluster-follower-0", 30445),
+		)
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		// The recorded address still points at the node the pod used to run on.
+		podName, err := namer.podName(context.Background(), node("192.168.10.99:30366@30781"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "redis-cluster-leader-0", podName)
+	})
+
+	t.Run("resolves a non-NodePort cluster node by pod IP", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster-follower-0", Namespace: "default"},
+				Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
+			},
+		)
+		namer := newClusterNodePodNamer(client, clusterIPCluster())
+
+		podName, err := namer.podName(context.Background(), node("10.0.0.2:6379@16379"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "redis-cluster-follower-0", podName)
+	})
+
+	t.Run("prefers the announced hostname and makes no API call", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset()
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		podName, err := namer.podName(context.Background(), node("127.0.0.1:30001@31001,redis-cluster-leader-0.headless.default.svc.cluster.local"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "redis-cluster-leader-0", podName)
+		assert.Empty(t, client.Actions(), "the hostname is enough, nothing should be looked up")
+	})
+
+	t.Run("reports the unresolvable address instead of the element count", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(perPodService("redis-cluster-leader-0", 30366))
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		_, err := namer.podName(context.Background(), node("192.168.10.16:31999@32999"))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `announces address "192.168.10.16:31999@32999"`)
+	})
+
+	t.Run("reports a node the cluster lost the address of without any lookup", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(perPodService("redis-cluster-leader-0", 30366))
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		// Redis reports a node it no longer has an address for as ":0@0", flagged
+		// noaddr. It happens after a pod is replaced and loses its node identity.
+		_, err := namer.podName(context.Background(), clusterNodesResponse{"f54b90db", ":0@0", "master,noaddr"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "announces no address")
+		assert.Contains(t, err.Error(), "f54b90db")
+		assert.Empty(t, client.Actions(), "an address-less node cannot be matched, so nothing should be looked up")
+	})
+
+	t.Run("builds the address index only once", func(t *testing.T) {
+		client := k8sClientFake.NewSimpleClientset(perPodService("redis-cluster-leader-0", 30366))
+		namer := newClusterNodePodNamer(client, nodePortCluster())
+
+		for i := 0; i < 3; i++ {
+			_, err := namer.podName(context.Background(), node("192.168.10.16:30366@31366"))
+			require.NoError(t, err)
+		}
+
+		var gets int
+		for _, action := range client.Actions() {
+			if action.GetVerb() == "get" {
+				gets++
+			}
+		}
+		assert.Equal(t, 2, gets, "one lookup per ordinal, cached for later nodes")
+	})
+}
+
+// TestRepairStaleReplication_nodePortClusterWithoutHostname reproduces the live
+// failure: a NodePort cluster runs without cluster-announce-hostname, so every
+// CLUSTER NODES entry is a bare "ip:port@cport". Resolving the follower used to
+// fail outright, which made the repair a no-op on exactly the clusters that need
+// it.
+func TestRepairStaleReplication_nodePortClusterWithoutHostname(t *testing.T) {
+	ctx := context.Background()
+	redisClient, mock := redismock.NewClientMock()
+
+	mock.ExpectClusterNodes().SetVal(`
+e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 192.168.10.16:30366@30781 myself,master - 0 0 1 connected 0-16383
+07c37dfeb235213a872192d90877d0cd55635b91 192.168.10.16:30445@30199 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 1 connected
+`)
+
+	followerClient, followerMock := redismock.NewClientMock()
+	followerMock.ExpectInfo("replication").SetVal(
+		"# Replication\r\nrole:slave\r\nmaster_host:10.130.24.167\r\nmaster_port:6379\r\nmaster_link_status:down\r\n",
+	)
+	followerMock.ExpectClusterReplicate("e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca").SetVal("OK")
+
+	perPodService := func(name string, nodePort int32) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{Name: "redis-client", Port: 6379, NodePort: nodePort},
+					{Name: "redis-bus", Port: 16379, NodePort: nodePort + 10000},
+				},
+			},
+		}
+	}
+	client := k8sClientFake.NewSimpleClientset(
+		perPodService("redis-cluster-leader-0", 30366),
+		perPodService("redis-cluster-follower-0", 30445),
+	)
+	namer := newClusterNodePodNamer(client, &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+		Spec: rcvb2.RedisClusterSpec{
+			ClusterSize: ptr.To(int32(1)),
+			KubernetesConfig: common.KubernetesConfig{
+				Service: &common.ServiceConfig{ServiceType: "NodePort"},
+			},
+		},
+	})
+
+	var repairedPod string
+	repaired, lastError := repairStaleReplication(ctx, redisClient, func(podName string) *redis.Client {
+		repairedPod = podName
+		return followerClient
+	}, namer.podName)
+
+	require.NoError(t, lastError)
+	assert.Equal(t, 1, repaired)
+	assert.Equal(t, "redis-cluster-follower-0", repairedPod)
+	assert.NoError(t, followerMock.ExpectationsWereMet(), "expected CLUSTER REPLICATE on the stale follower")
 }


### PR DESCRIPTION
## What is broken

`getHostFromClusterNode` reads the address field of a `CLUSTER NODES` entry, splits it on `,` and requires exactly two elements:

```go
addressAndHost := node[1]
s := strings.Split(addressAndHost, ",")
if len(s) != 2 {
    return "", fmt.Errorf("failed to extract host from host and address string, unexpected number of elements: %d", len(s))
}
```

Redis formats that field as `<ip:port@cport[,hostname[,auxiliary-field=value]*]>`. The `,hostname` part is present only when the node runs with `cluster-announce-hostname` set.

A NodePort cluster does not set it. Every entry is a bare `<ip:port@cport>`, so `len(s) == 1` and the parse fails for every node. That has two consequences:

- `RepairStaleReplication` resolves no follower, repairs nothing, and logs `failed to repair stale replication links` on every reconciliation.
- `RepairDisconnectedNodes` fails the same way, silently, because it only runs once a node is already failed or disconnected. Self-healing is unavailable on exactly the clusters that need it.

The strict length check is also wrong in the other direction: Redis 7.2 and later may append auxiliary fields after the hostname, giving three or more elements, which is rejected just the same.

### Observed on a live cluster

A three-shard NodePort cluster on Kubernetes 1.35, Redis 8.4.2:

```text
$ redis-cli config get 'cluster-announce*'
cluster-announce-ip         192.168.10.16
cluster-announce-port       30445
cluster-announce-bus-port   30199
cluster-announce-hostname   <empty>

$ redis-cli cluster nodes
745ef44f91c7... 192.168.10.16:32253@32232 slave 9477a6bb... 0 ... connected
                └────────── node[1], no comma ──────────┘
```

The operator logged the error 81 times in 15 minutes on an otherwise healthy cluster.

## History

The logic arrived in de6b066 (#1105) as `getMasterHostFromClusterNode`, byte-identical. Its only caller was gated on masters that were already failed, so on a healthy cluster it never ran and the bug stayed latent.

1e7e76e (#1705) renamed it and added `repairStaleReplication`, which calls it for **healthy slaves**. That is what made it fire continuously. #1705 did not introduce the bug, it exposed it.

## The change

Parse the address field into its parts, then resolve the pod:

1. Through the announced hostname when Redis reports one. Unchanged behaviour for clusters that announce hostnames, and no additional API calls — the fallback index is built lazily.
2. Otherwise by matching the announced address against the addresses the operator expects each pod to announce: the node port of the pod's own Service for NodePort clusters, the pod IP for every other service type.

Matching a NodePort cluster on the **node port** rather than the node IP is deliberate. The node port identifies the pod on its own, and unlike the node IP it survives the pod being rescheduled onto another node, so a node recorded against a stale address still resolves. This mirrors `getEndpoint`, which already builds the same address in the forward direction.

A node the cluster has lost the address of is reported as `:0@0` with the `noaddr` flag. It cannot be matched by address at all, so it now says that plainly rather than reporting a failed lookup. Resolving those by node identity is a separate gap and is not addressed here.

## Tests

`TestRepairStaleReplication_nodePortClusterWithoutHostname` reproduces the reported failure end to end. Against `main` it fails with the production error:

```text
=== RUN   TestRepairStaleReplication_nodePortClusterWithoutHostname
    Error:  Received unexpected error:
            failed to extract host from host and address string, unexpected number of elements: 1
--- FAIL: TestRepairStaleReplication_nodePortClusterWithoutHostname (0.00s)
```

Also added: `TestParseClusterNodeAddress` covering an announced hostname, a bare address, auxiliary fields after the hostname, IPv6, a missing port and a truncated entry; and `TestClusterNodePodNamer` covering NodePort resolution, resolution of a node recorded against a stale node IP, pod-IP resolution for non-NodePort clusters, the hostname shortcut making no API call, the `noaddr` node, and the index being built once.

The existing `TestRepairDisconnectedNodes*` and `TestRepairStaleReplication_*` tests are unchanged in behaviour and still pass.

## Verification

`go build ./...`, `go test ./...` with the 1.31 envtest assets, `golangci-lint run` (0 issues) and `git diff --check` are all clean.

Deployed to the live cluster above. The error count went from 81 in 15 minutes to 0. The only failures that remained were for a genuinely address-less `:0@0` node, produced deliberately by destroying a pod's node identity.
