### PR TITLE
fix(cluster): delete per-pod NodePort Services on scale-down

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller_test.go
+++ b/internal/controller/rediscluster/rediscluster_controller_test.go
@@ -322,6 +322,14 @@ var _ = Describe("Redis Cluster Controller", func() {
 
 		AfterEach(func() {
 			Expect(k8sClient.Delete(context.Background(), redisCluster)).Should(Succeed())
+			// The finalizer is removed on a later reconciliation, so the object
+			// outlives the Delete call. Recreating it before then fails.
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      redisCluster.Name,
+					Namespace: ns,
+				}, &rcvb2.RedisCluster{})
+			}, timeout, interval).ShouldNot(Succeed())
 		})
 
 		It("should announce the allocated node ports from the first StatefulSet revision", func() {
@@ -381,6 +389,91 @@ var _ = Describe("Redis Cluster Controller", func() {
 			for name := range announceEnv(followerSts) {
 				Expect(name).NotTo(ContainSubstring("_leader_"))
 			}
+		})
+
+		It("should delete the per-pod Services of ordinals removed by a scale-down", func() {
+			// No StatefulSet controller runs in envtest, so readiness has to be
+			// simulated. The operator refuses to scale down until both StatefulSets
+			// report ready, and their spec changes as the test scales, so this is
+			// re-applied on every poll rather than once.
+			markReady := func(name string) {
+				sts := &appsv1.StatefulSet{}
+				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, sts); err != nil {
+					return
+				}
+				if sts.Spec.Replicas == nil {
+					return
+				}
+				sts.Status.Replicas = *sts.Spec.Replicas
+				sts.Status.ReadyReplicas = *sts.Spec.Replicas
+				sts.Status.AvailableReplicas = *sts.Spec.Replicas
+				sts.Status.CurrentReplicas = *sts.Spec.Replicas
+				sts.Status.UpdatedReplicas = *sts.Spec.Replicas
+				sts.Status.ObservedGeneration = sts.Generation
+				_ = k8sClient.Status().Update(context.Background(), sts)
+			}
+
+			// perPodServices counts the Services named after a pod of a role, which
+			// are the ones holding a node port allocation.
+			perPodServices := func(role string) int {
+				services := &corev1.ServiceList{}
+				if err := k8sClient.List(context.Background(), services,
+					client.InNamespace(ns),
+					client.MatchingLabels{"app": redisCluster.Name + "-" + role},
+				); err != nil {
+					return -1
+				}
+				var count int
+				for i := range services.Items {
+					if _, perPod := services.Items[i].Labels["statefulset.kubernetes.io/pod-name"]; perPod {
+						count++
+					}
+				}
+				return count
+			}
+
+			setClusterSize := func(size int32) {
+				Eventually(func() error {
+					rc := &rcvb2.RedisCluster{}
+					if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: redisCluster.Name, Namespace: ns}, rc); err != nil {
+						return err
+					}
+					rc.Spec.ClusterSize = ptr.To(size)
+					return k8sClient.Update(context.Background(), rc)
+				}, timeout, interval).Should(Succeed())
+			}
+
+			countWhileReady := func(role string) func() int {
+				return func() int {
+					markReady(redisCluster.Name + "-leader")
+					markReady(redisCluster.Name + "-follower")
+					return perPodServices(role)
+				}
+			}
+
+			By("waiting for the initial three shards")
+			Eventually(countWhileReady("leader"), time.Second*30, interval).Should(Equal(3))
+
+			By("scaling up to four shards")
+			setClusterSize(4)
+			Eventually(countWhileReady("leader"), time.Second*60, interval).Should(Equal(4))
+			Eventually(countWhileReady("follower"), time.Second*60, interval).Should(Equal(4))
+
+			By("scaling back down to three shards")
+			setClusterSize(3)
+
+			By("verifying the Service of the removed ordinal is deleted rather than left holding its node port")
+			Eventually(countWhileReady("leader"), time.Second*60, interval).Should(Equal(3))
+			Eventually(countWhileReady("follower"), time.Second*60, interval).Should(Equal(3))
+
+			By("verifying the removed ordinal is gone by name")
+			Consistently(func() error {
+				svc := &corev1.Service{}
+				return k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      redisCluster.Name + "-leader-3",
+					Namespace: ns,
+				}, svc)
+			}, time.Second*3, interval).ShouldNot(Succeed())
 		})
 	})
 })

