### PR TITLE
fix(k8sutils): avoid infinite loop in ExecuteRedisReplicationCommand

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -326,7 +326,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			if followerReplicas > 0 {
 				logger.Info("All leader are part of the cluster, adding follower/replicas", "Leaders.Count", leaderCount, "Instance.Size", leaderReplicas, "Follower.Replicas", followerReplicas)
-				k8sutils.ExecuteRedisReplicationCommand(ctx, r.K8sClient, instance)
+				if err := k8sutils.ExecuteRedisReplicationCommand(ctx, r.K8sClient, instance); err != nil {
+					return ctrl.Result{}, err
+				}
 			} else {
 				logger.Info("no follower/replicas configured, skipping replication configuration", "Leaders.Count", leaderCount, "Leader.Size", leaderReplicas, "Follower.Replicas", followerReplicas)
 			}

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -116,10 +116,12 @@ func getEndpoint(ctx context.Context, client kubernetes.Interface, cr *rcvb2.Red
 	return host + ":" + strconv.Itoa(port)
 }
 
-// podExecFunc matches executeCommand's signature; it is injected into
-// executeSingleLeaderAddSlots so the command assembly and batching logic
-// can be unit tested without a live pod exec.
-type podExecFunc func(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string)
+// podExecFunc matches executeCommandE's signature; it is injected into
+// executeSingleLeaderAddSlots and executeRedisReplicationCommand so the
+// command assembly and batching logic can be unit tested without a live pod
+// exec. It returns the exec error so callers that reconcile with retries can
+// propagate failures instead of only logging them.
+type podExecFunc func(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) error
 
 // checkRedisCLIAuthInEnv returns true if we can use the pod's REDISCLI_AUTH variable instead of sending redis-cli -a <password>.
 // It checks only variables specified via env[].valueFrom since this is what the operator sets; it does not look at envFrom.
@@ -208,7 +210,7 @@ func executeSingleLeaderAddSlots(ctx context.Context, client kubernetes.Interfac
 		cmd = append(cmd, flags...)
 		cmd = append(cmd, "CLUSTER", "ADDSLOTSRANGE", "0", "16383")
 		logger.V(1).Info("Executing CLUSTER ADDSLOTSRANGE 0 16383")
-		execute(ctx, client, cr, cmd, podName)
+		_ = execute(ctx, client, cr, cmd, podName)
 		return
 	}
 
@@ -227,7 +229,7 @@ func executeSingleLeaderAddSlots(ctx context.Context, client kubernetes.Interfac
 		}
 		logger.V(1).Info("Executing CLUSTER ADDSLOTS batch",
 			"SlotsRange", fmt.Sprintf("%d-%d", start, end-1))
-		execute(ctx, client, cr, cmd, podName)
+		_ = execute(ctx, client, cr, cmd, podName)
 	}
 }
 
@@ -427,7 +429,7 @@ func ExecuteRedisClusterCommand(ctx context.Context, client kubernetes.Interface
 		if err != nil {
 			log.FromContext(ctx).Error(err, "error executing failover command")
 		}
-		executeSingleLeaderAddSlots(ctx, client, cr, executeCommand)
+		executeSingleLeaderAddSlots(ctx, client, cr, executeCommandE)
 	default:
 		cmd := CreateMultipleLeaderRedisCommand(ctx, client, cr)
 		authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, cr.Name+"-leader-0")
@@ -469,67 +471,79 @@ func getRedisTLSArgs(tlsConfig *commonapi.TLSConfig, clientHost string) []string
 }
 
 // createRedisReplicationCommand will create redis replication creation command
