### PR TITLE
fix(chart): conditionally render pdb fields and document mutual exclusivity

### DIFF
--- a/charts/redis-cluster/README.md
+++ b/charts/redis-cluster/README.md
@@ -79,8 +79,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.follower.livenessProbe | object | `{}` |  |
 | redisCluster.follower.nodeSelector | string | `nil` |  |
 | redisCluster.follower.pdb.enabled | bool | `false` |  |
-| redisCluster.follower.pdb.maxUnavailable | int | `1` |  |
-| redisCluster.follower.pdb.minAvailable | int | `1` |  |
+| redisCluster.follower.pdb.maxUnavailable | int | `1` | Cannot be set together with minAvailable |
 | redisCluster.follower.readinessProbe | object | `{}` |  |
 | redisCluster.follower.replicas | int | `3` | Number of Redis follower (slave) nodes. If not set, uses clusterSize value |
 | redisCluster.follower.securityContext | object | `{}` |  |
@@ -94,8 +93,7 @@ helm delete <my-release> --namespace <namespace>
 | redisCluster.leader.livenessProbe | object | `{}` |  |
 | redisCluster.leader.nodeSelector | string | `nil` |  |
 | redisCluster.leader.pdb.enabled | bool | `false` |  |
-| redisCluster.leader.pdb.maxUnavailable | int | `1` |  |
-| redisCluster.leader.pdb.minAvailable | int | `1` |  |
+| redisCluster.leader.pdb.maxUnavailable | int | `1` | Cannot be set together with minAvailable |
 | redisCluster.leader.readinessProbe | object | `{}` |  |
 | redisCluster.leader.replicas | int | `3` | Number of Redis leader (master) nodes. If not set, uses clusterSize value |
 | redisCluster.leader.securityContext | object | `{}` |  |

--- a/charts/redis-cluster/templates/_helpers.tpl
+++ b/charts/redis-cluster/templates/_helpers.tpl
@@ -33,8 +33,12 @@ tolerations:
 {{- if .pdb.enabled  }}
 pdb:
   enabled: {{ .pdb.enabled }}
+  {{- if .pdb.maxUnavailable }}
   maxUnavailable: {{ .pdb.maxUnavailable }}
+  {{- end }}
+  {{- if .pdb.minAvailable }}
   minAvailable: {{ .pdb.minAvailable }}
+  {{- end }}
 {{- end }}
 {{- if .nodeSelector }}
 nodeSelector:

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -78,8 +78,10 @@ redisCluster:
       #       clusterId: redis-cluster
     pdb:
       enabled: false
+      # -- Cannot be set together with minAvailable
       maxUnavailable: 1
-      minAvailable: 1
+      # -- Cannot be set together with maxUnavailable; uncomment to use instead
+      # minAvailable: 1
     livenessProbe: {}
       # timeoutSeconds: 30
       # periodSeconds: 45
@@ -124,8 +126,10 @@ redisCluster:
       #       clusterId: redis-cluster
     pdb:
       enabled: false
+      # -- Cannot be set together with minAvailable
       maxUnavailable: 1
-      minAvailable: 1
+      # -- Cannot be set together with maxUnavailable; uncomment to use instead
+      # minAvailable: 1
     livenessProbe: {}
       # timeoutSeconds: 30
       # periodSeconds: 45


### PR DESCRIPTION
Fixes #1745 (https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1745)

## Problem

When PDB is enabled in the redis-cluster Helm chart, the `redis.role` helper in `_helpers.tpl` unconditionally rendered both `maxUnavailable` and `minAvailable` fields. Kubernetes rejects this with:

  "PodDisruptionBudget is invalid: spec: Invalid value: minAvailable and maxUnavailable cannot be both set"

This caused operator reconciliation to fail and follower StatefulSets to never be created.

## Changes

- `_helpers.tpl`: wrap each PDB field in a conditional so only the field that is actually set gets rendered
- `values.yaml`: remove the default `minAvailable: 1` from both leader and follower sections, leaving `maxUnavailable: 1` as the single default

## Test plan

- [ ] Enable PDB with only `maxUnavailable` set — only that field appears in rendered output
- [ ] Enable PDB with only `minAvailable` set — only that field appears in rendered output
- [ ] `helm template` produces a PDB spec that Kubernetes accepts without error