--- a/internal/k8sutils/redis-cluster.go
+++ b/internal/k8sutils/redis-cluster.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -465,7 +466,67 @@ func (service RedisClusterService) createOrUpdateClusterNodePortService(ctx cont
 			return err
 		}
 	}
+	if err := service.deleteStaleClusterNodePortServices(ctx, cr, cl, replicas); err != nil {
+		log.FromContext(ctx).Error(err, "Cannot delete stale nodeport services for Redis", "Setup.Type", service.RedisServiceRole)
+		return err
+	}
 	return nil
+}
+
+// deleteStaleClusterNodePortServices removes the per-pod NodePort Services left
+// behind by a scale-down. Their node ports stay allocated for as long as the
+// Services exist, so a cluster that is repeatedly scaled up and down eventually
+// exhausts the node port range.
+//
+// This runs as part of the Service reconciliation, which the controller performs
+// only after the StatefulSet has been updated to the smaller size. Deleting a
+// Service whose pod is still meant to be running would strip that pod of the node
+// port it announces to the cluster, so the ordering matters: never move this
+// ahead of the StatefulSet update, and in particular never into the preflight in
+// EnsureRedisClusterNodePortServices, which deliberately runs before it.
+func (service RedisClusterService) deleteStaleClusterNodePortServices(ctx context.Context, cr *rcvb2.RedisCluster, cl kubernetes.Interface, replicas int32) error {
+	prefix := cr.Name + "-" + service.RedisServiceRole + "-"
+	selector := labels.SelectorFromSet(getRedisStableLabels(cr.Name+"-"+service.RedisServiceRole, string(cluster), service.RedisServiceRole))
+
+	services, err := cl.CoreV1().Services(cr.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return err
+	}
+
+	for i := range services.Items {
+		stale := &services.Items[i]
+		// The role wide Services carry the same labels; only the per-pod ones are
+		// named after a pod and labelled with it.
+		if _, perPod := stale.Labels["statefulset.kubernetes.io/pod-name"]; !perPod {
+			continue
+		}
+		ordinal, err := strconv.Atoi(strings.TrimPrefix(stale.Name, prefix))
+		if err != nil || ordinal < int(replicas) {
+			continue
+		}
+		// Only ever delete Services this cluster owns.
+		if !isOwnedByRedisCluster(stale, cr) {
+			continue
+		}
+		log.FromContext(ctx).Info("Deleting nodeport service of a scaled down replica",
+			"Service", stale.Name, "Setup.Type", service.RedisServiceRole, "Replicas", replicas)
+		if err := deleteService(ctx, cl, cr.Namespace, stale.Name); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// isOwnedByRedisCluster reports whether cr owns obj. The owner reference is
+// matched on UID and name rather than on Kind, because the Kind of an object read
+// through a typed client is empty, and redisClusterAsOwner copies it verbatim.
+func isOwnedByRedisCluster(obj metav1.Object, cr *rcvb2.RedisCluster) bool {
+	for _, owner := range obj.GetOwnerReferences() {
+		if owner.UID == cr.UID && owner.Name == cr.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // clusterNodePortServiceParams returns the object metadata and the cluster-bus

--- a/internal/k8sutils/redis-cluster_test.go
+++ b/internal/k8sutils/redis-cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -789,5 +790,152 @@ func Test_generateRedisClusterContainerParams_NodePort(t *testing.T) {
 
 		require.NotNil(t, cr.Spec.EnvVars)
 		assert.Len(t, *cr.Spec.EnvVars, 1, "the cluster spec must not be mutated by rendering")
+	})
+}
+
+func TestDeleteStaleClusterNodePortServices(t *testing.T) {
+	newRedisCluster := func() *rcvb2.RedisCluster {
+		cluster := &rcvb2.RedisCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "redis.redis.opstreelabs.in/v1beta2",
+				Kind:       "RedisCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "redis-cluster",
+				Namespace: "redis",
+				UID:       "11111111-2222-3333-4444-555555555555",
+			},
+			Spec: rcvb2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(4)),
+				KubernetesConfig: common.KubernetesConfig{
+					Service: &common.ServiceConfig{ServiceType: "NodePort"},
+				},
+			},
+		}
+		cluster.SetDefault()
+		return cluster
+	}
+	serviceNames := func(t *testing.T, client *fake.Clientset) []string {
+		t.Helper()
+		services, err := client.CoreV1().Services("redis").List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		names := make([]string, 0, len(services.Items))
+		for i := range services.Items {
+			names = append(names, services.Items[i].Name)
+		}
+		sort.Strings(names)
+		return names
+	}
+	// createPerPodServices builds the per-pod Services through the production code
+	// path, so the labels and owner references cannot drift from what is deleted.
+	createPerPodServices := func(t *testing.T, client *fake.Clientset, cr *rcvb2.RedisCluster, role string, count int) {
+		t.Helper()
+		service := RedisClusterService{RedisServiceRole: role}
+		for i := 0; i < count; i++ {
+			require.NoError(t, service.createOrUpdateClusterNodePortServiceForReplica(t.Context(), cr, client, i))
+		}
+	}
+
+	t.Run("deletes the services of scaled down ordinals", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		createPerPodServices(t, client, cr, "leader", 4)
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		require.NoError(t, service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 2))
+
+		assert.Equal(t, []string{"redis-cluster-leader-0", "redis-cluster-leader-1"}, serviceNames(t, client))
+	})
+
+	t.Run("keeps every service when nothing was scaled down", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		createPerPodServices(t, client, cr, "leader", 3)
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		require.NoError(t, service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 3))
+
+		require.Len(t, serviceNames(t, client), 3)
+		var deletes int
+		for _, action := range client.Actions() {
+			if action.GetVerb() == "delete" {
+				deletes++
+			}
+		}
+		assert.Zero(t, deletes)
+	})
+
+	t.Run("only touches the role it was asked about", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		createPerPodServices(t, client, cr, "leader", 4)
+		createPerPodServices(t, client, cr, "follower", 4)
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		require.NoError(t, service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 3))
+
+		assert.Equal(t, []string{
+			"redis-cluster-follower-0", "redis-cluster-follower-1",
+			"redis-cluster-follower-2", "redis-cluster-follower-3",
+			"redis-cluster-leader-0", "redis-cluster-leader-1", "redis-cluster-leader-2",
+		}, serviceNames(t, client))
+	})
+
+	t.Run("keeps the role wide services that share the same labels", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		createPerPodServices(t, client, cr, "leader", 4)
+		// The role wide Services carry app/role/redis_setup_type just like the
+		// per-pod ones, but are not named after a pod.
+		roleLabels := getRedisLabels("redis-cluster-leader", cluster, "leader", nil)
+		for _, name := range []string{"redis-cluster-leader", "redis-cluster-leader-headless", "redis-cluster-leader-additional"} {
+			_, err := client.CoreV1().Services("redis").Create(t.Context(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redis", Labels: roleLabels},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		require.NoError(t, service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 0))
+
+		assert.Equal(t, []string{
+			"redis-cluster-leader", "redis-cluster-leader-additional", "redis-cluster-leader-headless",
+		}, serviceNames(t, client))
+	})
+
+	t.Run("never deletes a service this cluster does not own", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		createPerPodServices(t, client, cr, "leader", 4)
+
+		// Same name and labels, but owned by a different RedisCluster.
+		foreign, err := client.CoreV1().Services("redis").Get(t.Context(), "redis-cluster-leader-3", metav1.GetOptions{})
+		require.NoError(t, err)
+		foreign.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "redis.redis.opstreelabs.in/v1beta2",
+			Kind:       "RedisCluster",
+			Name:       "some-other-cluster",
+			UID:        "99999999-9999-9999-9999-999999999999",
+		}}
+		_, err = client.CoreV1().Services("redis").Update(t.Context(), foreign, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		require.NoError(t, service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 3))
+
+		assert.Contains(t, serviceNames(t, client), "redis-cluster-leader-3")
+	})
+
+	t.Run("returns a list error", func(t *testing.T) {
+		cr := newRedisCluster()
+		client := fake.NewSimpleClientset()
+		client.PrependReactor("list", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("service list failed")
+		})
+
+		service := RedisClusterService{RedisServiceRole: "leader"}
+		err := service.deleteStaleClusterNodePortServices(t.Context(), cr, client, 3)
+
+		require.EqualError(t, err, "service list failed")
 	})
 }