-func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, leaderPod RedisDetails, followerPod RedisDetails) []string {
+func createRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, leaderPod RedisDetails, followerPod RedisDetails) ([]string, error) {
 	cmd := []string{"redis-cli", "--cluster", "add-node"}
 	cmd = append(cmd, getEndpoint(ctx, client, cr, followerPod))
 	cmd = append(cmd, getEndpoint(ctx, client, cr, leaderPod))
 	cmd = append(cmd, "--cluster-slave")
 	authArgs, err := getRedisClusterAuthArgs(ctx, client, cr, leaderPod.PodName)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Failed to get password authentication arguments")
+		// Bail out instead of emitting an unauthenticated add-node command
+		// that is guaranteed to fail with NOAUTH.
+		return nil, fmt.Errorf("failed to get password authentication arguments: %w", err)
 	}
 	cmd = append(cmd, authArgs...)
 	cmd = append(cmd, getRedisTLSArgs(cr.Spec.TLS, leaderPod.PodName)...)
-	return cmd
+	return cmd, nil
 }
 
-// ExecuteRedisReplicationCommand will execute the replication command
-func ExecuteRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) {
-	var podIP string
+// ExecuteRedisReplicationCommand will execute the replication command that
+// joins every follower to the cluster as a replica of a leader. It returns an
+// error so the caller can rely on the reconcile retry/backoff instead of
+// retrying inside this function.
+func ExecuteRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) error {
+	return executeRedisReplicationCommand(ctx, client, cr, executeCommandE)
+}
+
+// executeRedisReplicationCommand walks every follower once, round-robin
+// pairing follower i with leader i%leaderCounts. The loop condition is the
+// only place followerIdx advances, so no failure path can stall progress: an
+// unreachable follower or a failed add-node exec surfaces as an error and the
+// caller retries with reconcile backoff.
+func executeRedisReplicationCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, executeCmd podExecFunc) error {
 	followerCounts := cr.Spec.GetReplicaCounts("follower")
 	leaderCounts := cr.Spec.GetReplicaCounts("leader")
-	followerPerLeader := followerCounts / leaderCounts
 
 	redisClient := configureRedisClient(ctx, client, cr, cr.Name+"-leader-0")
 	defer redisClient.Close()
 
 	nodes, err := clusterNodes(ctx, redisClient)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to get cluster nodes")
+		return fmt.Errorf("failed to get cluster nodes: %w", err)
 	}
