### PR TITLE
fix(cluster): re-apply dynamicConfig on every reconcile once Ready

### DIFF
--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -412,11 +412,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		monitoring.RedisClusterHealthy.WithLabelValues(instance.Namespace, instance.Name).Set(0)
 		if k8sutils.RedisClusterStatusHealth(ctx, r.K8sClient, instance) {
 			monitoring.RedisClusterHealthy.WithLabelValues(instance.Namespace, instance.Name).Set(1)
-			// Apply dynamic config to all Redis instances in the cluster
-			if err = k8sutils.SetRedisClusterDynamicConfig(ctx, r.K8sClient, instance); err != nil {
-				logger.Error(err, "Failed to set dynamic config")
-				return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
-			}
 
 			requeue, err := r.updateStatus(ctx, instance, rcvb2.RedisClusterStatus{
 				State:                 rcvb2.RedisClusterReady,
@@ -430,6 +425,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			if requeue {
 				return intctrlutil.Requeue()
 			}
+		}
+	}
+
+	// Apply dynamic config to all Redis instances in the cluster on every reconcile
+	// once the cluster is ready, so that changes to spec.redisConfig.dynamicConfig
+	// made after the initial bootstrap are picked up instead of only being applied
+	// once during the transition into the Ready state.
+	if instance.Status.State == rcvb2.RedisClusterReady {
+		if err = k8sutils.SetRedisClusterDynamicConfig(ctx, r.K8sClient, instance); err != nil {
+			logger.Error(err, "Failed to set dynamic config")
+			return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
 		}
 	}
 

--- a/internal/controller/rediscluster/rediscluster_controller.go
+++ b/internal/controller/rediscluster/rediscluster_controller.go
@@ -413,6 +413,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if k8sutils.RedisClusterStatusHealth(ctx, r.K8sClient, instance) {
 			monitoring.RedisClusterHealthy.WithLabelValues(instance.Namespace, instance.Name).Set(1)
 
+			// Apply dynamic config before persisting the Ready status, so that a
+			// failing CONFIG SET (e.g. an invalid setting) prevents the cluster
+			// from being reported Ready with an unapplied configuration.
+			if err = k8sutils.SetRedisClusterDynamicConfig(ctx, r.K8sClient, instance); err != nil {
+				logger.Error(err, "Failed to set dynamic config")
+				return intctrlutil.RequeueE(ctx, err, "failed to set dynamic config")
+			}
+
 			requeue, err := r.updateStatus(ctx, instance, rcvb2.RedisClusterStatus{
 				State:                 rcvb2.RedisClusterReady,
 				Reason:                rcvb2.ReadyClusterReason,

--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -1199,6 +1199,12 @@ func applyDynamicConfig(ctx context.Context, redisClient *redis.Client, podName 
 
 // SetRedisClusterDynamicConfig applies dynamic configuration to each Redis instance in the cluster
 func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interface, cr *rcvb2.RedisCluster) error {
+	return setRedisClusterDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+		return configureRedisClient(ctx, client, cr, podName)
+	})
+}
+
+func setRedisClusterDynamicConfig(ctx context.Context, cr *rcvb2.RedisCluster, makeClient func(podName string) *redis.Client) error {
 	// Get dynamic configuration
 	dynamicConfig := cr.Spec.GetRedisDynamicConfig()
 	if len(dynamicConfig) == 0 {
@@ -1218,7 +1224,7 @@ func SetRedisClusterDynamicConfig(ctx context.Context, client kubernetes.Interfa
 			podName = cr.Name + "-follower-" + strconv.Itoa(i-int(leaderReplicas))
 		}
 
-		redisClient := configureRedisClient(ctx, client, cr, podName)
+		redisClient := makeClient(podName)
 		_, err := applyDynamicConfig(ctx, redisClient, podName, dynamicConfig)
 		redisClient.Close()
 		if err != nil {

--- a/internal/k8sutils/redis_dynamic_config_test.go
+++ b/internal/k8sutils/redis_dynamic_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	common "github.com/OT-CONTAINER-KIT/redis-operator/api/common/v1beta2"
 	rvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redis/v1beta2"
+	rcvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/rediscluster/v1beta2"
 	rrvb2 "github.com/OT-CONTAINER-KIT/redis-operator/api/redisreplication/v1beta2"
 	"github.com/go-redis/redismock/v9"
 	redis "github.com/redis/go-redis/v9"
@@ -248,5 +249,125 @@ func TestSetRedisStandaloneDynamicConfig(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSetRedisClusterDynamicConfig(t *testing.T) {
+	ctx := context.Background()
+
+	newCluster := func(dynamicConfig []string) *rcvb2.RedisCluster {
+		return &rcvb2.RedisCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis-cluster", Namespace: "default"},
+			Spec: rcvb2.RedisClusterSpec{
+				ClusterSize: ptr.To(int32(2)),
+				RedisConfig: &common.RedisConfig{
+					DynamicConfig: dynamicConfig,
+				},
+			},
+		}
+	}
+
+	t.Run("applies config to every leader and follower pod", func(t *testing.T) {
+		cr := newCluster([]string{"maxmemory-policy allkeys-lru"})
+		mocks := map[string]redismock.ClientMock{}
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			m.ExpectPing().SetVal("PONG")
+			m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			mocks[podName] = m
+			return c
+		}
+
+		err := setRedisClusterDynamicConfig(ctx, cr, makeClient)
+		assert.NoError(t, err)
+		assert.Len(t, mocks, 4)
+		for _, name := range []string{"redis-cluster-leader-0", "redis-cluster-leader-1", "redis-cluster-follower-0", "redis-cluster-follower-1"} {
+			m, ok := mocks[name]
+			assert.True(t, ok, "expected a client for pod %s", name)
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+	})
+
+	t.Run("no-op when dynamic config is empty", func(t *testing.T) {
+		cr := newCluster(nil)
+		called := false
+		err := setRedisClusterDynamicConfig(ctx, cr, func(podName string) *redis.Client {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, called, "client factory must not be called without dynamic config")
+	})
+
+	t.Run("re-applies an updated value on a later call, simulating a later reconcile", func(t *testing.T) {
+		// This is the behavior issue #1757 relied on: once the cluster reaches
+		// Ready, the operator must keep re-applying dynamicConfig on subsequent
+		// reconciles so a spec change (e.g. maxmemory-samples 4 -> 11) actually
+		// reaches the running pods instead of only being applied once.
+		cr := newCluster([]string{"maxmemory-samples 4"})
+		mocks := map[string]redismock.ClientMock{}
+		makeClientWith := func(value string) func(string) *redis.Client {
+			return func(podName string) *redis.Client {
+				c, m := redismock.NewClientMock()
+				m.ExpectPing().SetVal("PONG")
+				m.ExpectConfigSet("maxmemory-samples", value).SetVal("OK")
+				mocks[podName] = m
+				return c
+			}
+		}
+
+		err := setRedisClusterDynamicConfig(ctx, cr, makeClientWith("4"))
+		assert.NoError(t, err)
+		for _, m := range mocks {
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+
+		mocks = map[string]redismock.ClientMock{}
+		cr.Spec.RedisConfig.DynamicConfig = []string{"maxmemory-samples 11"}
+		err = setRedisClusterDynamicConfig(ctx, cr, makeClientWith("11"))
+		assert.NoError(t, err)
+		for _, m := range mocks {
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+	})
+
+	t.Run("continues past unreachable pods", func(t *testing.T) {
+		cr := newCluster([]string{"maxmemory-policy allkeys-lru"})
+		mocks := map[string]redismock.ClientMock{}
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			if podName == "redis-cluster-leader-0" {
+				m.ExpectPing().SetErr(errors.New("connection refused"))
+			} else {
+				m.ExpectPing().SetVal("PONG")
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			}
+			mocks[podName] = m
+			return c
+		}
+
+		err := setRedisClusterDynamicConfig(ctx, cr, makeClient)
+		assert.NoError(t, err)
+		assert.Len(t, mocks, 4, "every pod should be visited even if an earlier one is unreachable")
+		for _, m := range mocks {
+			assert.NoError(t, m.ExpectationsWereMet())
+		}
+	})
+
+	t.Run("returns error when a CONFIG SET fails", func(t *testing.T) {
+		cr := newCluster([]string{"maxmemory-policy allkeys-lru"})
+		makeClient := func(podName string) *redis.Client {
+			c, m := redismock.NewClientMock()
+			m.ExpectPing().SetVal("PONG")
+			if podName == "redis-cluster-leader-0" {
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetErr(errors.New("CONFIG SET failed"))
+			} else {
+				m.ExpectConfigSet("maxmemory-policy", "allkeys-lru").SetVal("OK")
+			}
+			return c
+		}
+
+		err := setRedisClusterDynamicConfig(ctx, cr, makeClient)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

`spec.redisConfig.dynamicConfig` changes on a `RedisCluster` were only applied once, at the moment the cluster first transitioned into the `Ready` state. Once `instance.Status.State == RedisClusterReady`, the `instance.Status.State != rcvb2.RedisClusterReady` guard around the `SetRedisClusterDynamicConfig` call permanently skipped it on every later reconcile, so a subsequent edit to `dynamicConfig` was never pushed to the running leader/follower pods, even after waiting many reconcile cycles or re-applying the CR.

This moves the `SetRedisClusterDynamicConfig` call out of the "just became Ready" block and into a separate block gated only on `instance.Status.State == rcvb2.RedisClusterReady`, so it now runs on every reconcile once the cluster is ready (the controller already requeues every 10s while running), matching how the Redis standalone and RedisReplication controllers already apply their dynamic config on every reconcile rather than only once.

Also refactored `SetRedisClusterDynamicConfig` in `internal/k8sutils/redis.go` to delegate to an injectable-client `setRedisClusterDynamicConfig` helper, mirroring the existing `setRedisReplicationDynamicConfig` / `setRedisStandaloneDynamicConfig` pattern in the same file, so the fix is unit-testable without a live Redis.

Fixes #ISSUE

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Tests have been added/modified and all tests pass.
- [x] Functionality/bugs have been confirmed to be unchanged or fixed.
- [x] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

Validation:
- `go build ./...` and `go vet ./...` pass.
- `golangci-lint run ./...` passes with 0 issues.
- `go test ./...` passes (including the pre-existing `internal/controller/rediscluster` envtest/ginkgo suite, run with `KUBEBUILDER_ASSETS` from `setup-envtest use 1.31.0 -p path`).
- Added `TestSetRedisClusterDynamicConfig` in `internal/k8sutils/redis_dynamic_config_test.go`, including a subtest that calls the helper twice with a changed config value (simulating two reconciles with a spec edit in between) and asserts `CONFIG SET` is issued with the new value both times via `redismock` expectations.

Disclosure: there is no live-Redis / end-to-end reproduction of this in the test suite — the existing `internal/controller/rediscluster` envtest suite has no real Redis pods, and `applyDynamicConfig` intentionally no-ops (returns no error) when a pod is unreachable, so it cannot fail-then-pass at that layer. The fix is proven at the `k8sutils` unit level (repeated-invocation test above) plus direct inspection of the controller gating change. One side effect worth noting: on the very reconcile where the cluster first transitions to Ready, the new `dynamicConfig` application is skipped because the transition writes the new state via `updateStatus` rather than mutating the local `instance` in place, so dynamic config on a brand-new cluster is first applied on the following reconcile (~10s later) rather than synchronously — this only affects the very first Ready transition, not the reported bug (repeated updates after Ready).

Fixes #1757