--- a/internal/k8sutils/services.go
+++ b/internal/k8sutils/services.go
@@ -120,6 +120,17 @@ func updateService(ctx context.Context, k8sClient kubernetes.Interface, namespac
 	return nil
 }
 
+// deleteService is a method to delete a service in Kubernetes
+func deleteService(ctx context.Context, k8sClient kubernetes.Interface, namespace string, name string) error {
+	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Redis service deletion failed", "service", name)
+		return err
+	}
+	log.FromContext(ctx).V(1).Info("Redis service deleted successfully", "service", name)
+	return nil
+}
+
 // getService is a method to get service is Kubernetes
 func getService(ctx context.Context, k8sClient kubernetes.Interface, namespace string, name string) (*corev1.Service, error) {
 	getOpts := metav1.GetOptions{


### PR DESCRIPTION
## What leaks

`createOrUpdateClusterNodePortService` and `EnsureRedisClusterNodePortServices` both reconcile the per-pod NodePort Services with

```go
for i := 0; i < int(replicas); i++ { ... }
```

and nothing removes the Services of the ordinals above `replicas`. Scaling a cluster from four shards down to three leaves `<name>-leader-3` and `<name>-follower-3` behind, each holding a client and a cluster bus node port for as long as the cluster exists. A cluster that is repeatedly scaled up and down keeps consuming the node port range, which is only `30000-32767` by default.

Deleting the CR is already handled — the Services carry an owner reference and are garbage collected with it. Only shrinking leaks.

### Observed on a live cluster

A NodePort cluster scaled 3 → 4 → 3 on Kubernetes 1.35:

```text
$ kubectl get sts
NAME                              SPEC   READY
redis-cluster-nodeport-follower   3      3
redis-cluster-nodeport-leader     3      3

$ kubectl get svc | grep -E 'leader-[0-9]|follower-[0-9]' | wc -l
8          # six pods, eight Services

$ kubectl get svc redis-cluster-nodeport-leader-3 -o jsonpath='{.spec.ports}'
redis-client:31509  redis-bus:31657
$ kubectl get endpoints redis-cluster-nodeport-leader-3
<none>     # four node ports held by two Services that select nothing
```

## The change

Delete the Services of ordinals at or above the replica count as part of the Service reconciliation.

**Placement is the substance of this change.** The controller runs the Service reconciliation only *after* `CreateRedisLeader` / `CreateRedisFollower` has updated the StatefulSet to the smaller size. Deleting a Service whose pod is still meant to be running would strip that pod of the node port it announces to the cluster, so the cleanup has to sit behind the StatefulSet update. In particular it must not move into the preflight added by #1875, which deliberately runs *before* it. The doc comment says so, because the next person to touch that ordering needs to know.

If the StatefulSet update fails, `CreateRedisLeader` returns early and the Service reconciliation — and so the cleanup — never runs that round. The existing sequencing gives that for free.

Selection is deliberately narrow:

- the labels the operator already applies (`app`, `redis_setup_type`, `role`),
- narrowed to Services named after a pod, so the role wide Services that carry the same labels (`<name>-leader`, `-headless`, `-additional`) are left alone,
- and checked against the owner reference, so a cluster can only ever delete its own Services.

The owner reference is matched on UID and name rather than Kind: an object read through a typed client has an empty `TypeMeta`, and `redisClusterAsOwner` copies `cr.Kind` verbatim, so a `Kind == "RedisCluster"` check would never match in the operator.

## Tests

`TestDeleteStaleClusterNodePortServices` builds the Services through the production code path, so the labels and owner references under test cannot drift from the ones the operator writes. It covers: deleting scaled down ordinals, issuing no deletes when nothing shrank, leaving the other role alone, leaving the role wide Services alone, refusing to delete a Service owned by a different cluster, and propagating a list error.

An envtest spec scales a NodePort cluster 3 → 4 → 3 and asserts the per-pod Service count follows. Against `main` it fails:

```text
[FAILED] Timed out after 60.001s.
Expected
    <int>: 4
    <int>: 3
```

The suite's `AfterEach` now waits for the RedisCluster to actually disappear. The finalizer is removed on a later reconciliation, so the object outlives the `Delete` call and recreating it in the next spec failed.

## Verification

`go build ./...`, `go test ./...` with the 1.31 envtest assets, `golangci-lint run` (0 issues) and `git diff --check` are all clean.

Deployed to the live cluster above, which was sitting on the leaked state. Both orphans were removed on the first reconciliation:

```text
Deleting nodeport service of a scaled down replica  Service=redis-cluster-nodeport-leader-3    Setup.Type=leader    Replicas=3
Deleting nodeport service of a scaled down replica  Service=redis-cluster-nodeport-follower-3  Setup.Type=follower  Replicas=3
```

Eight Services became six, and the cluster stayed `cluster_state:ok` with `cluster_size:3`.

## Not covered

Changing `serviceType` away from `NodePort` on a live cluster orphans the per-pod Services the same way, because `createOrUpdateClusterNodePortService` is only reached while the type is still NodePort. That is a separate path and is left alone here.