-	for followerIdx := 0; followerIdx <= int(followerCounts)-1; {
-		for i := 0; i < int(followerPerLeader) && followerIdx <= int(followerCounts)-1; i++ {
-			followerPod := RedisDetails{
-				PodName:   cr.Name + "-follower-" + strconv.Itoa(followerIdx),
-				Namespace: cr.Namespace,
-			}
-			leaderPod := RedisDetails{
-				PodName:   cr.Name + "-leader-" + strconv.Itoa((followerIdx)%int(leaderCounts)),
-				Namespace: cr.Namespace,
-			}
-			podIP = getRedisServerIP(ctx, client, followerPod)
-			if !checkRedisNodePresence(ctx, nodes, podIP) {
-				log.FromContext(ctx).V(1).Info("Adding node to cluster.", "Node.IP", podIP, "Follower.Pod", followerPod)
-				cmd := createRedisReplicationCommand(ctx, client, cr, leaderPod, followerPod)
-				redisClient := configureRedisClient(ctx, client, cr, followerPod.PodName)
-				pong, err := redisClient.Ping(ctx).Result()
-				redisClient.Close()
-				if err != nil {
-					log.FromContext(ctx).Error(err, "Failed to ping Redis server", "Follower.Pod", followerPod)
-					continue
-				}
-				if pong == "PONG" {
-					executeCommand(ctx, client, cr, cmd, cr.Name+"-leader-0")
-				} else {
-					log.FromContext(ctx).V(1).Info("Skipping execution of command due to failed Redis ping", "Follower.Pod", followerPod)
-				}
-			} else {
-				log.FromContext(ctx).V(1).Info("Skipping Adding node to cluster, already present.", "Follower.Pod", followerPod)
-			}
-
-			followerIdx++
+	for followerIdx := 0; followerIdx < int(followerCounts); followerIdx++ {
+		followerPod := RedisDetails{
+			PodName:   cr.Name + "-follower-" + strconv.Itoa(followerIdx),
+			Namespace: cr.Namespace,
+		}
+		leaderPod := RedisDetails{
+			PodName:   cr.Name + "-leader-" + strconv.Itoa((followerIdx)%int(leaderCounts)),
+			Namespace: cr.Namespace,
+		}
+		podIP := getRedisServerIP(ctx, client, followerPod)
+		if checkRedisNodePresence(ctx, nodes, podIP) {
+			log.FromContext(ctx).V(1).Info("Skipping Adding node to cluster, already present.", "Node.IP", podIP, "Follower.Pod", followerPod)
+			continue
+		}
+		cmd, err := createRedisReplicationCommand(ctx, client, cr, leaderPod, followerPod)
+		if err != nil {
+			return fmt.Errorf("failed to build add-node command for follower %s: %w", followerPod.PodName, err)
+		}
+		followerClient := configureRedisClient(ctx, client, cr, followerPod.PodName)
+		pong, err := followerClient.Ping(ctx).Result()
+		followerClient.Close()
+		if err != nil {
+			return fmt.Errorf("failed to ping follower %s: %w", followerPod.PodName, err)
+		}
+		if pong != "PONG" {
+			log.FromContext(ctx).V(1).Info("Skipping execution of command due to failed Redis ping", "Follower.Pod", followerPod)
+			continue
+		}
+		if err := executeCmd(ctx, client, cr, cmd, cr.Name+"-leader-0"); err != nil {
+			return fmt.Errorf("failed to add follower %s to the cluster: %w", followerPod.PodName, err)
 		}
 	}
+	return nil
 }
 
 type clusterNodesResponse []string
@@ -822,14 +836,23 @@ func configureRedisStandaloneClient(ctx context.Context, client kubernetes.Inter
 	return redis.NewClient(opts)
 }
 
-// executeCommand will execute the commands in pod
+// executeCommand will execute the commands in pod, logging any failure.
 func executeCommand(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) {
+	_ = executeCommandE(ctx, client, cr, cmd, podName)
+}
+
+// executeCommandE executes a command in a pod and returns the error instead of
+// swallowing it, so callers that reconcile with retries (e.g.
+// executeRedisReplicationCommand) can propagate failures. The error is also
+// logged with the command and output for operator context.
+func executeCommandE(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster, cmd []string, podName string) error {
 	execOut, execErr := executeCommand1(ctx, client, cr, cmd, podName)
 	if execErr != nil {
 		log.FromContext(ctx).Error(execErr, "Could not execute command", "Command", cmd, "Output", execOut)
-		return
+		return execErr
 	}
 	log.FromContext(ctx).V(1).Info("Successfully executed the command", "Command", cmd, "Output", execOut)
+	return nil
 }
 
 // defaultExecCommandTimeout bounds a single exec stream against a redis pod. It is generous
@@ -866,6 +889,9 @@ func executeCommand1(ctx context.Context, client kubernetes.Interface, cr *rcvb2
 	}
 	targetContainer, pod := getContainerID(ctx, client, cr, podName)
 	if targetContainer < 0 {
+		// getContainerID logs the underlying cause; surface a real error so a
+		// missing pod cannot be mistaken for a successful exec.
+		err = fmt.Errorf("could not find pod %s/%s or its leader container", cr.Namespace, podName)
 		log.FromContext(ctx).Error(err, "Could not find pod to execute")
 		return "", err
 	}

--- a/internal/k8sutils/redis_replication_test.go
+++ b/internal/k8sutils/redis_replication_test.go
@@ -1,0 +1,382 @@
+package k8sutils
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+// fakeRedisServer speaks enough RESP for go-redis v9 (RESP3 handshake
+// included): HELLO, PING and CLUSTER NODES. Everything else is rejected, so a
+// test that expects no other traffic will notice.
+type fakeRedisServer struct {
+	ln           net.Listener
+	port         int
+	nodesPayload string
+	pongReply    string
+
+	mu    sync.Mutex
+	pings int
+}
+
+func newFakeRedisServer(t *testing.T, nodesPayload string) *fakeRedisServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start fake redis server: %v", err)
+	}
+	s := &fakeRedisServer{ln: ln, port: ln.Addr().(*net.TCPAddr).Port, nodesPayload: nodesPayload, pongReply: "+PONG\r\n"}
+	go s.serve()
+	t.Cleanup(func() { ln.Close() })
+	return s
+}
+
+func (s *fakeRedisServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeRedisServer) handle(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	for {
+		args, err := readRESPArray(r)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			continue
+		}
+		switch cmd := strings.ToUpper(args[0]); {
+		case cmd == "HELLO":
+			// Minimal RESP3 map reply; the handshake only needs valid framing.
+			fmt.Fprint(conn, "%2\r\n$6\r\nserver\r\n$5\r\nredis\r\n$5\r\nproto\r\n:3\r\n")
+		case cmd == "PING":
+			s.mu.Lock()
+			s.pings++
+			s.mu.Unlock()
+			fmt.Fprint(conn, s.pongReply)
+		case cmd == "CLUSTER" && len(args) > 1 && strings.ToUpper(args[1]) == "NODES":
+			fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(s.nodesPayload), s.nodesPayload)
+		default:
+			fmt.Fprint(conn, "-ERR unsupported command\r\n")
+		}
+	}
+}
+
+func (s *fakeRedisServer) pingCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pings
+}
+
+func readRESPArray(r *bufio.Reader) ([]string, error) {
+	header, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	header = strings.TrimRight(header, "\r\n")
+	if !strings.HasPrefix(header, "*") {
+		return nil, fmt.Errorf("unexpected line %q", header)
+	}
+	n, err := strconv.Atoi(header[1:])
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		lenLine, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		lenLine = strings.TrimRight(lenLine, "\r\n")
+		if !strings.HasPrefix(lenLine, "$") {
+			return nil, fmt.Errorf("expected bulk string, got %q", lenLine)
+		}
+		bl, err := strconv.Atoi(lenLine[1:])
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, bl+2) // payload + CRLF
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:bl]))
+	}
+	return args, nil
+}
+
+// replicationCR builds a RedisCluster with independent leader/follower counts.
+func replicationCR(name string, leaders, followers, port int) *rcvb2.RedisCluster {
+	cr := &rcvb2.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: rcvb2.RedisClusterSpec{
+			Port:           ptr.To(port),
+			ClusterVersion: ptr.To("v7"),
+		},
+	}
+	cr.Spec.RedisLeader.Replicas = ptr.To(int32(leaders))
+	cr.Spec.RedisFollower.Replicas = ptr.To(int32(followers))
+	return cr
+}
+
+// replicationPods creates leader/follower pods. Unset IP funcs default to
+// 127.0.0.1, where the fake redis server listens; 127.0.0.2 listens on
+// nothing and fails every dial immediately with ECONNREFUSED.
+func replicationPods(name string, leaders, followers int, leaderIP, followerIP func(i int) string) []runtime.Object {
+	defaultIP := func(int) string { return "127.0.0.1" }
+	if leaderIP == nil {
+		leaderIP = defaultIP
+	}
+	if followerIP == nil {
+		followerIP = defaultIP
+	}
+	pods := []runtime.Object{}
+	for i := 0; i < leaders; i++ {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-leader-%d", name, i), Namespace: "default"},
+			Status:     corev1.PodStatus{PodIP: leaderIP(i)},
+		})
+	}
+	for i := 0; i < followers; i++ {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-follower-%d", name, i), Namespace: "default"},
+			Status:     corev1.PodStatus{PodIP: followerIP(i)},
+		})
+	}
+	return pods
+}
+
+func TestExecuteRedisReplicationCommand(t *testing.T) {
+	const name = "redis-cluster"
+
+	t.Run("adds every follower round-robin when none are in the cluster", func(t *testing.T) {
+		// Leader lines use 127.0.0.9 so follower IPs (127.0.0.1) never match.
+		server := newFakeRedisServer(t, "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 2, 3, nil, nil)...)
+
+		var execCmds [][]string
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 2, 3, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, cmd []string, _ string) error {
+				execCmds = append(execCmds, cmd)
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if len(execCmds) != 3 {
+			t.Fatalf("expected 3 add-node executions, got %d", len(execCmds))
+		}
+		for i, cmd := range execCmds {
+			joined := strings.Join(cmd, " ")
+			wantLeader := fmt.Sprintf("%s-leader-%d", name, i%2)
+			if !strings.Contains(joined, fmt.Sprintf("%s-follower-%d", name, i)) ||
+				!strings.Contains(joined, wantLeader) {
+				t.Errorf("execution %d: expected follower-%d paired with %s, got %q", i, i, wantLeader, joined)
+			}
+		}
+		if server.pingCount() != 3 {
+			t.Errorf("expected 3 pings (one per follower), got %d", server.pingCount())
+		}
+	})
+
+	t.Run("returns without exec when no followers are configured", func(t *testing.T) {
+		server := newFakeRedisServer(t, "")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 2, 0, nil, nil)...)
+
+		execCount := 0
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 2, 0, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, _ []string, _ string) error {
+				execCount++
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if execCount != 0 {
+			t.Errorf("expected no executions with followers=0, got %d", execCount)
+		}
+	})
+
+	t.Run("handles fewer followers than leaders", func(t *testing.T) {
+		// followers(1) < leaders(3) used to spin forever: followerPerLeader
+		// truncated to 0 and followerIdx never advanced.
+		server := newFakeRedisServer(t, "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 3, 1, nil, nil)...)
+
+		var execCmds [][]string
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 3, 1, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, cmd []string, _ string) error {
+				execCmds = append(execCmds, cmd)
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if len(execCmds) != 1 {
+			t.Fatalf("expected 1 add-node execution, got %d", len(execCmds))
+		}
+		joined := strings.Join(execCmds[0], " ")
+		if !strings.Contains(joined, name+"-follower-0") || !strings.Contains(joined, name+"-leader-0") {
+			t.Errorf("expected follower-0 paired with leader-0, got %q", joined)
+		}
+	})
+
+	t.Run("skips followers that are already part of the cluster", func(t *testing.T) {
+		// follower-0 (127.0.0.10) is listed in CLUSTER NODES, follower-1 is not.
+		payload := "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n" +
+			"id1 127.0.0.10:6379@16379 slave id0 0 0 2 connected\n"
+		server := newFakeRedisServer(t, payload)
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 1, 2,
+			nil,
+			func(i int) string {
+				if i == 0 {
+					return "127.0.0.10"
+				}
+				return "127.0.0.1"
+			})...)
+
+		var execCmds [][]string
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 1, 2, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, cmd []string, _ string) error {
+				execCmds = append(execCmds, cmd)
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if len(execCmds) != 1 {
+			t.Fatalf("expected only the missing follower to be added, got %d executions", len(execCmds))
+		}
+		if !strings.Contains(strings.Join(execCmds[0], " "), name+"-follower-1") {
+			t.Errorf("expected the execution to target follower-1, got %q", strings.Join(execCmds[0], " "))
+		}
+		if server.pingCount() != 1 {
+			t.Errorf("expected 1 ping (present followers are skipped before ping), got %d", server.pingCount())
+		}
+	})
+
+	t.Run("fails fast when a follower is unreachable", func(t *testing.T) {
+		// follower-0 dials 127.0.0.2 where nothing listens; follower-1 would be
+		// reachable but must never be attempted after the failure.
+		server := newFakeRedisServer(t, "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 3, 2,
+			nil,
+			func(i int) string {
+				if i == 0 {
+					return "127.0.0.2"
+				}
+				return "127.0.0.1"
+			})...)
+
+		execCount := 0
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 3, 2, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, _ []string, _ string) error {
+				execCount++
+				return nil
+			})
+
+		if err == nil {
+			t.Fatal("expected an error for the unreachable follower, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to ping follower "+name+"-follower-0") {
+			t.Errorf("error should name the unreachable follower, got %v", err)
+		}
+		if execCount != 0 {
+			t.Errorf("fail-fast must not attempt followers after the failure, got %d executions", execCount)
+		}
+	})
+
+	t.Run("surfaces a failed CLUSTER NODES lookup", func(t *testing.T) {
+		// leader-0 dials 127.0.0.2 where nothing listens.
+		server := newFakeRedisServer(t, "")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 1, 1,
+			func(int) string { return "127.0.0.2" }, nil)...)
+
+		execCount := 0
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 1, 1, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, _ []string, _ string) error {
+				execCount++
+				return nil
+			})
+
+		if err == nil {
+			t.Fatal("expected an error for the failed cluster nodes lookup, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to get cluster nodes") {
+			t.Errorf("error should mention the cluster nodes lookup, got %v", err)
+		}
+		if execCount != 0 {
+			t.Errorf("no add-node may run without cluster nodes, got %d executions", execCount)
+		}
+	})
+
+	t.Run("propagates a failed add-node exec", func(t *testing.T) {
+		server := newFakeRedisServer(t, "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n")
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 1, 1, nil, nil)...)
+
+		execCount := 0
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 1, 1, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, _ []string, _ string) error {
+				execCount++
+				return errors.New("exec failed")
+			})
+
+		if err == nil {
+			t.Fatal("expected the add-node exec failure to surface, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to add follower "+name+"-follower-0") {
+			t.Errorf("error should name the follower being added, got %v", err)
+		}
+		if execCount != 1 {
+			t.Errorf("expected exactly one exec attempt, got %d", execCount)
+		}
+	})
+
+	t.Run("skips execution when the ping reply is unexpected", func(t *testing.T) {
+		server := newFakeRedisServer(t, "id0 127.0.0.9:6379@16379 master - 0 0 1 connected 0-16383\n")
+		server.pongReply = "+OK\r\n"
+		client := k8sClientFake.NewSimpleClientset(replicationPods(name, 1, 1, nil, nil)...)
+
+		execCount := 0
+		err := executeRedisReplicationCommand(context.Background(), client,
+			replicationCR(name, 1, 1, server.port),
+			func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, _ []string, _ string) error {
+				execCount++
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if execCount != 0 {
+			t.Errorf("add-node must not run when ping does not answer PONG, got %d executions", execCount)
+		}
+	})
+}

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -523,8 +523,9 @@ func TestExecuteSingleLeaderAddSlots(t *testing.T) {
 			client := k8sClientFake.NewSimpleClientset(objects...)
 
 			var execs []recordedExec
-			executeSingleLeaderAddSlots(context.TODO(), client, tt.redisCluster, func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, cmd []string, podName string) {
+			executeSingleLeaderAddSlots(context.TODO(), client, tt.redisCluster, func(_ context.Context, _ kubernetes.Interface, _ *rcvb2.RedisCluster, cmd []string, podName string) error {
 				execs = append(execs, recordedExec{cmd: cmd, podName: podName})
+				return nil
 			})
 
 			expectedPrefix := append([]string{"redis-cli"}, tt.expectedFlags...)
@@ -740,6 +741,7 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 		leaderPod       RedisDetails
 		followerPod     RedisDetails
 		expectedCommand []string
+		wantAuthErr     bool
 	}{
 		{
 			name: "Test case with cluster version v7",
@@ -813,12 +815,9 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 				PodName:   "redis-cluster-follower-0",
 				Namespace: "default",
 			},
-			expectedCommand: []string{
-				"redis-cli", "--cluster", "add-node",
-				"redis-cluster-follower-0.redis-cluster-follower-headless.default.svc.cluster.local:6379",
-				"redis-cluster-leader-0.redis-cluster-leader-headless.default.svc.cluster.local:6379",
-				"--cluster-slave",
-			},
+			// getRedisClusterAuthArgs must fail the caller instead of building
+			// an add-node command without authentication.
+			wantAuthErr: true,
 		},
 		{
 			name: "Test case without cluster version v7",
@@ -894,9 +893,17 @@ func TestCreateRedisReplicationCommand(t *testing.T) {
 			objects = append(objects, secret...)
 
 			client := k8sClientFake.NewSimpleClientset(objects...)
-			cmd := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod)
+			cmd, err := createRedisReplicationCommand(context.TODO(), client, tt.redisCluster, tt.leaderPod, tt.followerPod)
 
+			if tt.wantAuthErr {
+				// A failure to resolve the password must abort command
+				// assembly instead of emitting an unauthenticated add-node.
+				assert.Error(t, err)
+				assert.Nil(t, cmd)
+				return
+			}
 			// Assert the command is as expected using testify
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedCommand, cmd)
 		})
 	}


