### PR TITLE
fix(utils): propagate context to Kubernetes API calls

### DIFF
--- a/internal/k8sutils/context_propagation_test.go
+++ b/internal/k8sutils/context_propagation_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 )
 
 type contextPropagationKey struct{}
@@ -26,12 +27,31 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func newContextCheckingClient(t *testing.T) kubernetes.Interface {
+// responder lets a test override the response for a particular request. Returning
+// nil falls through to the default success response.
+type responder func(*http.Request) *http.Response
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func newContextCheckingClient(t *testing.T, overrides ...responder) kubernetes.Interface {
 	t.Helper()
 
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Context().Value(contextPropagationKey{}) != "reconcile" {
 			return nil, errors.New("reconcile context was not propagated to the Kubernetes API request")
+		}
+
+		for _, override := range overrides {
+			if resp := override(req); resp != nil {
+				resp.Request = req
+				return resp, nil
+			}
 		}
 
 		body := `{}`
@@ -48,12 +68,9 @@ func newContextCheckingClient(t *testing.T) kubernetes.Interface {
 			body = `{"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"name":"data-test-0","namespace":"test"},"spec":{"resources":{"requests":{"storage":"2Gi"}}}}`
 		}
 
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Request:    req,
-		}, nil
+		resp := jsonResponse(http.StatusOK, body)
+		resp.Request = req
+		return resp, nil
 	})
 
 	client, err := kubernetes.NewForConfig(&rest.Config{
@@ -84,6 +101,34 @@ func TestStatefulSetHelpersPropagateContext(t *testing.T) {
 	require.NoError(t, updateStatefulSet(ctx, client, "test", statefulSet, false, nil))
 	_, err := GetStatefulSet(ctx, client, "test", "test")
 	require.NoError(t, err)
+}
+
+// updateStatefulSet falls back to deleting the StatefulSet when the API server
+// rejects the update as Invalid, and relies on the controller to recreate it.
+// That DELETE is a request of its own, on a path the success case never reaches,
+// so it needs its own coverage.
+func TestStatefulSetRecreatePropagatesContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), contextPropagationKey{}, "reconcile")
+
+	var deleteRequests int
+	client := newContextCheckingClient(t, func(req *http.Request) *http.Response {
+		if !strings.Contains(req.URL.Path, "/statefulsets") {
+			return nil
+		}
+		switch req.Method {
+		case http.MethodPut:
+			return jsonResponse(http.StatusUnprocessableEntity, `{"apiVersion":"v1","kind":"Status","status":"Failure","code":422,"reason":"Invalid","message":"StatefulSet.apps \"test\" is invalid","details":{"name":"test","group":"apps","kind":"StatefulSet","causes":[{"reason":"FieldValueForbidden","message":"updates to statefulset spec for fields other than 'replicas' are forbidden","field":"spec"}]}}`)
+		case http.MethodDelete:
+			deleteRequests++
+			return jsonResponse(http.StatusOK, `{"apiVersion":"v1","kind":"Status","status":"Success"}`)
+		}
+		return nil
+	})
+
+	statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}
+
+	require.NoError(t, updateStatefulSet(ctx, client, "test", statefulSet, true, ptr.To(metav1.DeletePropagationForeground)))
+	require.Equal(t, 1, deleteRequests, "the recreate branch should delete the StatefulSet once")
 }
 
 func TestPodDisruptionBudgetHelpersPropagateContext(t *testing.T) {

--- a/internal/k8sutils/context_propagation_test.go
+++ b/internal/k8sutils/context_propagation_test.go
@@ -1,0 +1,123 @@
+package k8sutils
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type contextPropagationKey struct{}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newContextCheckingClient(t *testing.T) kubernetes.Interface {
+	t.Helper()
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Context().Value(contextPropagationKey{}) != "reconcile" {
+			return nil, errors.New("reconcile context was not propagated to the Kubernetes API request")
+		}
+
+		body := `{}`
+		switch {
+		case strings.Contains(req.URL.Path, "/services"):
+			body = `{"apiVersion":"v1","kind":"Service","metadata":{"name":"test","namespace":"test"}}`
+		case strings.Contains(req.URL.Path, "/statefulsets"):
+			body = `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"test","namespace":"test"}}`
+		case strings.Contains(req.URL.Path, "/poddisruptionbudgets"):
+			body = `{"apiVersion":"policy/v1","kind":"PodDisruptionBudget","metadata":{"name":"test","namespace":"test"}}`
+		case strings.Contains(req.URL.Path, "/persistentvolumeclaims") && req.Method == http.MethodGet:
+			body = `{"apiVersion":"v1","kind":"PersistentVolumeClaimList","items":[{"metadata":{"name":"data-test-0","namespace":"test"},"spec":{"resources":{"requests":{"storage":"1Gi"}}}}]}`
+		case strings.Contains(req.URL.Path, "/persistentvolumeclaims"):
+			body = `{"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"name":"data-test-0","namespace":"test"},"spec":{"resources":{"requests":{"storage":"2Gi"}}}}`
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	client, err := kubernetes.NewForConfig(&rest.Config{
+		Host:      "https://kubernetes.test",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+func TestServiceHelpersPropagateContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), contextPropagationKey{}, "reconcile")
+	client := newContextCheckingClient(t)
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}
+
+	require.NoError(t, createService(ctx, client, "test", service))
+	require.NoError(t, updateService(ctx, client, "test", service))
+	_, err := getService(ctx, client, "test", "test")
+	require.NoError(t, err)
+}
+
+func TestStatefulSetHelpersPropagateContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), contextPropagationKey{}, "reconcile")
+	client := newContextCheckingClient(t)
+	statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}
+
+	require.NoError(t, createStatefulSet(ctx, client, "test", statefulSet))
+	require.NoError(t, updateStatefulSet(ctx, client, "test", statefulSet, false, nil))
+	_, err := GetStatefulSet(ctx, client, "test", "test")
+	require.NoError(t, err)
+}
+
+func TestPodDisruptionBudgetHelpersPropagateContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), contextPropagationKey{}, "reconcile")
+	client := newContextCheckingClient(t)
+	pdb := &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}
+
+	require.NoError(t, createPodDisruptionBudget(ctx, "test", pdb, client))
+	require.NoError(t, updatePodDisruptionBudget(ctx, "test", pdb, client))
+	_, err := getPodDisruptionBudget(ctx, "test", "test", client)
+	require.NoError(t, err)
+	require.NoError(t, deletePodDisruptionBudget(ctx, "test", "test", client))
+}
+
+func TestPVCResizePropagatesContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), contextPropagationKey{}, "reconcile")
+	client := newContextCheckingClient(t)
+	storedSize := resource.MustParse("1Gi")
+	desiredSize := resource.MustParse("2Gi")
+	stored := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{"storageCapacity": "1073741824"},
+		},
+		Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: storedSize},
+			}},
+		}}},
+	}
+	desired := stored.DeepCopy()
+	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = desiredSize
+
+	require.NoError(t, HandlePVCResizing(ctx, stored, desired, client))
+}

