### PR TITLE
fix(config): use lowercase appendfilename to match Redis default

### DIFF
--- a/internal/agent/bootstrap/redis/config.go
+++ b/internal/agent/bootstrap/redis/config.go
@@ -162,8 +162,8 @@ func GenerateConfig() error {
 		cfg.Append("save", "900 1")
 		cfg.Append("save", "300 10")
 		cfg.Append("save", "60 10000")
-		cfg.Append("Appendonly", "yes")
-		cfg.Append("Appendfilename", "\"Appendonly.aof\"")
+		cfg.Append("appendonly", "yes")
+		cfg.Append("appendfilename", "\"appendonly.aof\"")
 		cfg.Append("dir", dataDir)
 	} else {
 		fmt.Println("Running without persistence mode")

--- a/internal/agent/bootstrap/redis/config_test.go
+++ b/internal/agent/bootstrap/redis/config_test.go
@@ -69,6 +69,27 @@ func Test_GenerateConfig_TLS_CACertFile(t *testing.T) {
 	}
 }
 
+func Test_GenerateConfig_AppendOnlyFilename_MatchesRedisDefault(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "redis.conf")
+
+	t.Setenv("REDIS_CONFIG_FILE", confPath)
+	t.Setenv("PERSISTENCE_ENABLED", "true")
+	t.Setenv("SETUP_MODE", "standalone")
+	t.Setenv("TLS_MODE", "false")
+
+	require.NoError(t, GenerateConfig())
+
+	raw, err := os.ReadFile(confPath)
+	require.NoError(t, err)
+	conf := string(raw)
+
+	// The generated appendfilename must match Redis' own lowercase default
+	// ("appendonly.aof"). Diverging from it (e.g. "Appendonly.aof") makes
+	// Redis look for a file that doesn't exist on disk, silently losing all
+	// previously persisted data on startup.
+	assert.Contains(t, conf, `appendfilename "appendonly.aof"`)
+}
+
 func Test_GenerateConfig_ReplicaAnnounceIP(t *testing.T) {
 	const fakeFQDN = "redis-replication-0.redis-replication-headless.ns.svc.cluster.local"
 


### PR DESCRIPTION
**Description**

Enabling the `GenerateConfigInInitContainer` feature gate on an existing Redis deployment causes total data loss. The init-container config generator (`internal/agent/bootstrap/redis/config.go`) wrote `Appendfilename "Appendonly.aof"` (mixed case) when persistence is enabled, while Redis's own built-in default AOF filename is lowercase `appendonly.aof`. On a case-sensitive filesystem, Redis then looks for a file that doesn't exist and re-initializes with an empty dataset instead of loading the pre-existing AOF file.

This change makes the generator write `appendonly`/`appendfilename "appendonly.aof"` in lowercase, matching Redis's own default and every other directive already written lowercase by this function.

Note: this only affects config written by *future* runs of this code path (i.e. it prevents the bug when the feature gate is newly enabled going forward). It does not rename an `Appendonly.aof` file that a prior run may have already created on disk for deployments that already hit this bug — those still need a manual rename/migration, as the issue itself notes.

Fixes #1746

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Added `Test_GenerateConfig_AppendOnlyFilename_MatchesRedisDefault` in `internal/agent/bootstrap/redis/config_test.go`, which enables `PERSISTENCE_ENABLED` and asserts the generated `redis.conf` contains `appendfilename "appendonly.aof"`. Verified (via a temporary local revert of the fix) that this test fails against the old mixed-case value and passes after the fix.

Ran locally:
- `go build ./...`
- `go test ./internal/agent/...`
- `golangci-lint run ./internal/agent/...`

All pass. Did not run the repo's `chainsaw` e2e suite (requires a live kind cluster); the defect and fix are fully demonstrated by the targeted unit test above, which reproduces the exact string written to `redis.conf`.

As mentioned in the issue, it may also be worth documenting this filename gotcha in migration notes for users upgrading existing deployments, since this fix alone can't recover data that was already lost or rename files that already exist on disk under the old (wrong) name.