### PR TITLE
fix(redis): set dial/read/write timeouts on the service Redis client

### DIFF
--- a/internal/service/redis/client.go
+++ b/internal/service/redis/client.go
@@ -6,12 +6,17 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	rediscli "github.com/redis/go-redis/v9"
 )
 
 const (
 	redisRoleMaster = "role:master"
+	// defaultRedisClientTimeout bounds dial/read/write operations so an
+	// unreachable pod cannot stall a reconcile worker. It mirrors the
+	// defaultRedisClientTimeout used by the k8sutils exec-based path.
+	defaultRedisClientTimeout = 5 * time.Second
 )
 
 type ConnectionInfo struct {
@@ -85,9 +90,12 @@ func (s *service) createClient() *rediscli.Client {
 		return nil
 	}
 	opts := &rediscli.Options{
-		Addr:     s.connectionInfo.GetAddress(),
-		Password: s.connectionInfo.Password,
-		DB:       0,
+		Addr:         s.connectionInfo.GetAddress(),
+		Password:     s.connectionInfo.Password,
+		DB:           0,
+		DialTimeout:  defaultRedisClientTimeout,
+		ReadTimeout:  defaultRedisClientTimeout,
+		WriteTimeout: defaultRedisClientTimeout,
 	}
 	if s.connectionInfo.TLSConfig != nil {
 		opts.TLSConfig = s.connectionInfo.TLSConfig

--- a/internal/service/redis/client_test.go
+++ b/internal/service/redis/client_test.go
@@ -1,0 +1,61 @@
+package redis
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateClientSetsTimeouts(t *testing.T) {
+	s := &service{connectionInfo: &ConnectionInfo{Host: "127.0.0.1", Port: "6379"}}
+
+	cl := s.createClient()
+	require.NotNil(t, cl)
+	defer cl.Close()
+
+	opts := cl.Options()
+	assert.Equal(t, defaultRedisClientTimeout, opts.DialTimeout)
+	assert.Equal(t, defaultRedisClientTimeout, opts.ReadTimeout)
+	assert.Equal(t, defaultRedisClientTimeout, opts.WriteTimeout)
+}
+
+// TestCreateClientUnresponsiveServerReturns verifies that a Redis server that
+// accepts the connection but never answers does not stall the caller: the
+// read timeout must turn the PING into an error instead of blocking forever.
+func TestCreateClientUnresponsiveServerReturns(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		for {
+			_, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without ever responding.
+		}
+	}()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	s := &service{connectionInfo: &ConnectionInfo{Host: host, Port: portStr}}
+	cl := s.createClient()
+	require.NotNil(t, cl)
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = cl.Ping(ctx).Err()
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "PING against an unresponsive server must fail, not hang")
+	assert.Less(t, elapsed, 10*time.Second, "read timeout should bound the wait (~5s), far below the 30s ctx budget")
+}


### PR DESCRIPTION
The go-redis client created by `service.createClient()` (`internal/service/redis/client.go`) sets no `DialTimeout`/`ReadTimeout`/`WriteTimeout`. go-redis v9 defaults to no timeout, so when a Redis pod is unreachable in a way that blackholes packets (stuck pod, NetworkPolicy, dropped conntrack), calls like `IsMaster` (invoked per pod per reconcile from `common/redis/heal.go` and `check.go`) block indefinitely and the reconcile worker holds its concurrency slot until the blackhole clears. Enough such reconciles exhaust `MAX_CONCURRENT_RECONCILES` and the operator stops making progress.

The exec/go-redis path in k8sutils already solved this exact problem with `defaultRedisClientTimeout = 5s` (`internal/k8sutils/redis.go:840-842`, applied in `configureRedisClient`). This change mirrors it on the `internal/service/redis` path.

Fixes #1892

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Tests added in `internal/service/redis/client_test.go`:

1. `TestCreateClientSetsTimeouts` — asserts the three timeout options are set (via `client.Options()`).
2. `TestCreateClientUnresponsiveServerReturns` — regression test against a local TCP listener that accepts but never responds: `PING` must return an error within the read timeout (~5s) instead of hanging. Before the fix this call blocks until the 30s test context expires; after the fix it returns in ~5s.

The timeout value (5s) intentionally matches `k8sutils.defaultRedisClientTimeout` so both connection paths behave identically. No configuration knob was added to keep the change minimal; if maintainers prefer this to be configurable (like `execCommandTimeout` in #1810), happy to follow that pattern instead.