--- a/internal/k8sutils/poddisruption.go
+++ b/internal/k8sutils/poddisruption.go
@@ -224,7 +224,7 @@ func patchPodDisruptionBudget(ctx context.Context, storedPdb *policyv1.PodDisrup
 
 // createPodDisruptionBudget is a method to create PodDisruptionBudgets in Kubernetes
 func createPodDisruptionBudget(ctx context.Context, namespace string, pdb *policyv1.PodDisruptionBudget, cl kubernetes.Interface) error {
-	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Create(context.TODO(), pdb, metav1.CreateOptions{})
+	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Create(ctx, pdb, metav1.CreateOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis PodDisruptionBudget creation failed")
 		return err
@@ -235,7 +235,7 @@ func createPodDisruptionBudget(ctx context.Context, namespace string, pdb *polic
 
 // updatePodDisruptionBudget is a method to update PodDisruptionBudgets in Kubernetes
 func updatePodDisruptionBudget(ctx context.Context, namespace string, pdb *policyv1.PodDisruptionBudget, cl kubernetes.Interface) error {
-	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Update(context.TODO(), pdb, metav1.UpdateOptions{})
+	_, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Update(ctx, pdb, metav1.UpdateOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis PodDisruptionBudget update failed")
 		return err
@@ -246,7 +246,7 @@ func updatePodDisruptionBudget(ctx context.Context, namespace string, pdb *polic
 
 // deletePodDisruptionBudget is a method to delete PodDisruptionBudgets in Kubernetes
 func deletePodDisruptionBudget(ctx context.Context, namespace string, pdbName string, cl kubernetes.Interface) error {
-	err := cl.PolicyV1().PodDisruptionBudgets(namespace).Delete(context.TODO(), pdbName, metav1.DeleteOptions{})
+	err := cl.PolicyV1().PodDisruptionBudgets(namespace).Delete(ctx, pdbName, metav1.DeleteOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis PodDisruption deletion failed")
 		return err
@@ -260,7 +260,7 @@ func getPodDisruptionBudget(ctx context.Context, namespace string, pdb string, c
 	getOpts := metav1.GetOptions{
 		TypeMeta: generateMetaInformation("PodDisruptionBudget", "policy/v1"),
 	}
-	pdbInfo, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), pdb, getOpts)
+	pdbInfo, err := cl.PolicyV1().PodDisruptionBudgets(namespace).Get(ctx, pdb, getOpts)
 	if err != nil {
 		log.FromContext(ctx).V(1).Info("Redis PodDisruptionBudget get action failed")
 		return nil, err

--- a/internal/k8sutils/pvc.go
+++ b/internal/k8sutils/pvc.go
@@ -80,7 +80,7 @@ func HandlePVCResizing(ctx context.Context, storedStateful, newStateful *appsv1.
 	})
 	listOpt := metav1.ListOptions{LabelSelector: labelSelector}
 
-	pvcs, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).List(context.Background(), listOpt)
+	pvcs, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).List(ctx, listOpt)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func HandlePVCResizing(ctx context.Context, storedStateful, newStateful *appsv1.
 		currentCapacity := pvc.Spec.Resources.Requests.Storage().Value()
 		if currentCapacity != desiredCapacity {
 			pvc.Spec.Resources.Requests = newStateful.Spec.VolumeClaimTemplates[targetIndex].Spec.Resources.Requests
-			if _, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
+			if _, err := cl.CoreV1().PersistentVolumeClaims(storedStateful.Namespace).Update(ctx, pvc, metav1.UpdateOptions{}); err != nil {
 				updateFailed = true
 				log.FromContext(ctx).Error(fmt.Errorf("sts:%s resize pvc [%s] failed: %s", storedStateful.Name, pvc.Name, err.Error()), "")
 			} else {

--- a/internal/k8sutils/services.go
+++ b/internal/k8sutils/services.go
@@ -100,7 +100,7 @@ func generateServiceType(k8sServiceType string) corev1.ServiceType {
 
 // createService is a method to create service is Kubernetes
 func createService(ctx context.Context, kusClient kubernetes.Interface, namespace string, service *corev1.Service) error {
-	_, err := kusClient.CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+	_, err := kusClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis service creation is failed")
 		return err
@@ -111,7 +111,7 @@ func createService(ctx context.Context, kusClient kubernetes.Interface, namespac
 
 // updateService is a method to update service is Kubernetes
 func updateService(ctx context.Context, k8sClient kubernetes.Interface, namespace string, service *corev1.Service) error {
-	_, err := k8sClient.CoreV1().Services(namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+	_, err := k8sClient.CoreV1().Services(namespace).Update(ctx, service, metav1.UpdateOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis service update failed")
 		return err
@@ -125,7 +125,7 @@ func getService(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 	getOpts := metav1.GetOptions{
 		TypeMeta: generateMetaInformation("Service", "v1"),
 	}
-	serviceInfo, err := k8sClient.CoreV1().Services(namespace).Get(context.TODO(), name, getOpts)
+	serviceInfo, err := k8sClient.CoreV1().Services(namespace).Get(ctx, name, getOpts)
 	if err != nil {
 		log.FromContext(ctx).V(1).Info("Redis service get action is failed")
 		return nil, err

--- a/internal/k8sutils/statefulset.go
+++ b/internal/k8sutils/statefulset.go
@@ -1101,7 +1101,7 @@ func getEnvironmentVariables(role string, enabledPassword *bool, secretName *str
 
 // createStatefulSet is a method to create statefulset in Kubernetes
 func createStatefulSet(ctx context.Context, cl kubernetes.Interface, namespace string, stateful *appsv1.StatefulSet) error {
-	_, err := cl.AppsV1().StatefulSets(namespace).Create(context.TODO(), stateful, metav1.CreateOptions{})
+	_, err := cl.AppsV1().StatefulSets(namespace).Create(ctx, stateful, metav1.CreateOptions{})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Redis stateful creation failed")
 		return err
@@ -1112,7 +1112,7 @@ func createStatefulSet(ctx context.Context, cl kubernetes.Interface, namespace s
 
 // updateStatefulSet is a method to update statefulset in Kubernetes
 func updateStatefulSet(ctx context.Context, cl kubernetes.Interface, namespace string, stateful *appsv1.StatefulSet, recreateStateFulSet bool, deletePropagation *metav1.DeletionPropagation) error {
-	_, err := cl.AppsV1().StatefulSets(namespace).Update(context.TODO(), stateful, metav1.UpdateOptions{})
+	_, err := cl.AppsV1().StatefulSets(namespace).Update(ctx, stateful, metav1.UpdateOptions{})
 	if recreateStateFulSet {
 		sErr, ok := err.(*apierrors.StatusError)
 		if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
@@ -1121,7 +1121,7 @@ func updateStatefulSet(ctx context.Context, cl kubernetes.Interface, namespace s
 				failMsg[messageCount] = cause.Message
 			}
 			log.FromContext(ctx).V(1).Info("recreating StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
-			if err := cl.AppsV1().StatefulSets(namespace).Delete(context.TODO(), stateful.GetName(), metav1.DeleteOptions{PropagationPolicy: deletePropagation}); err != nil { //nolint:gocritic
+			if err := cl.AppsV1().StatefulSets(namespace).Delete(ctx, stateful.GetName(), metav1.DeleteOptions{PropagationPolicy: deletePropagation}); err != nil { //nolint:gocritic
 				return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")
 			}
 			return nil // rely on the controller to recreate the StatefulSet
@@ -1140,7 +1140,7 @@ func GetStatefulSet(ctx context.Context, cl kubernetes.Interface, namespace stri
 	getOpts := metav1.GetOptions{
 		TypeMeta: generateMetaInformation("StatefulSet", "apps/v1"),
 	}
-	statefulInfo, err := cl.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, getOpts)
+	statefulInfo, err := cl.AppsV1().StatefulSets(namespace).Get(ctx, name, getOpts)
 	if err != nil {
 		log.FromContext(ctx).V(1).Info("Redis statefulset get action failed")
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

Propagate the reconcile context through the Service, StatefulSet, PodDisruptionBudget, and PVC helpers instead of replacing it with `context.TODO()` or `context.Background()`.

This lets in-flight Kubernetes API calls observe reconcile cancellation and deadlines. The NodePort Service preflight introduced by #1875 also benefits because its per-ordinal Service GETs now remain attached to the reconcile lifecycle.

## Why include more than Service helpers?

The same pattern existed in the StatefulSet, PDB, and PVC helpers. They are fixed in the same commit so these closely related resource helpers behave consistently.

## Regression coverage

The new tests use a Kubernetes REST client whose transport rejects requests that do not carry a marker from the supplied context.

Against base `5dd04e17`, the tests fail with real errors such as:

```text
Post "https://kubernetes.test/api/v1/namespaces/test/services": reconcile context was not propagated to the Kubernetes API request
Post "https://kubernetes.test/apis/apps/v1/namespaces/test/statefulsets": reconcile context was not propagated to the Kubernetes API request
Post "https://kubernetes.test/apis/policy/v1/namespaces/test/poddisruptionbudgets": reconcile context was not propagated to the Kubernetes API request
Get "https://kubernetes.test/api/v1/namespaces/test/persistentvolumeclaims?labelSelector=app%3Dtest": reconcile context was not propagated to the Kubernetes API request
```

After the fix:

```text
=== RUN   TestServiceHelpersPropagateContext
--- PASS: TestServiceHelpersPropagateContext (0.00s)
=== RUN   TestStatefulSetHelpersPropagateContext
--- PASS: TestStatefulSetHelpersPropagateContext (0.00s)
=== RUN   TestPodDisruptionBudgetHelpersPropagateContext
--- PASS: TestPodDisruptionBudgetHelpersPropagateContext (0.00s)
=== RUN   TestPVCResizePropagatesContext
--- PASS: TestPVCResizePropagatesContext (0.00s)
PASS
```

## Validation

```text
$ go build ./...

$ KUBEBUILDER_ASSETS=/root/.local/share/kubebuilder-envtest/k8s/1.31.0-linux-amd64 go test ./...
...
ok github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/redis 14.937s
ok github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/rediscluster 20.389s
ok github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/redisreplication 13.700s
ok github.com/OT-CONTAINER-KIT/redis-operator/internal/controller/redissentinel 12.648s
ok github.com/OT-CONTAINER-KIT/redis-operator/internal/k8sutils 0.227s
...

$ ./bin/golangci-lint run
0 issues.
```

Live-cluster verification is not included because this change only affects request cancellation and has deterministic REST-client regression coverage.