### PR DESCRIPTION
`ExecuteRedisReplicationCommand` (RedisCluster reconcile, follower-adding branch) can spin forever in two ways:

1. **followers < leaders**: `followerPerLeader := followerCounts / leaderCounts` truncates to `0`, the inner loop never runs, and the outer loop (no post statement) spins forever — the reconcile worker blocks permanently, and a few such CRs exhaust `MAX_CONCURRENT_RECONCILES`.
2. **Unreachable follower**: a failed `Ping` executes `continue`, skipping the `followerIdx++` inside the inner loop body — the same pod is retried indefinitely within a single reconcile.

Fixes #1894

**What changed**

- Flatten the nested loop into a single loop over `followerIdx`; the loop head is the only place the index advances, so no failure path can stall progress.
- Drop `followerPerLeader`: leader pairing is round-robin (`followerIdx % leaderCounts`), so the value never carried meaning beyond an inner batch size — and a batch size of 0 was fatal.
- Return an error on ping / cluster-nodes failures instead of logging and spinning; the caller now propagates it so controller-runtime owns retries with backoff (matching the surrounding `ClusterHasEmptyMasters` error handling and `ExecuteFailoverOperation`'s error-returning signature).
- Keep the exported call site simple: `ExecuteRedisReplicationCommand` delegates to an injectable core, following the existing `podExecFunc` pattern used by `executeSingleLeaderAddSlots`.

**Tests**

`internal/k8sutils/redis_replication_test.go` (new) drives the function against a minimal RESP fake (HELLO / PING / CLUSTER NODES, RESP3 handshake included) with a fake clientset and a recorded exec func:

1. all followers added round-robin (2 leaders / 3 followers, pairing asserted per execution)
2. followers=0 → no-op
3. followers < leaders (1/3) — the case that used to hang forever
4. followers already present in `CLUSTER NODES` are skipped before ping
5. unreachable follower → error naming the pod, no later followers attempted
6. failed `CLUSTER NODES` lookup → error, nothing executed
7. non-PONG ping reply → skip execution, no error

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [x] Documentation has been updated or added where necessary.

**Additional Context**

Verified the original hang empirically before the fix (watchdog + goroutine stack dumps showed the worker spinning at the outer loop condition / ping retry), and the same probes return instantly after the fix. `ExecuteRedisReplicationCommand` previously returned nothing, so the reconcile could not observe failures; the signature change is what lets the operator retry with backoff instead of blocking a worker.

Happy to adjust the error granularity (e.g. collect all failures with `errors.Join`) or anything else maintainers prefer.
